### PR TITLE
Fix project-wide generated field identity (12H)

### DIFF
--- a/crates/sifr_codegen/src/generated_rust_canonicalizer.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer.rs
@@ -1,5 +1,5 @@
 use quote::ToTokens;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use syn::visit::{self, Visit};
 use syn::visit_mut::{self, VisitMut};
 
@@ -27,7 +27,6 @@ pub use api_cleanup::{
     discover_project_const_function_names,
     finalize_formatted_generated_rust_source_with_project_consts,
 };
-use field_name_cleanup::canonicalize_generated_field_names;
 pub use identifier_canonicalizer::canonicalize_generated_rust_identifier;
 #[cfg(test)]
 use item_dependencies::IdentifierCollector;
@@ -48,9 +47,37 @@ use syntax_cleanup::canonicalize_syntax;
 /// are escaped too, keeping the mapping injective when user code deliberately uses
 /// a canonical prefix.
 pub fn canonicalize_generated_rust_source(source: &str) -> Result<String, String> {
+    let mut sources = canonicalize_generated_rust_project(&BTreeMap::from([(
+        String::new(),
+        source.to_string(),
+    )]))?;
+    sources
+        .remove("")
+        .ok_or_else(|| "missing canonical crate root".to_string())
+}
+
+/// Canonicalize all physical modules together before per-file cleanup. Keys use
+/// Rust module paths (`a::b`); the empty key is the crate root.
+pub fn canonicalize_generated_rust_project(
+    sources: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, String> {
+    let fields = field_name_cleanup::canonicalize_fields(sources)?;
+    let names = identifier_canonicalizer::project_name_map(fields.values().map(String::as_str))?;
+    fields
+        .into_iter()
+        .map(|(module, source)| {
+            canonicalize_source_with_names(&source, &names).map(|source| (module, source))
+        })
+        .collect()
+}
+
+fn canonicalize_source_with_names(
+    source: &str,
+    names: &BTreeMap<String, String>,
+) -> Result<String, String> {
     let structurally_pruned = prune_closed_generated_binary(source)?;
     let source = structurally_pruned.as_deref().unwrap_or(source);
-    let mut canonical = identifier_canonicalizer::canonicalize_identifiers(source)?;
+    let mut canonical = identifier_canonicalizer::canonicalize_identifiers(source, names)?;
     for _ in 0..16 {
         let rewritten = rewrite_format_captures(&canonical)?;
         let structurally_pruned = prune_closed_generated_binary(&rewritten)?;
@@ -162,7 +189,7 @@ impl<'ast> Visit<'ast> for FallibleControlUse {
 fn rewrite_format_captures(source: &str) -> Result<String, String> {
     let mut file = syn::parse_file(source)
         .map_err(|error| format!("failed to parse canonical generated Rust: {error}"))?;
-    let field_names_changed = canonicalize_generated_field_names(&mut file);
+    let shorthand_changed = field_name_cleanup::compact_shorthand(&mut file);
     let syntax_changed = canonicalize_syntax_to_fixed_point(&mut file)?;
     let final_syntax = prettyplease::unparse(&file);
     let mut api_file = syn::parse_file(&final_syntax)
@@ -170,7 +197,7 @@ fn rewrite_format_captures(source: &str) -> Result<String, String> {
     let before_api = api_file.to_token_stream().to_string();
     improve_generated_api_items(&mut api_file.items, &final_syntax);
     let api_changed = api_file.to_token_stream().to_string() != before_api;
-    if !field_names_changed && !syntax_changed && !api_changed {
+    if !shorthand_changed && !syntax_changed && !api_changed {
         return Ok(source.to_string());
     }
     let first_api_source = prettyplease::unparse(&api_file);

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/field_name_cleanup.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/field_name_cleanup.rs
@@ -1,197 +1,139 @@
+//! Field spelling belongs to a nominal declaration, not a file's identifier set.
+use quote::ToTokens;
 use std::collections::{BTreeMap, BTreeSet};
-use syn::visit::{self, Visit};
 use syn::visit_mut::{self, VisitMut};
 
-const GENERATED_FIELD_PREFIX: &str = "sifr_generated_";
+mod registry;
+mod rewrite;
+use registry::Registry;
+use rewrite::Rewriter;
 
-/// Remove the compiler namespace from generated field members.
-///
-/// Fields already have a type-owned namespace, so retaining the global generated
-/// prefix is redundant and can make every member of a struct share one prefix.
-/// The rewrite only touches field declarations and member positions; local values
-/// keep their independently canonicalized names.
-pub(super) fn canonicalize_generated_field_names(file: &mut syn::File) -> bool {
-    let mut collector = FieldNameCollector::default();
-    collector.visit_file(file);
-    let names = canonical_field_name_map(&collector.names);
-    if names.is_empty() {
-        return false;
+#[cfg(test)]
+mod tests;
+
+pub(super) fn canonicalize_fields(
+    sources: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, String> {
+    let mut files = sources
+        .iter()
+        .map(|(module, source)| {
+            syn::parse_file(source)
+                .map(|file| (module.clone(), file))
+                .map_err(|error| {
+                    format!("failed to parse assembled generated Rust: module {module}: {error}")
+                })
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    let registry = Registry::collect(&files);
+    let mut result = BTreeMap::new();
+    for (module, file) in &mut files {
+        let before = file.to_token_stream().to_string();
+        let mut rewriter = Rewriter::new(&registry, module);
+        rewriter.visit_file_mut(file);
+        if let Some(error) = rewriter.error {
+            return Err(error);
+        }
+        let source = if before == file.to_token_stream().to_string() {
+            sources[module].clone()
+        } else {
+            prettyplease::unparse(file)
+        };
+        result.insert(module.clone(), source);
     }
-    FieldNameCanonicalizer { names }.visit_file_mut(file);
+    Ok(result)
+}
+
+fn field_names(fields: &syn::Fields) -> BTreeMap<String, String> {
+    let names = fields
+        .iter()
+        .filter_map(|field| field.ident.as_ref().map(ToString::to_string))
+        .collect::<BTreeSet<_>>();
+    let mut occupied = names
+        .iter()
+        .filter(|name| !name.starts_with('_'))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut result = BTreeMap::new();
+    for name in names.iter().filter(|name| name.starts_with('_')) {
+        let significant = name.trim_start_matches('_');
+        let base = significant.strip_prefix("sifr_").unwrap_or(significant);
+        let mut candidate = if base.is_empty() {
+            "underscore".to_string()
+        } else {
+            base.to_string()
+        };
+        if syn::parse_str::<syn::Ident>(&candidate).is_err() {
+            let raw = format!("r#{candidate}");
+            candidate = if syn::parse_str::<syn::Ident>(&raw).is_ok() {
+                raw
+            } else {
+                format!("{candidate}_field")
+            };
+        }
+        while occupied.contains(&candidate) {
+            candidate.push_str("_field");
+        }
+        occupied.insert(candidate.clone());
+        result.insert(name.clone(), candidate);
+    }
+    result
+}
+
+fn rename(member: &mut syn::Member, names: &BTreeMap<String, String>) -> bool {
+    let syn::Member::Named(identifier) = member else {
+        return false;
+    };
+    let Some(name) = names.get(&identifier.to_string()) else {
+        return false;
+    };
+    *identifier = if let Some(raw) = name.strip_prefix("r#") {
+        syn::Ident::new_raw(raw, identifier.span())
+    } else {
+        syn::Ident::new(name, identifier.span())
+    };
     true
 }
 
-fn canonical_field_name_map(fields: &BTreeSet<String>) -> BTreeMap<String, String> {
-    let candidates = fields
-        .iter()
-        .filter_map(|field| {
-            field
-                .strip_prefix(GENERATED_FIELD_PREFIX)
-                .filter(|candidate| !candidate.is_empty())
-                .map(|candidate| (field.clone(), recover_collision_suffix(candidate)))
-        })
-        .collect::<BTreeMap<_, _>>();
-    let mut occupied = fields
-        .iter()
-        .filter(|field| !candidates.contains_key(*field))
-        .cloned()
-        .collect::<BTreeSet<_>>();
-    let mut canonical = BTreeMap::new();
-    for (field, mut candidate) in candidates {
-        if occupied.contains(&candidate) {
-            candidate.push_str("_field");
-            while occupied.contains(&candidate) {
-                candidate.push_str("_generated");
+/// Values in shorthand syntax belong to the general identifier namespace;
+/// members belong to their resolved owner even when both start with an underscore.
+pub(super) fn expand_shorthand(file: &mut syn::File, names: &BTreeMap<String, String>) {
+    struct Expand<'a>(&'a BTreeMap<String, String>);
+    impl VisitMut for Expand<'_> {
+        fn visit_field_value_mut(&mut self, field: &mut syn::FieldValue) {
+            if let syn::Member::Named(name) = &field.member
+                && self.0.contains_key(&name.to_string())
+            {
+                field.colon_token = Some(Default::default());
             }
+            visit_mut::visit_field_value_mut(self, field);
         }
-        occupied.insert(candidate.clone());
-        canonical.insert(field, candidate);
+        fn visit_field_pat_mut(&mut self, field: &mut syn::FieldPat) {
+            if let syn::Member::Named(name) = &field.member
+                && self.0.contains_key(&name.to_string())
+            {
+                field.colon_token = Some(Default::default());
+            }
+            visit_mut::visit_field_pat_mut(self, field);
+        }
     }
-    canonical
+    Expand(names).visit_file_mut(file);
 }
 
-fn recover_collision_suffix(candidate: &str) -> String {
-    let Some((base, encoded)) = candidate.rsplit_once('_') else {
-        return candidate.to_string();
-    };
-    let Some(decoded) = decode_hex_identifier(encoded) else {
-        return candidate.to_string();
-    };
-    if decoded.trim_start_matches('_') == base {
-        base.to_string()
-    } else {
-        candidate.to_string()
-    }
-}
-
-fn decode_hex_identifier(encoded: &str) -> Option<String> {
-    if encoded.is_empty() || !encoded.len().is_multiple_of(2) {
-        return None;
-    }
-    let (pairs, remainder) = encoded.as_bytes().as_chunks::<2>();
-    if !remainder.is_empty() {
-        return None;
-    }
-    let bytes = pairs
-        .iter()
-        .map(|pair| {
-            let pair = std::str::from_utf8(pair.as_slice()).ok()?;
-            u8::from_str_radix(pair, 16).ok()
-        })
-        .collect::<Option<Vec<_>>>()?;
-    String::from_utf8(bytes).ok()
-}
-
-#[derive(Default)]
-struct FieldNameCollector {
-    names: BTreeSet<String>,
-}
-
-impl<'ast> Visit<'ast> for FieldNameCollector {
-    fn visit_field(&mut self, field: &'ast syn::Field) {
-        if let Some(identifier) = &field.ident {
-            self.names.insert(identifier.to_string());
-        }
-        visit::visit_field(self, field);
-    }
-}
-
-struct FieldNameCanonicalizer {
-    names: BTreeMap<String, String>,
-}
-
-impl VisitMut for FieldNameCanonicalizer {
-    fn visit_field_mut(&mut self, field: &mut syn::Field) {
-        if let Some(identifier) = &mut field.ident {
-            self.rename(identifier);
-        }
-        visit_mut::visit_field_mut(self, field);
-    }
-
-    fn visit_member_mut(&mut self, member: &mut syn::Member) {
-        if let syn::Member::Named(identifier) = member {
-            self.rename(identifier);
-        }
-        visit_mut::visit_member_mut(self, member);
-    }
-
-    fn visit_expr_field_mut(&mut self, field: &mut syn::ExprField) {
-        self.visit_expr_mut(&mut field.base);
-        if let syn::Member::Named(identifier) = &mut field.member {
-            self.rename(identifier);
+pub(super) fn compact_shorthand(file: &mut syn::File) -> bool {
+    struct Compact(bool);
+    impl VisitMut for Compact {
+        fn visit_field_value_mut(&mut self, field: &mut syn::FieldValue) {
+            if field.colon_token.is_some()
+                && let syn::Member::Named(name) = &field.member
+                && matches!(&field.expr, syn::Expr::Path(path) if path.qself.is_none() && path.path.is_ident(name))
+            {
+                field.colon_token = None;
+                self.0 = true;
+            }
+            visit_mut::visit_field_value_mut(self, field);
         }
     }
-
-    fn visit_field_value_mut(&mut self, field: &mut syn::FieldValue) {
-        let original = match &field.member {
-            syn::Member::Named(identifier) => Some(identifier.clone()),
-            syn::Member::Unnamed(_) => None,
-        };
-        if let syn::Member::Named(identifier) = &mut field.member {
-            self.rename(identifier);
-        }
-        if field.colon_token.is_none()
-            && let Some(original) = original
-            && matches!(&field.member, syn::Member::Named(canonical) if *canonical != original)
-        {
-            field.colon_token = Some(syn::token::Colon::default());
-            field.expr = syn::parse_quote!(#original);
-        }
-        self.visit_expr_mut(&mut field.expr);
-        if let syn::Member::Named(member) = &field.member
-            && matches!(field.expr, syn::Expr::Path(ref path)
-                if path.qself.is_none() && path.path.is_ident(member))
-        {
-            field.colon_token = None;
-        }
-    }
-
-    fn visit_field_pat_mut(&mut self, field: &mut syn::FieldPat) {
-        if let syn::Member::Named(identifier) = &mut field.member {
-            self.rename(identifier);
-        }
-        self.visit_pat_mut(&mut field.pat);
-    }
-
-    fn visit_macro_mut(&mut self, rust_macro: &mut syn::Macro) {
-        rust_macro.tokens = self.rename_macro_field_members(rust_macro.tokens.clone());
-        visit_mut::visit_macro_mut(self, rust_macro);
-    }
-}
-
-impl FieldNameCanonicalizer {
-    fn rename(&self, identifier: &mut proc_macro2::Ident) {
-        if let Some(canonical) = self.names.get(&identifier.to_string()) {
-            *identifier = proc_macro2::Ident::new(canonical, identifier.span());
-        }
-    }
-
-    fn rename_macro_field_members(
-        &self,
-        tokens: proc_macro2::TokenStream,
-    ) -> proc_macro2::TokenStream {
-        let mut follows_dot = false;
-        tokens
-            .into_iter()
-            .map(|token| {
-                let rewritten = match token {
-                    proc_macro2::TokenTree::Ident(mut identifier) if follows_dot => {
-                        self.rename(&mut identifier);
-                        proc_macro2::TokenTree::Ident(identifier)
-                    }
-                    proc_macro2::TokenTree::Group(group) => {
-                        let mut renamed = proc_macro2::Group::new(
-                            group.delimiter(),
-                            self.rename_macro_field_members(group.stream()),
-                        );
-                        renamed.set_span(group.span());
-                        proc_macro2::TokenTree::Group(renamed)
-                    }
-                    token => token,
-                };
-                follows_dot = matches!(&rewritten, proc_macro2::TokenTree::Punct(punct) if punct.as_char() == '.');
-                rewritten
-            })
-            .collect()
-    }
+    let mut compact = Compact(false);
+    compact.visit_file_mut(file);
+    compact.0
 }

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/field_name_cleanup/registry.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/field_name_cleanup/registry.rs
@@ -1,0 +1,403 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, Debug, Default)]
+pub(super) enum Ty {
+    Named(String, Vec<Ty>),
+    Tuple(Vec<Ty>),
+    #[default]
+    Unknown,
+}
+
+impl Ty {
+    pub(super) fn owner(&self) -> Option<&str> {
+        match self {
+            Self::Named(name, _) => Some(name),
+            _ => None,
+        }
+    }
+    pub(super) fn inner(&self) -> Self {
+        self.argument(0)
+    }
+    pub(super) fn argument(&self, index: usize) -> Self {
+        match self {
+            Self::Named(_, args) => args.get(index).cloned().unwrap_or_default(),
+            _ => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct Registry {
+    pub(super) fields: BTreeMap<String, BTreeMap<String, String>>,
+    field_types: BTreeMap<(String, String), (String, syn::Type)>,
+    functions: BTreeMap<String, (String, syn::ReturnType)>,
+    aliases: BTreeMap<String, (String, Vec<String>)>,
+    globs: BTreeMap<String, Vec<Vec<String>>>,
+    definitions: BTreeSet<String>,
+    type_aliases: BTreeMap<String, (String, syn::Type)>,
+    parameters: BTreeMap<String, Vec<String>>,
+}
+
+pub(super) fn qualify(module: &str, name: &str) -> String {
+    if module.is_empty() {
+        name.to_string()
+    } else {
+        format!("{module}::{name}")
+    }
+}
+
+impl Registry {
+    pub(super) fn collect(files: &BTreeMap<String, syn::File>) -> Self {
+        let mut registry = Self::default();
+        for module in files.keys() {
+            let mut path = String::new();
+            for component in module.split("::").filter(|part| !part.is_empty()) {
+                path = qualify(&path, component);
+                registry.definitions.insert(path.clone());
+            }
+        }
+        for (module, file) in files {
+            registry.collect_items(module, &file.items);
+        }
+        for (module, file) in files {
+            registry.collect_impls(module, &file.items);
+        }
+        registry
+    }
+
+    fn collect_items(&mut self, module: &str, items: &[syn::Item]) {
+        for item in items {
+            match item {
+                syn::Item::Struct(item) => {
+                    self.add_fields(module, &item.ident.to_string(), &item.fields);
+                    self.parameters.insert(
+                        qualify(module, &item.ident.to_string()),
+                        item.generics
+                            .type_params()
+                            .map(|param| param.ident.to_string())
+                            .collect(),
+                    );
+                }
+                syn::Item::Enum(item) => {
+                    let owner = qualify(module, &item.ident.to_string());
+                    self.definitions.insert(owner.clone());
+                    for variant in &item.variants {
+                        self.add_fields(&owner, &variant.ident.to_string(), &variant.fields);
+                        let variant_owner = qualify(&owner, &variant.ident.to_string());
+                        for ((field_owner, _), (scope, _)) in &mut self.field_types {
+                            if field_owner == &variant_owner {
+                                *scope = module.to_string();
+                            }
+                        }
+                    }
+                }
+                syn::Item::Mod(item) => {
+                    let child = qualify(module, &item.ident.to_string());
+                    self.definitions.insert(child.clone());
+                    if let Some((_, items)) = &item.content {
+                        self.collect_items(&child, items);
+                    }
+                }
+                syn::Item::Use(item) => self.collect_use(module, &item.tree, Vec::new()),
+                syn::Item::Type(item) => {
+                    let name = qualify(module, &item.ident.to_string());
+                    self.definitions.insert(name.clone());
+                    self.type_aliases
+                        .insert(name, (module.to_string(), (*item.ty).clone()));
+                }
+                syn::Item::Fn(item) => {
+                    let name = qualify(module, &item.sig.ident.to_string());
+                    self.definitions.insert(name.clone());
+                    self.functions
+                        .insert(name, (module.to_string(), item.sig.output.clone()));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn collect_impls(&mut self, module: &str, items: &[syn::Item]) {
+        for item in items {
+            if let syn::Item::Mod(item) = item
+                && let Some((_, items)) = &item.content
+            {
+                self.collect_impls(&qualify(module, &item.ident.to_string()), items);
+            }
+            if let syn::Item::Impl(item) = item {
+                let owner = self.ty(module, &item.self_ty, None);
+                if let Some(owner) = owner.owner() {
+                    for member in &item.items {
+                        if let syn::ImplItem::Fn(method) = member {
+                            self.functions.insert(
+                                qualify(owner, &method.sig.ident.to_string()),
+                                (module.to_string(), method.sig.output.clone()),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn add_fields(&mut self, module: &str, name: &str, fields: &syn::Fields) {
+        let owner = qualify(module, name);
+        self.definitions.insert(owner.clone());
+        self.fields
+            .insert(owner.clone(), super::field_names(fields));
+        for (index, field) in fields.iter().enumerate() {
+            let name = field
+                .ident
+                .as_ref()
+                .map_or_else(|| index.to_string(), ToString::to_string);
+            self.field_types.insert(
+                (owner.clone(), name),
+                (module.to_string(), field.ty.clone()),
+            );
+        }
+    }
+
+    fn collect_use(&mut self, module: &str, tree: &syn::UseTree, mut prefix: Vec<String>) {
+        match tree {
+            syn::UseTree::Path(path) => {
+                prefix.push(path.ident.to_string());
+                self.collect_use(module, &path.tree, prefix);
+            }
+            syn::UseTree::Name(name) => {
+                let binding = if name.ident == "self" {
+                    prefix.last().cloned().unwrap_or_default()
+                } else {
+                    prefix.push(name.ident.to_string());
+                    name.ident.to_string()
+                };
+                self.aliases
+                    .insert(qualify(module, &binding), (module.to_string(), prefix));
+            }
+            syn::UseTree::Rename(name) => {
+                if name.ident != "self" {
+                    prefix.push(name.ident.to_string());
+                }
+                self.aliases.insert(
+                    qualify(module, &name.rename.to_string()),
+                    (module.to_string(), prefix),
+                );
+            }
+            syn::UseTree::Glob(_) => {
+                self.globs
+                    .entry(module.to_string())
+                    .or_default()
+                    .push(prefix);
+            }
+            syn::UseTree::Group(group) => {
+                for tree in &group.items {
+                    self.collect_use(module, tree, prefix.clone());
+                }
+            }
+        }
+    }
+
+    fn resolve(
+        &self,
+        module: &str,
+        parts: &[String],
+        depth: usize,
+        visited: &mut BTreeSet<(String, Vec<String>)>,
+    ) -> Option<String> {
+        if depth > 32 || parts.is_empty() || !visited.insert((module.to_string(), parts.to_vec())) {
+            return None;
+        }
+        let (scope, tail) = match parts[0].as_str() {
+            "crate" => ("", &parts[1..]),
+            "self" => (module, &parts[1..]),
+            "super" => {
+                let parent = module.rsplit_once("::").map_or("", |(parent, _)| parent);
+                return self.resolve(parent, &parts[1..], depth + 1, visited);
+            }
+            _ => (module, parts),
+        };
+        if tail.is_empty() {
+            return Some(scope.to_string());
+        }
+        let local = qualify(scope, &tail[0]);
+        if let Some((alias_scope, path)) = self.aliases.get(&local) {
+            let mut expanded = path.clone();
+            expanded.extend_from_slice(&tail[1..]);
+            return self.resolve(alias_scope, &expanded, depth + 1, visited);
+        }
+        let candidate = qualify(scope, &tail.join("::"));
+        if self.definitions.contains(&candidate) || self.functions.contains_key(&candidate) {
+            return Some(candidate);
+        }
+        // Resolve re-exports at intermediate module boundaries too.
+        if tail.len() > 1 && self.definitions.contains(&local) {
+            return self.resolve(&local, &tail[1..], depth + 1, visited);
+        }
+        let mut matches = BTreeSet::new();
+        if let Some(globs) = self.globs.get(scope) {
+            for glob in globs {
+                let mut expanded = glob.clone();
+                expanded.extend_from_slice(tail);
+                if let Some(found) = self.resolve(scope, &expanded, depth + 1, visited) {
+                    matches.insert(found);
+                }
+            }
+        }
+        if matches.len() == 1 {
+            return matches.into_iter().next();
+        }
+        None
+    }
+
+    pub(super) fn path(&self, module: &str, path: &syn::Path, owner: Option<&str>) -> String {
+        let mut parts = path
+            .segments
+            .iter()
+            .map(|part| part.ident.to_string())
+            .collect::<Vec<_>>();
+        if parts.first().is_some_and(|part| part == "Self") {
+            if let Some(owner) = owner {
+                parts[0] = owner.to_string();
+                return parts.join("::");
+            }
+        }
+        // Leading :: names external crates; never bind them to a local nominal.
+        if path.leading_colon.is_some() {
+            return format!("::{}", parts.join("::"));
+        }
+        self.resolve(module, &parts, 0, &mut BTreeSet::new())
+            .unwrap_or_else(|| parts.join("::"))
+    }
+
+    pub(super) fn ty(&self, module: &str, ty: &syn::Type, owner: Option<&str>) -> Ty {
+        self.ty_at_depth(module, ty, owner, 0)
+    }
+
+    fn ty_at_depth(&self, module: &str, ty: &syn::Type, owner: Option<&str>, depth: usize) -> Ty {
+        if depth > 32 {
+            return Ty::Unknown;
+        }
+        match ty {
+            syn::Type::Reference(ty) => self.ty_at_depth(module, &ty.elem, owner, depth + 1),
+            syn::Type::Paren(ty) => self.ty_at_depth(module, &ty.elem, owner, depth + 1),
+            syn::Type::Group(ty) => self.ty_at_depth(module, &ty.elem, owner, depth + 1),
+            syn::Type::Slice(ty) => Ty::Named(
+                "Slice".to_string(),
+                vec![self.ty_at_depth(module, &ty.elem, owner, depth + 1)],
+            ),
+            syn::Type::Array(ty) => Ty::Named(
+                "Array".to_string(),
+                vec![self.ty_at_depth(module, &ty.elem, owner, depth + 1)],
+            ),
+            syn::Type::Tuple(ty) => Ty::Tuple(
+                ty.elems
+                    .iter()
+                    .map(|ty| self.ty_at_depth(module, ty, owner, depth + 1))
+                    .collect(),
+            ),
+            syn::Type::Path(ty) => {
+                let name = self.path(module, &ty.path, owner);
+                if let Some((scope, ty)) = self.type_aliases.get(&name) {
+                    return self.ty_at_depth(scope, ty, owner, depth + 1);
+                }
+                let args = ty
+                    .path
+                    .segments
+                    .last()
+                    .and_then(|segment| match &segment.arguments {
+                        syn::PathArguments::AngleBracketed(args) => Some(
+                            args.args
+                                .iter()
+                                .filter_map(|arg| {
+                                    if let syn::GenericArgument::Type(ty) = arg {
+                                        Some(self.ty_at_depth(module, ty, owner, depth + 1))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect(),
+                        ),
+                        _ => None,
+                    })
+                    .unwrap_or_default();
+                Ty::Named(name, args)
+            }
+            _ => Ty::Unknown,
+        }
+    }
+
+    pub(super) fn field_type(&self, owner: &Ty, member: &syn::Member) -> Ty {
+        let name = match member {
+            syn::Member::Named(name) => name.to_string(),
+            syn::Member::Unnamed(index) => {
+                if let Ty::Tuple(types) = owner {
+                    return types.get(index.index as usize).cloned().unwrap_or_default();
+                }
+                index.index.to_string()
+            }
+        };
+        let Ty::Named(owner, arguments) = owner else {
+            return Ty::Unknown;
+        };
+        self.field_types
+            .get(&(owner.to_string(), name))
+            .map_or(Ty::Unknown, |(module, ty)| {
+                let substitutions = self
+                    .parameters
+                    .get(owner)
+                    .into_iter()
+                    .flatten()
+                    .cloned()
+                    .zip(arguments.iter().cloned())
+                    .collect();
+                self.instantiated_type(module, ty, owner, &substitutions)
+            })
+    }
+
+    fn instantiated_type(
+        &self,
+        module: &str,
+        ty: &syn::Type,
+        owner: &str,
+        substitutions: &BTreeMap<String, Ty>,
+    ) -> Ty {
+        match ty {
+            syn::Type::Reference(ty) => {
+                self.instantiated_type(module, &ty.elem, owner, substitutions)
+            }
+            syn::Type::Path(path) => {
+                if let Some(name) = path.path.get_ident()
+                    && let Some(ty) = substitutions.get(&name.to_string())
+                {
+                    return ty.clone();
+                }
+                let mut result = self.ty(module, ty, Some(owner));
+                if let Ty::Named(_, arguments) = &mut result
+                    && let Some(segment) = path.path.segments.last()
+                    && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+                {
+                    *arguments = args
+                        .args
+                        .iter()
+                        .filter_map(|arg| {
+                            if let syn::GenericArgument::Type(ty) = arg {
+                                Some(self.instantiated_type(module, ty, owner, substitutions))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                }
+                result
+            }
+            _ => self.ty(module, ty, Some(owner)),
+        }
+    }
+
+    pub(super) fn return_type(&self, function: &str, owner: Option<&str>) -> Ty {
+        self.functions
+            .get(function)
+            .map_or(Ty::Unknown, |(module, result)| match result {
+                syn::ReturnType::Type(_, ty) => self.ty(module, ty, owner),
+                syn::ReturnType::Default => Ty::Unknown,
+            })
+    }
+}

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/field_name_cleanup/registry.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/field_name_cleanup/registry.rs
@@ -338,7 +338,7 @@ impl Registry {
             return Ty::Unknown;
         };
         self.field_types
-            .get(&(owner.to_string(), name))
+            .get(&(owner.clone(), name))
             .map_or(Ty::Unknown, |(module, ty)| {
                 let substitutions = self
                     .parameters

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/field_name_cleanup/rewrite.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/field_name_cleanup/rewrite.rs
@@ -1,0 +1,525 @@
+use super::registry::{Registry, Ty, qualify};
+use quote::ToTokens;
+use std::collections::BTreeMap;
+use syn::visit_mut::{self, VisitMut};
+
+pub(super) struct Rewriter<'a> {
+    registry: &'a Registry,
+    module: String,
+    owner: Option<String>,
+    locals: BTreeMap<String, Ty>,
+    pub(super) error: Option<String>,
+}
+
+impl<'a> Rewriter<'a> {
+    pub(super) fn new(registry: &'a Registry, module: &str) -> Self {
+        Self {
+            registry,
+            module: module.to_string(),
+            owner: None,
+            locals: BTreeMap::new(),
+            error: None,
+        }
+    }
+
+    fn expression_type(&self, expression: &syn::Expr) -> Ty {
+        match expression {
+            syn::Expr::Path(path) if path.path.is_ident("self") => self
+                .owner
+                .as_ref()
+                .map_or(Ty::Unknown, |owner| Ty::Named(owner.clone(), Vec::new())),
+            syn::Expr::Path(path) => path
+                .path
+                .get_ident()
+                .and_then(|name| self.locals.get(&name.to_string()))
+                .cloned()
+                .unwrap_or_default(),
+            syn::Expr::Struct(value) => Ty::Named(
+                self.registry
+                    .path(&self.module, &value.path, self.owner.as_deref()),
+                Vec::new(),
+            ),
+            syn::Expr::Reference(value) => self.expression_type(&value.expr),
+            syn::Expr::Paren(value) => self.expression_type(&value.expr),
+            syn::Expr::Group(value) => self.expression_type(&value.expr),
+            syn::Expr::Unary(value) => self.expression_type(&value.expr),
+            syn::Expr::Try(value) => self.expression_type(&value.expr).inner(),
+            syn::Expr::Index(value) => self.expression_type(&value.expr).inner(),
+            syn::Expr::Await(value) => self.expression_type(&value.base),
+            syn::Expr::Field(value) => self
+                .registry
+                .field_type(&self.expression_type(&value.base), &value.member),
+            syn::Expr::Tuple(value) => Ty::Tuple(
+                value
+                    .elems
+                    .iter()
+                    .map(|value| self.expression_type(value))
+                    .collect(),
+            ),
+            syn::Expr::Call(call) => {
+                let mut callee = call.func.as_ref();
+                while let syn::Expr::Paren(paren) = callee {
+                    callee = &paren.expr;
+                }
+                if let syn::Expr::Closure(closure) = callee {
+                    return match &closure.output {
+                        syn::ReturnType::Type(_, ty) => {
+                            self.registry.ty(&self.module, ty, self.owner.as_deref())
+                        }
+                        syn::ReturnType::Default => self.expression_type(&closure.body),
+                    };
+                }
+                let syn::Expr::Path(path) = callee else {
+                    return Ty::Unknown;
+                };
+                let name = self
+                    .registry
+                    .path(&self.module, &path.path, self.owner.as_deref());
+                if self.registry.fields.contains_key(&name) {
+                    return Ty::Named(name, Vec::new());
+                }
+                if matches!(name.as_str(), "Some" | "Ok" | "Err" | "Box::new") {
+                    return Ty::Named(
+                        name,
+                        call.args
+                            .first()
+                            .map(|value| vec![self.expression_type(value)])
+                            .unwrap_or_default(),
+                    );
+                }
+                let owner = name.rsplit_once("::").map(|(owner, _)| owner);
+                self.registry.return_type(&name, owner)
+            }
+            syn::Expr::MethodCall(call) => {
+                let receiver = self.expression_type(&call.receiver);
+                let declared = receiver.owner().map_or(Ty::Unknown, |owner| {
+                    self.registry
+                        .return_type(&qualify(owner, &call.method.to_string()), Some(owner))
+                });
+                if !matches!(declared, Ty::Unknown) {
+                    return declared;
+                }
+                if matches!(call.method.to_string().as_str(), "map" | "map_err")
+                    && let Some(syn::Expr::Closure(closure)) = call.args.first()
+                    && self.is_standard_container(&receiver)
+                {
+                    let index = usize::from(call.method == "map_err");
+                    let mut scope = Self::new(self.registry, &self.module);
+                    scope.owner.clone_from(&self.owner);
+                    scope.locals.clone_from(&self.locals);
+                    for pattern in &closure.inputs {
+                        scope.bind(pattern, receiver.argument(index));
+                    }
+                    let mapped = scope.expression_type(&closure.body);
+                    if let Ty::Named(name, mut args) = receiver {
+                        if let Some(argument) = args.get_mut(index) {
+                            *argument = mapped;
+                        }
+                        return Ty::Named(name, args);
+                    }
+                }
+                match call.method.to_string().as_str() {
+                    "clone" | "to_owned" | "as_ref" | "as_mut" => receiver,
+                    "unwrap" | "expect" | "unwrap_or_else" | "unwrap_or_default" => {
+                        receiver.inner()
+                    }
+                    "iter" | "iter_mut" | "into_iter" => {
+                        Ty::Named("Iterator".to_string(), vec![receiver.inner()])
+                    }
+                    "copied" | "cloned" | "rev" => receiver,
+                    "next" => Ty::Named("Option".to_string(), vec![receiver.inner()]),
+                    _ => receiver.owner().map_or(Ty::Unknown, |owner| {
+                        self.registry
+                            .return_type(&qualify(owner, &call.method.to_string()), Some(owner))
+                    }),
+                }
+            }
+            syn::Expr::Block(value) => self.block_type(&value.block),
+            syn::Expr::Macro(value) if value.mac.path.is_ident("vec") => {
+                let tokens = &value.mac.tokens;
+                let element = if let Ok(repeat) =
+                    syn::parse2::<syn::ExprRepeat>(quote::quote!([#tokens]))
+                {
+                    self.expression_type(&repeat.expr)
+                } else if let Ok(array) = syn::parse2::<syn::ExprArray>(quote::quote!([#tokens])) {
+                    array
+                        .elems
+                        .first()
+                        .map_or(Ty::Unknown, |element| self.expression_type(element))
+                } else {
+                    Ty::Unknown
+                };
+                Ty::Named("Vec".to_string(), vec![element])
+            }
+            syn::Expr::If(value) => self.block_type(&value.then_branch),
+            syn::Expr::Match(value) => value
+                .arms
+                .first()
+                .map_or(Ty::Unknown, |arm| self.expression_type(&arm.body)),
+            _ => Ty::Unknown,
+        }
+    }
+
+    fn block_type(&self, block: &syn::Block) -> Ty {
+        let mut scope = Self::new(self.registry, &self.module);
+        scope.owner.clone_from(&self.owner);
+        scope.locals.clone_from(&self.locals);
+        for statement in &block.stmts {
+            if let syn::Stmt::Local(local) = statement {
+                let ty = local
+                    .init
+                    .as_ref()
+                    .map_or(Ty::Unknown, |init| scope.expression_type(&init.expr));
+                scope.bind(&local.pat, ty);
+            }
+        }
+        match block.stmts.last() {
+            Some(syn::Stmt::Expr(value, None)) => scope.expression_type(value),
+            _ => Ty::Unknown,
+        }
+    }
+
+    fn is_standard_container(&self, ty: &Ty) -> bool {
+        ty.owner().is_some_and(|owner| {
+            !self.registry.fields.contains_key(owner)
+                && matches!(
+                    owner.trim_start_matches("::"),
+                    "Result"
+                        | "Option"
+                        | "Iterator"
+                        | "std::result::Result"
+                        | "core::result::Result"
+                        | "std::option::Option"
+                        | "core::option::Option"
+                )
+        })
+    }
+
+    fn bind(&mut self, pattern: &syn::Pat, ty: Ty) {
+        match pattern {
+            syn::Pat::Ident(binding) => {
+                self.locals.insert(binding.ident.to_string(), ty);
+            }
+            syn::Pat::Type(binding) => {
+                let ty = if matches!(binding.ty.as_ref(), syn::Type::Infer(_)) {
+                    ty
+                } else {
+                    self.registry
+                        .ty(&self.module, &binding.ty, self.owner.as_deref())
+                };
+                self.bind(&binding.pat, ty);
+            }
+            syn::Pat::Reference(binding) => self.bind(&binding.pat, ty),
+            syn::Pat::Paren(binding) => self.bind(&binding.pat, ty),
+            syn::Pat::Tuple(binding) => {
+                for (index, pattern) in binding.elems.iter().enumerate() {
+                    let ty = match &ty {
+                        Ty::Tuple(types) => types.get(index).cloned().unwrap_or_default(),
+                        _ => Ty::Unknown,
+                    };
+                    self.bind(pattern, ty);
+                }
+            }
+            syn::Pat::TupleStruct(binding) => {
+                let owner = Ty::Named(
+                    self.registry
+                        .path(&self.module, &binding.path, self.owner.as_deref()),
+                    Vec::new(),
+                );
+                for (position, pattern) in binding.elems.iter().enumerate() {
+                    let value = if owner
+                        .owner()
+                        .is_some_and(|owner| self.registry.fields.contains_key(owner))
+                    {
+                        self.registry
+                            .field_type(&owner, &syn::Member::Unnamed(syn::Index::from(position)))
+                    } else {
+                        let index = usize::from(binding.path.is_ident("Err"));
+                        ty.argument(index)
+                    };
+                    self.bind(pattern, value);
+                }
+            }
+            syn::Pat::Guard(binding) => self.bind(&binding.pat, ty),
+            syn::Pat::Struct(binding) => {
+                let owner = Ty::Named(
+                    self.registry
+                        .path(&self.module, &binding.path, self.owner.as_deref()),
+                    Vec::new(),
+                );
+                for field in &binding.fields {
+                    self.bind(&field.pat, self.registry.field_type(&owner, &field.member));
+                }
+            }
+            syn::Pat::Or(binding) => {
+                if let Some(pattern) = binding.cases.first() {
+                    self.bind(pattern, ty);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn member(&mut self, owner: &Ty, member: &mut syn::Member) -> bool {
+        if let Some(names) = owner
+            .owner()
+            .and_then(|owner| self.registry.fields.get(owner))
+        {
+            return super::rename(member, names);
+        }
+        if matches!(owner, Ty::Unknown)
+            && let syn::Member::Named(name) = member
+            && self
+                .registry
+                .fields
+                .values()
+                .any(|fields| fields.contains_key(&name.to_string()))
+        {
+            self.error.get_or_insert_with(|| {
+                format!(
+                    "cannot resolve generated field owner for {} in module {}",
+                    name, self.module
+                )
+            });
+        }
+        false
+    }
+
+    fn signature(&mut self, signature: &syn::Signature) {
+        for argument in &signature.inputs {
+            if let syn::FnArg::Typed(argument) = argument {
+                self.bind(
+                    &argument.pat,
+                    self.registry
+                        .ty(&self.module, &argument.ty, self.owner.as_deref()),
+                );
+            }
+        }
+    }
+}
+
+impl VisitMut for Rewriter<'_> {
+    fn visit_item_mod_mut(&mut self, item: &mut syn::ItemMod) {
+        let previous = self.module.clone();
+        self.module = qualify(&previous, &item.ident.to_string());
+        let locals = std::mem::take(&mut self.locals);
+        visit_mut::visit_item_mod_mut(self, item);
+        self.locals = locals;
+        self.module = previous;
+    }
+
+    fn visit_item_struct_mut(&mut self, item: &mut syn::ItemStruct) {
+        let owner = Ty::Named(qualify(&self.module, &item.ident.to_string()), Vec::new());
+        for field in &mut item.fields {
+            if let Some(identifier) = &mut field.ident {
+                let mut member = syn::Member::Named(identifier.clone());
+                self.member(&owner, &mut member);
+                if let syn::Member::Named(name) = member {
+                    *identifier = name;
+                }
+            }
+        }
+    }
+
+    fn visit_item_enum_mut(&mut self, item: &mut syn::ItemEnum) {
+        for variant in &mut item.variants {
+            let owner = Ty::Named(
+                qualify(
+                    &qualify(&self.module, &item.ident.to_string()),
+                    &variant.ident.to_string(),
+                ),
+                Vec::new(),
+            );
+            for field in &mut variant.fields {
+                if let Some(identifier) = &mut field.ident {
+                    let mut member = syn::Member::Named(identifier.clone());
+                    self.member(&owner, &mut member);
+                    if let syn::Member::Named(name) = member {
+                        *identifier = name;
+                    }
+                }
+            }
+        }
+    }
+
+    fn visit_item_impl_mut(&mut self, item: &mut syn::ItemImpl) {
+        let previous = self.owner.clone();
+        self.owner = self
+            .registry
+            .ty(&self.module, &item.self_ty, None)
+            .owner()
+            .map(str::to_owned);
+        visit_mut::visit_item_impl_mut(self, item);
+        self.owner = previous;
+    }
+
+    fn visit_item_fn_mut(&mut self, item: &mut syn::ItemFn) {
+        let locals = std::mem::take(&mut self.locals);
+        self.signature(&item.sig);
+        self.visit_block_mut(&mut item.block);
+        self.locals = locals;
+    }
+
+    fn visit_impl_item_fn_mut(&mut self, item: &mut syn::ImplItemFn) {
+        let locals = std::mem::take(&mut self.locals);
+        self.signature(&item.sig);
+        self.visit_block_mut(&mut item.block);
+        self.locals = locals;
+    }
+
+    fn visit_block_mut(&mut self, block: &mut syn::Block) {
+        let locals = self.locals.clone();
+        visit_mut::visit_block_mut(self, block);
+        self.locals = locals;
+    }
+
+    fn visit_local_mut(&mut self, local: &mut syn::Local) {
+        let ty = local
+            .init
+            .as_ref()
+            .map_or(Ty::Unknown, |init| self.expression_type(&init.expr));
+        // The initializer sees the previous binding; the pattern introduces the new one.
+        if let Some(init) = &mut local.init {
+            self.visit_expr_mut(&mut init.expr);
+            if let Some((_, diverge)) = &mut init.diverge {
+                self.visit_expr_mut(diverge);
+            }
+        }
+        self.bind(&local.pat, ty);
+        self.visit_pat_mut(&mut local.pat);
+    }
+
+    fn visit_expr_struct_mut(&mut self, value: &mut syn::ExprStruct) {
+        let owner = Ty::Named(
+            self.registry
+                .path(&self.module, &value.path, self.owner.as_deref()),
+            Vec::new(),
+        );
+        for field in &mut value.fields {
+            if self.member(&owner, &mut field.member) {
+                field.colon_token = Some(Default::default());
+            }
+            self.visit_expr_mut(&mut field.expr);
+        }
+        if let Some(rest) = &mut value.rest {
+            self.visit_expr_mut(rest);
+        }
+    }
+
+    fn visit_pat_struct_mut(&mut self, pattern: &mut syn::PatStruct) {
+        let owner = Ty::Named(
+            self.registry
+                .path(&self.module, &pattern.path, self.owner.as_deref()),
+            Vec::new(),
+        );
+        for field in &mut pattern.fields {
+            if self.member(&owner, &mut field.member) {
+                field.colon_token = Some(Default::default());
+            }
+            self.visit_pat_mut(&mut field.pat);
+        }
+    }
+
+    fn visit_expr_field_mut(&mut self, value: &mut syn::ExprField) {
+        let owner = self.expression_type(&value.base);
+        self.member(&owner, &mut value.member);
+        self.visit_expr_mut(&mut value.base);
+    }
+
+    fn visit_expr_match_mut(&mut self, value: &mut syn::ExprMatch) {
+        let ty = self.expression_type(&value.expr);
+        self.visit_expr_mut(&mut value.expr);
+        for arm in &mut value.arms {
+            let locals = self.locals.clone();
+            self.bind(&arm.pat, ty.clone());
+            self.visit_arm_mut(arm);
+            self.locals = locals;
+        }
+    }
+
+    fn visit_expr_if_mut(&mut self, value: &mut syn::ExprIf) {
+        let locals = self.locals.clone();
+        self.visit_expr_mut(&mut value.cond);
+        self.visit_block_mut(&mut value.then_branch);
+        self.locals = locals;
+        if let Some((_, branch)) = &mut value.else_branch {
+            self.visit_expr_mut(branch);
+        }
+    }
+
+    fn visit_expr_let_mut(&mut self, value: &mut syn::ExprLet) {
+        let ty = self.expression_type(&value.expr);
+        self.visit_expr_mut(&mut value.expr);
+        self.bind(&value.pat, ty);
+        self.visit_pat_mut(&mut value.pat);
+    }
+
+    fn visit_expr_closure_mut(&mut self, value: &mut syn::ExprClosure) {
+        let locals = self.locals.clone();
+        for pattern in &value.inputs {
+            self.bind(pattern, Ty::Unknown);
+        }
+        visit_mut::visit_expr_closure_mut(self, value);
+        self.locals = locals;
+    }
+
+    fn visit_expr_method_call_mut(&mut self, call: &mut syn::ExprMethodCall) {
+        let receiver = self.expression_type(&call.receiver);
+        let closure_input = match call.method.to_string().as_str() {
+            "map_err" => Some(receiver.argument(1)),
+            "map" | "and_then" | "filter" | "for_each" => Some(receiver.inner()),
+            _ => None,
+        }
+        .filter(|_| self.is_standard_container(&receiver));
+        self.visit_expr_mut(&mut call.receiver);
+        for argument in &mut call.args {
+            if let (Some(ty), syn::Expr::Closure(closure)) = (&closure_input, &mut *argument) {
+                let locals = self.locals.clone();
+                for pattern in &closure.inputs {
+                    self.bind(pattern, ty.clone());
+                }
+                self.visit_expr_mut(&mut closure.body);
+                self.locals = locals;
+            } else {
+                self.visit_expr_mut(argument);
+            }
+        }
+    }
+
+    fn visit_expr_for_loop_mut(&mut self, value: &mut syn::ExprForLoop) {
+        let element = self.expression_type(&value.expr).inner();
+        self.visit_expr_mut(&mut value.expr);
+        let locals = self.locals.clone();
+        self.bind(&value.pat, element);
+        self.visit_pat_mut(&mut value.pat);
+        self.visit_block_mut(&mut value.body);
+        self.locals = locals;
+    }
+
+    fn visit_expr_while_mut(&mut self, value: &mut syn::ExprWhile) {
+        let locals = self.locals.clone();
+        self.visit_expr_mut(&mut value.cond);
+        self.visit_block_mut(&mut value.body);
+        self.locals = locals;
+    }
+
+    fn visit_macro_mut(&mut self, value: &mut syn::Macro) {
+        if let Ok(mut arguments) = value.parse_body_with(
+            syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
+        ) {
+            for argument in &mut arguments {
+                self.visit_expr_mut(argument);
+            }
+            value.tokens = arguments.into_token_stream();
+        } else if value.path.is_ident("vec") {
+            let tokens = &value.tokens;
+            if let Ok(mut expression) = syn::parse2::<syn::ExprRepeat>(quote::quote!([#tokens])) {
+                self.visit_expr_mut(&mut expression.expr);
+                self.visit_expr_mut(&mut expression.len);
+                let element = expression.expr;
+                let length = expression.len;
+                value.tokens = quote::quote!(#element; #length);
+            }
+        }
+    }
+}

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/field_name_cleanup/tests.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/field_name_cleanup/tests.rs
@@ -1,0 +1,278 @@
+use super::canonicalize_fields;
+use std::collections::BTreeMap;
+
+fn project(sources: &[(&str, &str)]) -> BTreeMap<String, String> {
+    sources
+        .iter()
+        .map(|(name, source)| (name.to_string(), source.to_string()))
+        .collect()
+}
+
+fn compile_modules(sources: &BTreeMap<String, String>) {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+    let directory = std::env::temp_dir().join(format!(
+        "sifr-field-identity-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir(&directory).expect("unique compiler output directory");
+    let source = sources
+        .iter()
+        .map(|(module, source)| {
+            if module.is_empty() {
+                source.clone()
+            } else {
+                format!("mod {module} {{ {source} }}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut child = Command::new("rustc")
+        .args([
+            "--edition=2024",
+            "--crate-name=field_identity",
+            "--crate-type=lib",
+            "--emit=metadata",
+            "--out-dir",
+        ])
+        .arg(&directory)
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("rustc");
+    child
+        .stdin
+        .take()
+        .expect("rustc stdin")
+        .write_all(source.as_bytes())
+        .expect("write Rust");
+    let output = child.wait_with_output().expect("rustc completion");
+    std::fs::remove_dir_all(&directory).expect("remove owned test artifacts");
+    assert!(
+        output.status.success(),
+        "{}\n{source}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn project_field_identity_imports_collisions_patterns_and_members() {
+    let sources = project(&[
+        (
+            "left",
+            "pub struct Value { pub _payload: i64, pub payload: i64 }",
+        ),
+        ("right", "pub struct Value { pub _payload: i64 }"),
+        ("exports", "pub use crate::left::Value as Exported;"),
+        (
+            "consumer",
+            r#"
+            use crate::exports::Exported as Alias;
+            use crate::right::Value;
+            pub fn read(left: Alias, right: &Value) -> i64 {
+                let Alias { _payload, payload } = left;
+                let value = Value { _payload };
+                assert_eq!(value._payload, right._payload);
+                _payload + payload + value._payload
+            }
+        "#,
+        ),
+    ]);
+    let output = canonicalize_fields(&sources).expect("qualified field identities");
+    assert!(output["left"].contains("pub payload_field: i64"));
+    assert!(output["right"].contains("pub payload: i64"));
+    assert!(output["consumer"].contains("payload_field: _payload"));
+    assert!(output["consumer"].contains("payload: _payload"));
+    assert!(output["consumer"].contains("value.payload, right.payload"));
+    assert_eq!(canonicalize_fields(&output).expect("idempotent"), output);
+    compile_modules(&output);
+}
+
+#[test]
+fn project_field_identity_nested_modules_aliases_self_and_return_types() {
+    let sources = project(&[(
+        "",
+        r#"
+        mod records {
+            pub struct Value { pub __sifr_payload: i64 }
+            impl Value {
+                pub fn new(value: i64) -> Self { Self { __sifr_payload: value } }
+                pub fn get(&self) -> i64 { self.__sifr_payload }
+            }
+        }
+        mod consumer {
+            use super::records::*;
+            type Alias = Value;
+            fn read(value: &Alias) -> i64 { Value::new(5).__sifr_payload + value.__sifr_payload }
+        }
+    "#,
+    )]);
+    let output = canonicalize_fields(&sources).expect("nested module and return identities");
+    assert!(output[""].contains("pub payload: i64"));
+    assert!(output[""].contains("self.payload"));
+    assert!(output[""].contains("Value::new(5).payload + value.payload"));
+    compile_modules(&output);
+}
+
+#[test]
+fn project_field_identity_preserves_external_fields_and_local_shadowing() {
+    let sources = project(&[(
+        "",
+        r#"
+        struct Local { _payload: i64 }
+        fn read(value: Local, external: &::foreign::Local) -> i64 {
+            let result = value._payload;
+            { let value = external; assert_eq!(value._payload, 2); }
+            result + value._payload + external._payload
+        }
+    "#,
+    )]);
+    let output = canonicalize_fields(&sources).expect("external fields stay external");
+    assert!(output[""].contains("result + value.payload + external._payload"));
+    assert!(output[""].contains("value._payload, 2"));
+}
+
+#[test]
+fn project_field_identity_unresolved_receiver_fails_closed() {
+    let sources = project(&[(
+        "",
+        "struct Local { _payload: i64 } fn read() { unknown()._payload; }",
+    )]);
+    assert!(
+        canonicalize_fields(&sources)
+            .expect_err("no name-only substitution")
+            .contains("cannot resolve generated field owner")
+    );
+}
+
+#[test]
+fn project_field_identity_same_owner_collision_and_keyword_are_injective() {
+    let sources = project(&[(
+        "",
+        r#"
+        struct Value { __payload: i64, _payload: i64, payload: i64, payload_field: i64, _type: i64 }
+        fn read(value: Value) -> i64 { value.__payload + value._payload + value.payload + value.payload_field + value._type }
+    "#,
+    )]);
+    let output = canonicalize_fields(&sources).expect("collision disambiguation");
+    assert!(output[""].contains("payload_field_field: i64"));
+    assert!(output[""].contains("payload_field_field_field: i64"));
+    assert!(output[""].contains("r#type: i64"));
+    assert!(output[""].contains("value.r#type"));
+    compile_modules(&output);
+}
+
+#[test]
+fn project_field_identity_full_pipeline_keeps_shorthand_value_namespace() {
+    let sources = project(&[
+        (
+            "declaration",
+            "pub struct Value { pub _payload: i64, pub payload: i64 }",
+        ),
+        (
+            "",
+            r#"
+            mod declaration;
+            use crate::declaration::Value;
+            pub fn read(_payload: i64) -> i64 {
+                let value = Value { _payload, payload: 7 };
+                let Value { _payload, payload } = value;
+                _payload + payload
+            }
+        "#,
+        ),
+    ]);
+    let output = crate::canonicalize_generated_rust_project(&sources).expect("project pipeline");
+    assert!(output["declaration"].contains("pub payload_field: i64"));
+    assert!(output[""].contains("payload_field: sifr_generated_payload"));
+    for source in output.values() {
+        syn::parse_file(source).expect("valid Rust");
+    }
+}
+
+#[test]
+fn project_field_identity_loop_bindings_and_declared_method_returns() {
+    let sources = project(&[(
+        "",
+        r#"
+        struct Left { _payload: i64, payload: i64 }
+        #[derive(Clone)]
+        struct Right { _payload: i64 }
+        impl Left { fn clone(&self) -> Right { Right { _payload: 3 } } }
+        fn read(value: Left, values: Vec<Right>) -> i64 {
+            let mut total = value.clone()._payload;
+            for value in values.iter() { total += value._payload; }
+            let mut values = values.into_iter();
+            while let Some(value) = values.next() { total += value._payload; }
+            let repeated = vec![Right { _payload: 2 }; 3];
+            total + value._payload + repeated[0]._payload
+        }
+    "#,
+    )]);
+    let output = canonicalize_fields(&sources).expect("loop scope and declared return identity");
+    assert!(output[""].contains("value.clone().payload"));
+    assert!(output[""].contains("total += value.payload;"));
+    assert!(output[""].contains("total + value.payload_field"));
+    compile_modules(&output);
+}
+
+#[test]
+fn project_field_identity_result_closure_and_error_pattern_payloads() {
+    let sources = project(&[
+        (
+            "errors",
+            "pub struct Failure { pub __sifr_payload: i64, pub payload: i64 }",
+        ),
+        (
+            "",
+            r#"
+            use crate::errors::Failure;
+            fn load() -> Result<i64, Failure> { Err(Failure { __sifr_payload: 3, payload: 2 }) }
+            fn convert() -> Result<i64, Failure> {
+                let result = (|| -> Result<i64, Failure> {
+                    let value = load().map_err(|error: _| Failure {
+                        __sifr_payload: error.__sifr_payload,
+                        payload: error.payload,
+                    })?;
+                    Ok(value)
+                })();
+                match result { Ok(value) => Ok(value), Err(error) => Err(Failure {
+                    __sifr_payload: error.__sifr_payload, payload: error.payload,
+                }) }
+            }
+        "#,
+        ),
+    ]);
+    let output = canonicalize_fields(&sources).expect("typed error flow");
+    assert!(!output[""].contains(".__sifr_payload"));
+    compile_modules(&output);
+}
+
+#[test]
+fn project_field_identity_generic_member_chain_and_variant_payload() {
+    let sources = project(&[(
+        "",
+        r#"
+        mod records {
+            pub struct Value { pub _payload: i64 }
+            pub struct Holder<T> { pub _inner: T }
+            pub enum Event { Ready(Value) }
+        }
+        use records::{Value, Holder, Event};
+        type Alias = Holder<Value>;
+        fn read(holder: Alias, event: Event) -> i64 {
+            let result = holder._inner._payload;
+            match event { Event::Ready(value) => result + value._payload }
+        }
+    "#,
+    )]);
+    let output = canonicalize_fields(&sources).expect("instantiated receiver type");
+    assert!(output[""].contains("holder.inner.payload"));
+    assert!(output[""].contains("result + value.payload"));
+    compile_modules(&output);
+}

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/identifier_canonicalizer.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/identifier_canonicalizer.rs
@@ -4,15 +4,39 @@ use syn::visit::{self, Visit};
 
 use super::identifier_policy::{canonical_identifier_candidate, canonical_name_map};
 
-pub(super) fn canonicalize_identifiers(source: &str) -> Result<String, String> {
-    let file = syn::parse_file(source)
-        .map_err(|error| format!("failed to parse assembled generated Rust: {error}"))?;
+pub(super) fn project_name_map<'a>(
+    sources: impl IntoIterator<Item = &'a str>,
+) -> Result<BTreeMap<String, String>, String> {
     let mut identifiers = IdentifierCollector::default();
-    identifiers.visit_file(&file);
+    for source in sources {
+        let file = syn::parse_file(source)
+            .map_err(|error| format!("failed to parse assembled generated Rust: {error}"))?;
+        identifiers.visit_file(&file);
+    }
+    Ok(canonical_name_map(&identifiers.names))
+}
+
+pub(super) fn canonicalize_identifiers(
+    source: &str,
+    names: &BTreeMap<String, String>,
+) -> Result<String, String> {
+    use quote::ToTokens;
+    let mut file = syn::parse_file(source)
+        .map_err(|error| format!("failed to parse assembled generated Rust: {error}"))?;
+    let before = file.to_token_stream().to_string();
+    super::field_name_cleanup::expand_shorthand(&mut file, names);
+    let expanded;
+    let source = if before == file.to_token_stream().to_string() {
+        source
+    } else {
+        expanded = prettyplease::unparse(&file);
+        &expanded
+    };
+    let file = syn::parse_file(source).map_err(|error| error.to_string())?;
     let mut canonicalizer = GeneratedIdentifierCanonicalizer {
         source,
         line_starts: line_starts(source),
-        names: canonical_name_map(&identifiers.names),
+        names: names.clone(),
         replacements: Vec::new(),
         error: None,
     };
@@ -142,13 +166,25 @@ impl IdentifierCollector {
 }
 
 impl<'ast> Visit<'ast> for IdentifierCollector {
+    fn visit_member(&mut self, _member: &'ast syn::Member) {}
+    fn visit_field(&mut self, field: &'ast syn::Field) {
+        self.visit_type(&field.ty);
+    }
     fn visit_ident(&mut self, ident: &'ast Ident) {
         self.names.insert(ident.to_string());
     }
 
     fn visit_macro(&mut self, rust_macro: &'ast syn::Macro) {
         visit::visit_macro(self, rust_macro);
-        self.collect_tokens(rust_macro.tokens.clone());
+        if let Ok(arguments) = rust_macro.parse_body_with(
+            syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
+        ) {
+            for argument in &arguments {
+                self.visit_expr(argument);
+            }
+        } else {
+            self.collect_tokens(rust_macro.tokens.clone());
+        }
     }
 
     fn visit_meta_list(&mut self, meta: &'ast syn::MetaList) {
@@ -158,13 +194,25 @@ impl<'ast> Visit<'ast> for IdentifierCollector {
 }
 
 impl<'ast> Visit<'ast> for GeneratedIdentifierCanonicalizer<'_> {
+    fn visit_member(&mut self, _member: &'ast syn::Member) {}
+    fn visit_field(&mut self, field: &'ast syn::Field) {
+        self.visit_type(&field.ty);
+    }
     fn visit_ident(&mut self, ident: &'ast Ident) {
         self.collect_ident(ident);
     }
 
     fn visit_macro(&mut self, rust_macro: &'ast syn::Macro) {
         visit::visit_macro(self, rust_macro);
-        self.collect_tokens(rust_macro.tokens.clone());
+        if let Ok(arguments) = rust_macro.parse_body_with(
+            syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
+        ) {
+            for argument in &arguments {
+                self.visit_expr(argument);
+            }
+        } else {
+            self.collect_tokens(rust_macro.tokens.clone());
+        }
     }
 
     fn visit_meta_list(&mut self, meta: &'ast syn::MetaList) {

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -12,8 +12,9 @@ mod generated_rust_canonicalizer;
 mod generated_visibility;
 pub(crate) use generated_dependency_metadata::retain_generated_dependency_metadata;
 pub use generated_rust_canonicalizer::{
-    canonicalize_generated_rust_identifier, canonicalize_generated_rust_source,
-    discover_project_const_function_names, finalize_formatted_generated_rust_source,
+    canonicalize_generated_rust_identifier, canonicalize_generated_rust_project,
+    canonicalize_generated_rust_source, discover_project_const_function_names,
+    finalize_formatted_generated_rust_source,
     finalize_formatted_generated_rust_source_with_project_consts,
 };
 pub(crate) use generated_rust_canonicalizer::{

--- a/crates/sifr_driver/src/build/materialize.rs
+++ b/crates/sifr_driver/src/build/materialize.rs
@@ -8,7 +8,6 @@ use super::cargo_resolution::{
 };
 use super::project_codegen::GeneratedBinaryProject;
 use super::report::BuildSysrootReport;
-use super::rust_interop_bridge_sources::generated_bridge_sources;
 use super::rust_interop_sqlx_offline::configure_hermetic_build_environment;
 use super::{CachedArtifactEntry, PreparedArtifactCache, prepare_cached_artifact};
 use crate::diagnostics::RenderedDiagnostic;
@@ -229,14 +228,6 @@ fn materialize_binary_project_files(
     generated_project: GeneratedBinaryProject,
     dependency_plan: &SysrootDependencyPlan,
 ) -> Result<(), Vec<RenderedDiagnostic>> {
-    let bridge_sources = generated_bridge_sources(
-        &generated_project
-            .interop
-            .rust
-            .bridge_contracts
-            .generated_types,
-    )
-    .map_err(|message| vec![build_error(message)])?;
     let src_dir = project_path.join("src");
     if src_dir.exists() {
         std::fs::remove_dir_all(&src_dir).map_err(|error| {
@@ -259,14 +250,25 @@ fn materialize_binary_project_files(
 
     write_project_file(&project_path.join("Cargo.toml"), cargo_toml, "Cargo.toml")?;
 
-    let main_rs = if bridge_sources.is_empty() {
+    // Module declarations contain no fields. Keep the source-listing boundary,
+    // but declare the already-canonicalized bridge family in the native crate.
+    let main_rs = if generated_project.bridge_modules.is_empty() {
         generated_project.main_rs
     } else {
-        format!("pub mod __sifr_bridge;\n{}", generated_project.main_rs)
+        format!(
+            "pub mod {};\n{}",
+            sifr_codegen::canonicalize_generated_rust_identifier("__sifr_bridge"),
+            generated_project.main_rs
+        )
     };
     write_project_file(&src_dir.join("main.rs"), main_rs, "main.rs")?;
 
-    for (path, source) in bridge_sources {
+    for (module, source) in generated_project.bridge_modules {
+        let path = if module == "__sifr_bridge" {
+            PathBuf::from("__sifr_bridge/mod.rs")
+        } else {
+            rust_module_file_path(&module.replace("::", "."))
+        };
         let canonical_path = canonical_rust_module_path(&path)?;
         write_project_file(
             &src_dir.join(&canonical_path),
@@ -282,7 +284,9 @@ fn materialize_binary_project_files(
         let mut contents = String::new();
         for module_name in &namespace_file.declarations {
             contents.push_str("pub mod ");
-            contents.push_str(module_name);
+            contents.push_str(&sifr_codegen::canonicalize_generated_rust_identifier(
+                module_name,
+            ));
             contents.push_str(";\n");
         }
         namespace_contents.insert(namespace_file.path, contents);
@@ -519,7 +523,7 @@ fn write_project_file(
                 "generated {label} is not valid UTF-8 before Rust formatting: {error}"
             ))]
         })?;
-        formatted = super::rust_formatter::format_generated_rust(source, label)?;
+        formatted = super::rust_formatter::format_canonical_generated_rust(source, label)?;
         formatted.as_bytes()
     } else {
         contents
@@ -544,6 +548,7 @@ fn binary_project_cache_key(
     let support_modules = generated_project
         .support_modules
         .iter()
+        .chain(generated_project.bridge_modules.iter())
         .map(|(name, code)| format!("{name}\n{code}"))
         .collect::<Vec<_>>()
         .join("\n===\n");
@@ -851,7 +856,7 @@ mod tests {
         );
     }
 
-    fn base_project() -> GeneratedBinaryProject {
+    pub(super) fn base_project() -> GeneratedBinaryProject {
         GeneratedBinaryProject {
             main_rs: "fn main() {}\n".to_string(),
             support_modules: BTreeMap::new(),
@@ -859,11 +864,12 @@ mod tests {
             required_features: HashSet::new(),
             interop: InteropBuildPlan::default(),
             cache_key_fragment: None,
+            bridge_modules: BTreeMap::new(),
             python_runtime: None,
         }
     }
 
-    fn test_dependency_plan(cache_fingerprint: &str) -> SysrootDependencyPlan {
+    pub(super) fn test_dependency_plan(cache_fingerprint: &str) -> SysrootDependencyPlan {
         SysrootDependencyPlan {
             stdlib_modules: BTreeSet::new(),
             required_features: BTreeSet::new(),
@@ -879,3 +885,7 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "materialize_field_identity_tests.rs"]
+mod field_identity_tests;

--- a/crates/sifr_driver/src/build/materialize_field_identity_tests.rs
+++ b/crates/sifr_driver/src/build/materialize_field_identity_tests.rs
@@ -1,0 +1,141 @@
+use super::tests::{base_project, test_dependency_plan};
+use super::{binary_project_cache_key, materialize_binary_project_files};
+use crate::build::project_codegen::format_generated_binary_project;
+use sifr_codegen::{
+    RustGeneratedBridgeField, RustGeneratedBridgeType, RustGeneratedBridgeTypeKind,
+};
+
+fn bridge(
+    module: &str,
+    kind: RustGeneratedBridgeTypeKind,
+    fields: &[&str],
+) -> RustGeneratedBridgeType {
+    RustGeneratedBridgeType {
+        module_name: Some(module.to_string()),
+        name: "RecordBridge".to_string(),
+        rust_type_path: format!("crate::__sifr_bridge::{module}::RecordBridge"),
+        kind,
+        supports_eq: true,
+        fields: fields
+            .iter()
+            .map(|name| RustGeneratedBridgeField {
+                name: (*name).to_string(),
+                sifr_type: "int".to_string(),
+                rust_type: "i64".to_string(),
+            })
+            .collect(),
+        variants: Vec::new(),
+    }
+}
+
+#[test]
+fn project_field_identity_materializes_bridged_records_and_errors() {
+    let mut project = base_project();
+    project.main_rs = r#"
+        mod consumers;
+        use crate::__sifr_bridge::left::RecordBridge as Left;
+        use crate::__sifr_bridge::right::RecordBridge as Right;
+        fn main() {
+            let left = Left { _name: 3, name: 8 };
+            let right = Right { _name: 5 };
+            assert_eq!(consumers::inspect(left, right), 16);
+        }
+    "#
+    .to_string();
+    project.support_modules.insert(
+        "consumers".to_string(),
+        r#"
+        use crate::__sifr_bridge::left::RecordBridge as Left;
+        use crate::__sifr_bridge::right::RecordBridge as Right;
+        pub fn inspect(left: Left, right: Right) -> i64 {
+            let Left { _name, name } = left;
+            _name + name + right._name
+        }
+    "#
+        .to_string(),
+    );
+    project.interop.rust.bridge_contracts.generated_types = vec![
+        bridge(
+            "left",
+            RustGeneratedBridgeTypeKind::Record,
+            &["_name", "name"],
+        ),
+        bridge("right", RustGeneratedBridgeTypeKind::Error, &["_name"]),
+    ];
+    let mut project =
+        format_generated_binary_project(project).expect("complete project formatting");
+    assert!(project.bridge_modules["__sifr_bridge::left"].contains("pub name_field: i64"));
+    assert!(project.bridge_modules["__sifr_bridge::left"].contains("pub name: i64"));
+    assert!(project.bridge_modules["__sifr_bridge::right"].contains("pub name: i64"));
+    assert!(project.support_modules["consumers"].contains("right.name"));
+    assert!(
+        !project
+            .emit_source_listing()
+            .contains("// src/__sifr_bridge/")
+    );
+    let plan = test_dependency_plan("field-identity");
+    let before = binary_project_cache_key("fields", &project, &plan);
+    project
+        .bridge_modules
+        .get_mut("__sifr_bridge::left")
+        .expect("left module")
+        .push_str("\n// cache identity\n");
+    assert_ne!(before, binary_project_cache_key("fields", &project, &plan));
+
+    let root = std::env::temp_dir().join(format!(
+        "sifr_bridge_field_identity_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    materialize_binary_project_files(&root, "fields", project, &plan)
+        .expect("materialize once-canonicalized sources");
+    let left = std::fs::read_to_string(root.join("src/sifr_generated_bridge/left.rs"))
+        .expect("bridge source");
+    assert!(left.contains("pub name_field: i64"));
+    let binary = root.join("fields");
+    let output = std::process::Command::new("rustc")
+        .args(["--edition", "2024"])
+        .arg(root.join("src/main.rs"))
+        .arg("-o")
+        .arg(&binary)
+        .output()
+        .expect("compile materialized project");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        std::process::Command::new(binary)
+            .status()
+            .expect("run bridge regression")
+            .success()
+    );
+    std::fs::remove_dir_all(root).expect("remove owned test artifacts");
+}
+
+#[test]
+fn project_field_identity_rejects_bridge_module_collision() {
+    let mut project = base_project();
+    project.support_modules.insert(
+        "__sifr_bridge.left".to_string(),
+        "pub struct Unrelated;".to_string(),
+    );
+    project.interop.rust.bridge_contracts.generated_types = vec![bridge(
+        "left",
+        RustGeneratedBridgeTypeKind::Record,
+        &["_name"],
+    )];
+    let errors = match format_generated_binary_project(project) {
+        Ok(_) => panic!("bridge and support module identities must not overwrite each other"),
+        Err(errors) => errors,
+    };
+    assert!(
+        errors[0]
+            .message
+            .contains("duplicate generated project module identity: __sifr_bridge::left")
+    );
+}

--- a/crates/sifr_driver/src/build/mod.rs
+++ b/crates/sifr_driver/src/build/mod.rs
@@ -99,6 +99,7 @@ pub use report::{
     MaterializedRustProjectReport, PythonDeclarationCheck, PythonEnvironmentCheck,
     PythonInteropCheckReport, PythonTargetCheck, PythonTargetCheckStatus,
 };
+pub(crate) use rust_formatter::canonicalize_project_fields;
 pub(crate) use rust_formatter::format_generated_rust;
 pub use sql_profiles::{PreparedSqlProfiles, load_sql_editor_profiles, prepare_sql_profiles};
 pub use sql_query_signatures::{QUERY_SIGNATURE_ARTIFACT_NAME, emit_query_signature_artifact};

--- a/crates/sifr_driver/src/build/mod.rs
+++ b/crates/sifr_driver/src/build/mod.rs
@@ -100,7 +100,7 @@ pub use report::{
     PythonInteropCheckReport, PythonTargetCheck, PythonTargetCheckStatus,
 };
 pub(crate) use rust_formatter::canonicalize_project_fields;
-pub(crate) use rust_formatter::format_generated_rust;
+pub(crate) use rust_formatter::format_canonical_generated_rust;
 pub use sql_profiles::{PreparedSqlProfiles, load_sql_editor_profiles, prepare_sql_profiles};
 pub use sql_query_signatures::{QUERY_SIGNATURE_ARTIFACT_NAME, emit_query_signature_artifact};
 

--- a/crates/sifr_driver/src/build/project_codegen.rs
+++ b/crates/sifr_driver/src/build/project_codegen.rs
@@ -74,6 +74,10 @@ pub(super) fn codegen_single_file_frontend(
 pub(super) fn format_generated_binary_project(
     mut generated: GeneratedBinaryProject,
 ) -> Result<GeneratedBinaryProject, Vec<RenderedDiagnostic>> {
+    super::rust_formatter::canonicalize_project_fields(
+        &mut generated.main_rs,
+        &mut generated.support_modules,
+    )?;
     generated.main_rs =
         super::rust_formatter::format_generated_rust(&generated.main_rs, "project main.rs")?;
     for (module_name, source) in &mut generated.support_modules {

--- a/crates/sifr_driver/src/build/project_codegen.rs
+++ b/crates/sifr_driver/src/build/project_codegen.rs
@@ -15,6 +15,7 @@ use std::collections::{BTreeMap, HashSet};
 pub(super) struct GeneratedBinaryProject {
     pub(super) main_rs: String,
     pub(super) support_modules: BTreeMap<String, String>,
+    pub(super) bridge_modules: BTreeMap<String, String>,
     pub(super) used_stdlib_modules: HashSet<String>,
     pub(super) required_features: HashSet<StdlibFeature>,
     pub(super) interop: sifr_codegen::InteropBuildPlan,
@@ -74,35 +75,67 @@ pub(super) fn codegen_single_file_frontend(
 pub(super) fn format_generated_binary_project(
     mut generated: GeneratedBinaryProject,
 ) -> Result<GeneratedBinaryProject, Vec<RenderedDiagnostic>> {
+    generated.bridge_modules = super::rust_interop_bridge_sources::generated_bridge_sources(
+        &generated.interop.rust.bridge_contracts.generated_types,
+    )
+    .map_err(|message| {
+        vec![crate::diagnostics::diagnostic_with_code(
+            message,
+            sifr_diagnostics::DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+        )]
+    })?;
     super::rust_formatter::canonicalize_project_fields(
         &mut generated.main_rs,
-        &mut generated.support_modules,
+        generated
+            .support_modules
+            .iter_mut()
+            .chain(generated.bridge_modules.iter_mut()),
     )?;
-    generated.main_rs =
-        super::rust_formatter::format_generated_rust(&generated.main_rs, "project main.rs")?;
-    for (module_name, source) in &mut generated.support_modules {
+    generated.main_rs = super::rust_formatter::format_canonical_generated_rust(
+        &generated.main_rs,
+        "project main.rs",
+    )?;
+    for (module_name, source) in generated
+        .support_modules
+        .iter_mut()
+        .chain(generated.bridge_modules.iter_mut())
+    {
         let label = format!("project module {module_name}");
-        *source = super::rust_formatter::format_generated_rust(source, &label)?;
+        *source = super::rust_formatter::format_canonical_generated_rust(source, &label)?;
     }
     loop {
         let before = super::rust_formatter::discover_project_const_functions(
-            std::iter::once(generated.main_rs.as_str())
-                .chain(generated.support_modules.values().map(String::as_str)),
+            std::iter::once(generated.main_rs.as_str()).chain(
+                generated
+                    .support_modules
+                    .values()
+                    .chain(generated.bridge_modules.values())
+                    .map(String::as_str),
+            ),
         )?;
         generated.main_rs = super::rust_formatter::format_generated_rust_with_project_consts(
             &generated.main_rs,
             "project main.rs",
             &before,
         )?;
-        for (module_name, source) in &mut generated.support_modules {
+        for (module_name, source) in generated
+            .support_modules
+            .iter_mut()
+            .chain(generated.bridge_modules.iter_mut())
+        {
             let label = format!("project module {module_name}");
             *source = super::rust_formatter::format_generated_rust_with_project_consts(
                 source, &label, &before,
             )?;
         }
         let after = super::rust_formatter::discover_project_const_functions(
-            std::iter::once(generated.main_rs.as_str())
-                .chain(generated.support_modules.values().map(String::as_str)),
+            std::iter::once(generated.main_rs.as_str()).chain(
+                generated
+                    .support_modules
+                    .values()
+                    .chain(generated.bridge_modules.values())
+                    .map(String::as_str),
+            ),
         )?;
         if after == before {
             return Ok(generated);
@@ -142,6 +175,7 @@ pub(super) fn generated_single_file_binary_project(
         required_features: codegen_result.required_features,
         interop: codegen_result.interop,
         cache_key_fragment,
+        bridge_modules: BTreeMap::new(),
         python_runtime: None,
     }
 }
@@ -235,6 +269,7 @@ pub(super) fn generated_project_binary_project(
         required_features: codegen_result.required_features,
         interop: codegen_result.interop,
         cache_key_fragment,
+        bridge_modules: BTreeMap::new(),
         python_runtime: None,
     })
 }
@@ -321,6 +356,7 @@ mod tests {
             required_features: HashSet::new(),
             interop: sifr_codegen::InteropBuildPlan::default(),
             cache_key_fragment: None,
+            bridge_modules: BTreeMap::new(),
             python_runtime: None,
         }
     }

--- a/crates/sifr_driver/src/build/python_bridges.rs
+++ b/crates/sifr_driver/src/build/python_bridges.rs
@@ -176,6 +176,7 @@ mod tests {
             required_features: HashSet::new(),
             interop: sifr_codegen::InteropBuildPlan::default(),
             cache_key_fragment: None,
+            bridge_modules: Default::default(),
             python_runtime: None,
         }
     }

--- a/crates/sifr_driver/src/build/python_interop.rs
+++ b/crates/sifr_driver/src/build/python_interop.rs
@@ -838,6 +838,7 @@ mod tests {
                 ..InteropBuildPlan::default()
             },
             cache_key_fragment: None,
+            bridge_modules: Default::default(),
             python_runtime: None,
         }
     }

--- a/crates/sifr_driver/src/build/rust_formatter.rs
+++ b/crates/sifr_driver/src/build/rust_formatter.rs
@@ -15,13 +15,19 @@ pub(crate) fn canonicalize_project_fields<'a>(
     modules: impl IntoIterator<Item = (&'a String, &'a mut String)>,
 ) -> Result<(), Vec<RenderedDiagnostic>> {
     let modules = modules.into_iter().collect::<Vec<_>>();
-    let sources = std::iter::once((String::new(), root.clone()))
-        .chain(
-            modules
-                .iter()
-                .map(|(module, source)| (module.replace('.', "::"), (**source).clone())),
-        )
-        .collect();
+    let mut sources = std::collections::BTreeMap::from([(String::new(), root.clone())]);
+    for (module, source) in &modules {
+        let identity = module.replace('.', "::");
+        if sources
+            .insert(identity.clone(), (**source).clone())
+            .is_some()
+        {
+            return Err(vec![diagnostic_with_code(
+                format!("duplicate generated project module identity: {identity}"),
+                DiagnosticCode::BUILD_RUSTC_OR_CARGO_FAILURE,
+            )]);
+        }
+    }
     let canonical =
         sifr_codegen::canonicalize_generated_rust_project(&sources).map_err(|message| {
             vec![diagnostic_with_code(
@@ -36,11 +42,8 @@ pub(crate) fn canonicalize_project_fields<'a>(
     Ok(())
 }
 
-pub(crate) fn format_generated_rust(
-    source: &str,
-    label: &str,
-) -> Result<String, Vec<RenderedDiagnostic>> {
-    let executable = std::env::var_os("RUSTFMT").unwrap_or_else(|| OsString::from("rustfmt"));
+#[cfg(test)]
+fn format_generated_rust(source: &str, label: &str) -> Result<String, Vec<RenderedDiagnostic>> {
     let canonicalize = |source: &str| {
         sifr_codegen::canonicalize_generated_rust_source(source).map_err(|message| {
             vec![diagnostic_with_code(
@@ -50,13 +53,21 @@ pub(crate) fn format_generated_rust(
         })
     };
     let canonical = canonicalize(source)?;
-    let formatted =
-        format_generated_rust_with(&executable, &canonical, label).map_err(|message| {
-            vec![diagnostic_with_code(
-                message,
-                DiagnosticCode::BUILD_RUSTC_OR_CARGO_FAILURE,
-            )]
-        })?;
+    format_canonical_generated_rust(&canonical, label)
+}
+
+/// Layout and API cleanup only: project owners have already fixed field identity.
+pub(crate) fn format_canonical_generated_rust(
+    source: &str,
+    label: &str,
+) -> Result<String, Vec<RenderedDiagnostic>> {
+    let executable = std::env::var_os("RUSTFMT").unwrap_or_else(|| OsString::from("rustfmt"));
+    let formatted = format_generated_rust_with(&executable, source, label).map_err(|message| {
+        vec![diagnostic_with_code(
+            message,
+            DiagnosticCode::BUILD_RUSTC_OR_CARGO_FAILURE,
+        )]
+    })?;
     let final_canonical = sifr_codegen::finalize_formatted_generated_rust_source(&formatted)
         .map_err(|message| {
             vec![diagnostic_with_code(
@@ -98,7 +109,7 @@ pub(crate) fn format_generated_rust_with_project_consts(
             DiagnosticCode::BUILD_RUSTC_OR_CARGO_FAILURE,
         )]
     })?;
-    format_generated_rust(&finalized, label)
+    format_canonical_generated_rust(&finalized, label)
 }
 
 fn format_generated_rust_with(
@@ -167,9 +178,11 @@ mod tests {
             )]);
             super::canonicalize_project_fields(&mut root, &mut modules)
                 .expect("shared project field registry");
-            let root = format_generated_rust(&root, "root.rs").expect("root formatting");
-            let declaration = format_generated_rust(&modules["records"], "records.rs")
-                .expect("module formatting");
+            let root =
+                super::format_canonical_generated_rust(&root, "root.rs").expect("root formatting");
+            let declaration =
+                super::format_canonical_generated_rust(&modules["records"], "records.rs")
+                    .expect("module formatting");
             assert!(declaration.contains("pub payload: i64"), "{declaration}");
             assert!(root.contains("value.payload"), "{root}");
             assert!(!root.contains("sifr_generated_payload"), "{root}");

--- a/crates/sifr_driver/src/build/rust_formatter.rs
+++ b/crates/sifr_driver/src/build/rust_formatter.rs
@@ -10,6 +10,32 @@ const EMPTY_RUSTFMT_CONFIG: &str = "NUL";
 #[cfg(not(windows))]
 const EMPTY_RUSTFMT_CONFIG: &str = "/dev/null";
 
+pub(crate) fn canonicalize_project_fields<'a>(
+    root: &mut String,
+    modules: impl IntoIterator<Item = (&'a String, &'a mut String)>,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let modules = modules.into_iter().collect::<Vec<_>>();
+    let sources = std::iter::once((String::new(), root.clone()))
+        .chain(
+            modules
+                .iter()
+                .map(|(module, source)| (module.replace('.', "::"), (**source).clone())),
+        )
+        .collect();
+    let canonical =
+        sifr_codegen::canonicalize_generated_rust_project(&sources).map_err(|message| {
+            vec![diagnostic_with_code(
+                format!("failed to canonicalize generated project: {message}"),
+                DiagnosticCode::BUILD_RUSTC_OR_CARGO_FAILURE,
+            )]
+        })?;
+    root.clone_from(&canonical[""]);
+    for (module, source) in modules {
+        source.clone_from(&canonical[&module.replace('.', "::")]);
+    }
+    Ok(())
+}
+
 pub(crate) fn format_generated_rust(
     source: &str,
     label: &str,
@@ -127,6 +153,28 @@ fn format_generated_rust_with(
 #[cfg(test)]
 mod tests {
     use super::{format_generated_rust, format_generated_rust_with};
+
+    #[test]
+    fn project_field_identity_binary_and_test_root_modules() {
+        for root in [
+            "mod records; fn main() { let value = records::Value { __sifr_payload: 7 }; println!(\"{}\", value.__sifr_payload); }",
+            "mod records; #[cfg(test)] mod tests { use crate::records::Value; #[test] fn check() { let value = Value { __sifr_payload: 7 }; assert_eq!(value.__sifr_payload, 7); } }",
+        ] {
+            let mut root = root.to_string();
+            let mut modules = std::collections::BTreeMap::from([(
+                "records".to_string(),
+                "pub struct Value { pub __sifr_payload: i64 }".to_string(),
+            )]);
+            super::canonicalize_project_fields(&mut root, &mut modules)
+                .expect("shared project field registry");
+            let root = format_generated_rust(&root, "root.rs").expect("root formatting");
+            let declaration = format_generated_rust(&modules["records"], "records.rs")
+                .expect("module formatting");
+            assert!(declaration.contains("pub payload: i64"), "{declaration}");
+            assert!(root.contains("value.payload"), "{root}");
+            assert!(!root.contains("sifr_generated_payload"), "{root}");
+        }
+    }
 
     #[test]
     fn generated_rust_uses_the_canonical_toolchain_layout() {

--- a/crates/sifr_driver/src/build/rust_interop_advanced_data_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_advanced_data_contract_tests.rs
@@ -430,6 +430,7 @@ fn generated_from_source(
         required_features: result.required_features,
         interop: result.interop,
         cache_key_fragment: None,
+        bridge_modules: Default::default(),
         python_runtime: None,
     }
 }

--- a/crates/sifr_driver/src/build/rust_interop_async_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_async_contract_tests.rs
@@ -344,6 +344,7 @@ fn generated_from_source(
         required_features: result.required_features,
         interop: result.interop,
         cache_key_fragment: None,
+        bridge_modules: Default::default(),
         python_runtime: None,
     }
 }

--- a/crates/sifr_driver/src/build/rust_interop_bridge_sources.rs
+++ b/crates/sifr_driver/src/build/rust_interop_bridge_sources.rs
@@ -3,11 +3,10 @@ use sifr_codegen::{
 };
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
-use std::path::PathBuf;
 
 pub(super) fn generated_bridge_sources(
     bridge_types: &[RustGeneratedBridgeType],
-) -> Result<BTreeMap<PathBuf, String>, String> {
+) -> Result<BTreeMap<String, String>, String> {
     let mut canonical_modules = BTreeMap::<String, Option<String>>::new();
     let mut unique_types = BTreeMap::<(String, String), &RustGeneratedBridgeType>::new();
     let mut modules: BTreeMap<String, Vec<&RustGeneratedBridgeType>> = BTreeMap::new();
@@ -60,12 +59,9 @@ pub(super) fn generated_bridge_sources(
             }
             module_source.push_str(&render_bridge_type(bridge_type));
         }
-        sources.insert(
-            PathBuf::from("__sifr_bridge").join(format!("{module_name}.rs")),
-            module_source,
-        );
+        sources.insert(format!("__sifr_bridge::{module_name}"), module_source);
     }
-    sources.insert(PathBuf::from("__sifr_bridge/mod.rs"), root);
+    sources.insert("__sifr_bridge".to_string(), root);
     Ok(sources)
 }
 
@@ -175,13 +171,11 @@ mod tests {
         .expect("bridge sources should be canonical");
 
         assert_eq!(
-            sources
-                .get(&PathBuf::from("__sifr_bridge/mod.rs"))
-                .map(String::as_str),
+            sources.get("__sifr_bridge").map(String::as_str),
             Some("pub mod app;\n")
         );
         let app_source = sources
-            .get(&PathBuf::from("__sifr_bridge/app.rs"))
+            .get("__sifr_bridge::app")
             .expect("app bridge source");
         assert!(app_source.contains("pub struct TokenBridge"));
         assert!(app_source.contains("pub text: String"));
@@ -209,7 +203,7 @@ mod tests {
         };
         let sources = generated_bridge_sources(&[bridge_type.clone(), bridge_type])
             .expect("identical bridge demand should deduplicate");
-        let source = &sources[&PathBuf::from("__sifr_bridge/app.rs")];
+        let source = &sources["__sifr_bridge::app"];
         assert_eq!(source.matches("pub struct TokenBridge").count(), 1);
     }
 

--- a/crates/sifr_driver/src/build/rust_interop_callback_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_callback_contract_tests.rs
@@ -453,6 +453,7 @@ fn generated_from_source(source: &str) -> GeneratedBinaryProject {
         required_features: result.required_features,
         interop: result.interop,
         cache_key_fragment: None,
+        bridge_modules: Default::default(),
         python_runtime: None,
     }
 }

--- a/crates/sifr_driver/src/build/rust_interop_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_contract_tests.rs
@@ -457,6 +457,7 @@ pub(super) fn base_project_with_contracts(
             ..InteropBuildPlan::default()
         },
         cache_key_fragment: None,
+        bridge_modules: Default::default(),
         python_runtime: None,
     }
 }

--- a/crates/sifr_driver/src/build/rust_interop_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_tests.rs
@@ -558,6 +558,7 @@ fn base_project(declarations: Vec<RustInteropPlanDeclaration>) -> GeneratedBinar
             ..InteropBuildPlan::default()
         },
         cache_key_fragment: None,
+        bridge_modules: Default::default(),
         python_runtime: None,
     }
 }

--- a/crates/sifr_driver/src/build/rust_interop_zero_copy_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_zero_copy_contract_tests.rs
@@ -353,6 +353,7 @@ fn generated_from_fixture_source(source: &str) -> GeneratedBinaryProject {
         required_features: result.required_features,
         interop: result.interop,
         cache_key_fragment: None,
+        bridge_modules: Default::default(),
         python_runtime: None,
     }
 }

--- a/crates/sifr_driver/src/build/sysroot_interop.rs
+++ b/crates/sifr_driver/src/build/sysroot_interop.rs
@@ -699,6 +699,7 @@ class FileHandle:\n\
             required_features: HashSet::<StdlibFeature>::new(),
             interop: InteropBuildPlan::default(),
             cache_key_fragment: None,
+            bridge_modules: Default::default(),
             python_runtime: None,
         }
     }

--- a/crates/sifr_driver/src/build/sysroot_interop_tests.rs
+++ b/crates/sifr_driver/src/build/sysroot_interop_tests.rs
@@ -330,6 +330,7 @@ fn base_project() -> GeneratedBinaryProject {
         required_features: HashSet::new(),
         interop: InteropBuildPlan::default(),
         cache_key_fragment: None,
+        bridge_modules: Default::default(),
         python_runtime: None,
     }
 }

--- a/crates/sifr_driver/src/test_runner/orchestrator.rs
+++ b/crates/sifr_driver/src/test_runner/orchestrator.rs
@@ -1,5 +1,5 @@
 use super::execution::execute_test_runner_project;
-use crate::build::format_generated_rust;
+use crate::build::format_canonical_generated_rust;
 use crate::diagnostics::{RenderedDiagnostic, run_codegen_with_boundary, write_stderr_line};
 use crate::project::{
     DiscoveryDiagnosticStyle, ModuleResolver, ParsedProjectModule,
@@ -166,9 +166,9 @@ pub(crate) fn build_test_runner_project(
     )?;
     for (module_name, source) in &mut generated.support_rust_files {
         let label = format!("test support module {module_name}");
-        *source = format_generated_rust(source, &label)?;
+        *source = format_canonical_generated_rust(source, &label)?;
     }
-    all_rust_code = format_generated_rust(&all_rust_code, "test runner lib.rs body")?;
+    all_rust_code = format_canonical_generated_rust(&all_rust_code, "test runner lib.rs body")?;
 
     Ok(GeneratedTestRunnerProject {
         cache_scope: test_dir.to_path_buf(),

--- a/crates/sifr_driver/src/test_runner/orchestrator.rs
+++ b/crates/sifr_driver/src/test_runner/orchestrator.rs
@@ -139,11 +139,6 @@ pub(crate) fn build_test_runner_project(
     )
     .map_err(|error| vec![*error])?;
 
-    for (module_name, source) in &mut generated.support_rust_files {
-        let label = format!("test support module {module_name}");
-        *source = format_generated_rust(source, &label)?;
-    }
-
     let mut all_rust_code = generated.project_union_prelude;
     if !all_rust_code.is_empty() {
         all_rust_code.push('\n');
@@ -164,6 +159,14 @@ pub(crate) fn build_test_runner_project(
         all_rust_code.push('\n');
         all_rust_code.push_str(rust_source);
         all_rust_code.push('\n');
+    }
+    crate::build::canonicalize_project_fields(
+        &mut all_rust_code,
+        &mut generated.support_rust_files,
+    )?;
+    for (module_name, source) in &mut generated.support_rust_files {
+        let label = format!("test support module {module_name}");
+        *source = format_generated_rust(source, &label)?;
     }
     all_rust_code = format_generated_rust(&all_rust_code, "test runner lib.rs body")?;
 

--- a/demos/advanced_class_libraries/emitted.rs
+++ b/demos/advanced_class_libraries/emitted.rs
@@ -1189,7 +1189,7 @@ mod sifr_generated_project_nominals {
     use ::std::collections::VecDeque;
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct SifrGeneratedStdlibSifrX2ecollectionsX2edeque<T> {
-        pub data_field: VecDeque<T>,
+        pub data: VecDeque<T>,
         pub maxlen: Option<SifrInt>,
     }
     impl<T: Clone> SifrGeneratedStdlibSifrX2ecollectionsX2edeque<T> {
@@ -1229,18 +1229,18 @@ mod sifr_generated_project_nominals {
                 VecDeque::from(data);
             Self {
                 maxlen: sifr_generated_field_value_169953f6befb0270_6d61786c656e,
-                data_field: sifr_generated_field_value_90770dc80a1c57ce_5f64617461,
+                data: sifr_generated_field_value_90770dc80a1c57ce_5f64617461,
             }
         }
     }
     impl<T: Clone> SifrGeneratedStdlibSifrX2ecollectionsX2edeque<T> {
         pub fn append(&mut self, val: &T) {
-            self.data_field.push_back(val.clone());
+            self.data.push_back(val.clone());
             let maxlen_opt: Option<SifrInt> = self.maxlen.clone();
             if let Some(maxlen_opt) = maxlen_opt.clone() {
                 let maxlen: SifrInt = maxlen_opt.clone();
-                if &SifrInt::from(self.data_field.len()) > &maxlen {
-                    self.data_field.pop_front();
+                if &SifrInt::from(self.data.len()) > &maxlen {
+                    self.data.pop_front();
                 }
             }
         }
@@ -1248,13 +1248,13 @@ mod sifr_generated_project_nominals {
     impl<T> SifrGeneratedStdlibSifrX2ecollectionsX2edeque<T> {
         #[must_use]
         pub fn popleft(&mut self) -> Option<T> {
-            if &SifrInt::from(self.data_field.len()) == &SifrInt::from_i64(0) {
+            if &SifrInt::from(self.data.len()) == &SifrInt::from_i64(0) {
                 return None;
             }
             Some({
                 let sifr_generated_nonempty_pop_index = 0_usize;
                 let mut sifr_generated_nonempty_pop_values = self
-                    .data_field
+                    .data
                     .drain(sifr_generated_nonempty_pop_index..=sifr_generated_nonempty_pop_index)
                     .collect::<Vec<_>>();
                 sifr_generated_nonempty_pop_values.remove(0_usize)
@@ -1264,19 +1264,19 @@ mod sifr_generated_project_nominals {
     impl<T> SifrGeneratedStdlibSifrX2ecollectionsX2edeque<T> {
         #[must_use]
         pub fn len(&self) -> SifrInt {
-            SifrInt::from(self.data_field.len())
+            SifrInt::from(self.data.len())
         }
     }
     impl<T> SifrGeneratedStdlibSifrX2ecollectionsX2edeque<T> {
         pub fn clear(&mut self) {
-            self.data_field.clear();
+            self.data.clear();
         }
     }
     impl<T: Clone + PartialEq> SifrGeneratedStdlibSifrX2ecollectionsX2edeque<T> {
         #[must_use]
         pub fn count(&self, value: &T) -> SifrInt {
             let mut total: SifrInt = SifrInt::from_i64(0);
-            for item in self.data_field.iter().cloned() {
+            for item in self.data.iter().cloned() {
                 if item == *value {
                     total = &total + &SifrInt::from_i64(1);
                 }
@@ -1287,7 +1287,7 @@ mod sifr_generated_project_nominals {
     impl<T: Clone + PartialEq> SifrGeneratedStdlibSifrX2ecollectionsX2edeque<T> {
         #[must_use]
         pub fn index(&self, value: &T, start: &SifrInt, stop: &Option<SifrInt>) -> Option<SifrInt> {
-            let size: SifrInt = SifrInt::from(self.data_field.len());
+            let size: SifrInt = SifrInt::from(self.data.len());
             let mut begin: SifrInt = start.clone();
             if &begin < &SifrInt::from_i64(0) {
                 begin = &size + &begin;
@@ -1311,7 +1311,7 @@ mod sifr_generated_project_nominals {
             let mut i: SifrInt = begin.clone();
             while &i < &end {
                 let current: Option<T> = {
-                    let sifr_generated_checked_read_collection = &self.data_field;
+                    let sifr_generated_checked_read_collection = &self.data;
                     let sifr_generated_checked_read_index = i.clone();
                     let sifr_generated_checked_read_normalized = sifr_generated_checked_read_index
                         .normalize_index_or_len(sifr_generated_checked_read_collection.len());
@@ -1335,9 +1335,9 @@ mod sifr_generated_project_nominals {
             if let Some(idx) = idx.clone() {
                 let mut rebuilt: Vec<T> = Vec::new();
                 let mut i: SifrInt = SifrInt::from_i64(0);
-                while &i < &SifrInt::from(self.data_field.len()) {
+                while &i < &SifrInt::from(self.data.len()) {
                     let current: Option<T> = {
-                        let sifr_generated_checked_read_collection = &self.data_field;
+                        let sifr_generated_checked_read_collection = &self.data;
                         let sifr_generated_checked_read_index = i.clone();
                         let sifr_generated_checked_read_normalized =
                             sifr_generated_checked_read_index.normalize_index_or_len(
@@ -1354,9 +1354,9 @@ mod sifr_generated_project_nominals {
                     }
                     i = &i + &SifrInt::from_i64(1);
                 }
-                self.data_field.clear();
+                self.data.clear();
                 for item in rebuilt.iter().cloned() {
-                    self.data_field.push_back(item.clone());
+                    self.data.push_back(item.clone());
                 }
             }
         }
@@ -1834,7 +1834,7 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct SifrGeneratedStdlibSifrX2ecsvX2eDictReader {
-        pub fieldnames_field: Vec<String>,
+        pub fieldnames: Vec<String>,
         pub rows: Vec<Vec<String>>,
         pub pos: SifrInt,
         pub restkey: String,
@@ -1930,8 +1930,7 @@ mod sifr_generated_project_nominals {
                 restkey: sifr_generated_field_value_d10323292550fbae_726573746b6579,
                 restval: sifr_generated_field_value_e9b6e328a309fdee_7265737476616c,
                 pos: sifr_generated_field_value_e04b9443eebba9b4_5f706f73,
-                fieldnames_field:
-                    sifr_generated_field_value_efdb691f099ff036_5f6669656c646e616d6573,
+                fieldnames: sifr_generated_field_value_efdb691f099ff036_5f6669656c646e616d6573,
                 rows: sifr_generated_field_value_d742ae5cfb4259e3_5f726f7773,
             }
         }
@@ -1940,7 +1939,7 @@ mod sifr_generated_project_nominals {
         #[must_use]
         pub fn fieldnames(&self) -> Vec<String> {
             let mut copied: Vec<String> = Vec::new();
-            for field in self.fieldnames_field.iter().cloned() {
+            for field in self.fieldnames.iter().cloned() {
                 copied.push(field.to_string());
             }
             copied
@@ -1955,7 +1954,7 @@ mod sifr_generated_project_nominals {
                     continue;
                 }
                 result.push(sifr_generated_dict_reader_row(
-                    &self.fieldnames_field,
+                    &self.fieldnames,
                     &row,
                     &self.restkey,
                     &self.restval,
@@ -2348,7 +2347,7 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct SifrGeneratedStdlibSifrX2eloggingX2eLogger {
-        pub name_field: String,
+        pub name: String,
         pub level: SifrInt,
         pub log_path: String,
         pub handler_kind: String,
@@ -2372,7 +2371,7 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_98e9bbb8fd5643d6_5f68616e646c65725f666d74: String =
                 "%(levelname)s:%(name)s:%(message)s".to_string();
             Self {
-                name_field: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
+                name: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
                 level: sifr_generated_field_value_70fb616fceb1e22c_5f6c6576656c,
                 log_path: sifr_generated_field_value_1fb1dcbc22de0cba_5f6c6f675f70617468,
                 handler_kind:
@@ -2404,7 +2403,7 @@ mod sifr_generated_project_nominals {
         pub fn sifr_generated_handler_line(&self, level: &str, msg: &str) -> String {
             let formatter: SifrGeneratedStdlibSifrX2eloggingX2eFormatter =
                 SifrGeneratedStdlibSifrX2eloggingX2eFormatter::new(self.handler_fmt.clone());
-            formatter.format(level, &self.name_field.clone(), msg)
+            formatter.format(level, &self.name.clone(), msg)
         }
     }
     impl SifrGeneratedStdlibSifrX2eloggingX2eLogger {
@@ -2464,7 +2463,7 @@ mod sifr_generated_project_nominals {
                 sifr_generated_concat.push('[');
                 sifr_generated_concat.push_str(level);
                 sifr_generated_concat.push_str("] ");
-                sifr_generated_concat.push_str(self.name_field.clone().as_str());
+                sifr_generated_concat.push_str(self.name.clone().as_str());
                 sifr_generated_concat.push_str(": ");
                 sifr_generated_concat.push_str(msg);
                 sifr_generated_concat
@@ -2530,7 +2529,7 @@ mod sifr_generated_project_nominals {
             write!(
                 f,
                 "Logger(_name={}, _level={}, _log_path={}, _handler_kind={}, _handler_path={}, _handler_level={}, _handler_fmt={})",
-                self.name_field,
+                self.name,
                 self.level,
                 self.log_path,
                 self.handler_kind,

--- a/demos/advanced_class_libraries/emitted.rs
+++ b/demos/advanced_class_libraries/emitted.rs
@@ -398,26 +398,17 @@ mod sifr_generated_generated_support {
         rows.push(row);
     }
     pub(crate) fn sifr_generated_char_at(text: &str, index: SifrInt) -> String {
-        let sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874: Vec<
-            char,
-        > = text.chars().collect::<Vec<char>>();
+        let sifr_generated_chars_text: Vec<char> = text.chars().collect::<Vec<char>>();
         if &index < &SifrInt::from_i64(0)
-            || &index
-                >= &SifrInt::from(
-                    sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                        .len(),
-                )
+            || &index >= &SifrInt::from(sifr_generated_chars_text.len())
         {
             return String::new();
         }
         let ch: Option<String> = {
             let sifr_generated_string_index = index.clone();
-            let sifr_generated_string_index_normalized = sifr_generated_string_index
-                .normalize_index_or_len(
-                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                    .len(),
-            );
-            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
+            let sifr_generated_string_index_normalized =
+                sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_text.len());
+            sifr_generated_chars_text
                 .get(sifr_generated_string_index_normalized)
                 .copied()
         }
@@ -501,9 +492,7 @@ mod sifr_generated_generated_support {
         quoting: SifrInt,
     ) -> Vec<Vec<String>> {
         let quotechar = quotechar.to_owned();
-        let sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874: Vec<
-            char,
-        > = text.chars().collect::<Vec<char>>();
+        let sifr_generated_chars_text: Vec<char> = text.chars().collect::<Vec<char>>();
         let resolved: SifrGeneratedStdlibSifrX2ecsvX2eDialect = sifr_generated_resolve_dialect(
             dialect,
             delimiter,
@@ -520,27 +509,17 @@ mod sifr_generated_generated_support {
         let mut in_quotes: bool = false;
         let mut field_started: bool = false;
         let mut i: SifrInt = SifrInt::from_i64(0);
-        while &i
-            < &SifrInt::from(
-                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                    .len(),
-            )
-        {
+        while &i < &SifrInt::from(sifr_generated_chars_text.len()) {
             let ch_value: String = sifr_generated_char_at(text, i.clone());
             if in_quotes {
                 if !resolved.escapechar.clone().is_empty()
                     && ch_value == resolved.escapechar.clone()
                 {
                     if &(&i + &SifrInt::from_i64(1))
-                        < &SifrInt::from(
-                            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                .len(),
-                        )
+                        < &SifrInt::from(sifr_generated_chars_text.len())
                     {
-                        let escaped_value: String = sifr_generated_char_at(
-                            text,
-                            &i + &SifrInt::from_i64(1),
-                        );
+                        let escaped_value: String =
+                            sifr_generated_char_at(text, &i + &SifrInt::from_i64(1));
                         field.push_str(escaped_value.as_str());
                         i = &i + &SifrInt::from_i64(2);
                         continue;
@@ -554,12 +533,8 @@ mod sifr_generated_generated_support {
                     let quotechar: String = sifr_generated_quotechar_value(&resolved);
                     if resolved.doublequote
                         && &(&i + &SifrInt::from_i64(1))
-                            < &SifrInt::from(
-                                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                    .len(),
-                            )
-                        && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1))
-                            == quotechar
+                            < &SifrInt::from(sifr_generated_chars_text.len())
+                        && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1)) == quotechar
                     {
                         field.push_str(quotechar.as_str());
                         i = &i + &SifrInt::from_i64(2);
@@ -578,16 +553,9 @@ mod sifr_generated_generated_support {
                 continue;
             }
             if !resolved.escapechar.clone().is_empty() && ch_value == resolved.escapechar.clone() {
-                if &(&i + &SifrInt::from_i64(1))
-                    < &SifrInt::from(
-                        sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                            .len(),
-                    )
-                {
-                    let escaped_plain_value: String = sifr_generated_char_at(
-                        text,
-                        &i + &SifrInt::from_i64(1),
-                    );
+                if &(&i + &SifrInt::from_i64(1)) < &SifrInt::from(sifr_generated_chars_text.len()) {
+                    let escaped_plain_value: String =
+                        sifr_generated_char_at(text, &i + &SifrInt::from_i64(1));
                     field.push_str(escaped_plain_value.as_str());
                     field_started = true;
                     i = &i + &SifrInt::from_i64(2);
@@ -620,10 +588,7 @@ mod sifr_generated_generated_support {
             if ch_value == "\n" || ch_value == "\r" {
                 if ch_value == "\r"
                     && &(&i + &SifrInt::from_i64(1))
-                        < &SifrInt::from(
-                            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                .len(),
-                        )
+                        < &SifrInt::from(sifr_generated_chars_text.len())
                     && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1)) == "\n"
                 {
                     i = &i + &SifrInt::from_i64(1);

--- a/demos/class_libraries/emitted.rs
+++ b/demos/class_libraries/emitted.rs
@@ -1254,7 +1254,7 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct SifrGeneratedStdlibSifrX2eloggingX2eLogger {
-        pub name_field: String,
+        pub name: String,
         pub level: SifrInt,
         pub log_path: String,
         pub handler_kind: String,
@@ -1278,7 +1278,7 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_98e9bbb8fd5643d6_5f68616e646c65725f666d74: String =
                 "%(levelname)s:%(name)s:%(message)s".to_string();
             Self {
-                name_field: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
+                name: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
                 level: sifr_generated_field_value_70fb616fceb1e22c_5f6c6576656c,
                 log_path: sifr_generated_field_value_1fb1dcbc22de0cba_5f6c6f675f70617468,
                 handler_kind:
@@ -1310,7 +1310,7 @@ mod sifr_generated_project_nominals {
         pub fn sifr_generated_handler_line(&self, level: &str, msg: &str) -> String {
             let formatter: SifrGeneratedStdlibSifrX2eloggingX2eFormatter =
                 SifrGeneratedStdlibSifrX2eloggingX2eFormatter::new(self.handler_fmt.clone());
-            formatter.format(level, &self.name_field.clone(), msg)
+            formatter.format(level, &self.name.clone(), msg)
         }
     }
     impl SifrGeneratedStdlibSifrX2eloggingX2eLogger {
@@ -1370,7 +1370,7 @@ mod sifr_generated_project_nominals {
                 sifr_generated_concat.push('[');
                 sifr_generated_concat.push_str(level);
                 sifr_generated_concat.push_str("] ");
-                sifr_generated_concat.push_str(self.name_field.clone().as_str());
+                sifr_generated_concat.push_str(self.name.clone().as_str());
                 sifr_generated_concat.push_str(": ");
                 sifr_generated_concat.push_str(msg);
                 sifr_generated_concat
@@ -1436,7 +1436,7 @@ mod sifr_generated_project_nominals {
             write!(
                 f,
                 "Logger(_name={}, _level={}, _log_path={}, _handler_kind={}, _handler_path={}, _handler_level={}, _handler_fmt={})",
-                self.name_field,
+                self.name,
                 self.level,
                 self.log_path,
                 self.handler_kind,

--- a/demos/codegen_preamble/emitted.rs
+++ b/demos/codegen_preamble/emitted.rs
@@ -937,7 +937,7 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct SifrGeneratedStdlibSifrX2eloggingX2eLogger {
-        pub name_field: String,
+        pub name: String,
         pub level: SifrInt,
         pub log_path: String,
         pub handler_kind: String,
@@ -961,7 +961,7 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_98e9bbb8fd5643d6_5f68616e646c65725f666d74: String =
                 "%(levelname)s:%(name)s:%(message)s".to_string();
             Self {
-                name_field: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
+                name: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
                 level: sifr_generated_field_value_70fb616fceb1e22c_5f6c6576656c,
                 log_path: sifr_generated_field_value_1fb1dcbc22de0cba_5f6c6f675f70617468,
                 handler_kind:
@@ -993,7 +993,7 @@ mod sifr_generated_project_nominals {
         pub fn sifr_generated_handler_line(&self, level: &str, msg: &str) -> String {
             let formatter: SifrGeneratedStdlibSifrX2eloggingX2eFormatter =
                 SifrGeneratedStdlibSifrX2eloggingX2eFormatter::new(self.handler_fmt.clone());
-            formatter.format(level, &self.name_field.clone(), msg)
+            formatter.format(level, &self.name.clone(), msg)
         }
     }
     impl SifrGeneratedStdlibSifrX2eloggingX2eLogger {
@@ -1053,7 +1053,7 @@ mod sifr_generated_project_nominals {
                 sifr_generated_concat.push('[');
                 sifr_generated_concat.push_str(level);
                 sifr_generated_concat.push_str("] ");
-                sifr_generated_concat.push_str(self.name_field.clone().as_str());
+                sifr_generated_concat.push_str(self.name.clone().as_str());
                 sifr_generated_concat.push_str(": ");
                 sifr_generated_concat.push_str(msg);
                 sifr_generated_concat
@@ -1101,7 +1101,7 @@ mod sifr_generated_project_nominals {
             write!(
                 f,
                 "Logger(_name={}, _level={}, _log_path={}, _handler_kind={}, _handler_path={}, _handler_level={}, _handler_fmt={})",
-                self.name_field,
+                self.name,
                 self.level,
                 self.log_path,
                 self.handler_kind,

--- a/demos/csv/emitted.rs
+++ b/demos/csv/emitted.rs
@@ -90,26 +90,17 @@ mod sifr_generated_generated_support {
         rows.push(row);
     }
     pub(crate) fn sifr_generated_char_at(text: &str, index: SifrInt) -> String {
-        let sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874: Vec<
-            char,
-        > = text.chars().collect::<Vec<char>>();
+        let sifr_generated_chars_text: Vec<char> = text.chars().collect::<Vec<char>>();
         if &index < &SifrInt::from_i64(0)
-            || &index
-                >= &SifrInt::from(
-                    sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                        .len(),
-                )
+            || &index >= &SifrInt::from(sifr_generated_chars_text.len())
         {
             return String::new();
         }
         let ch: Option<String> = {
             let sifr_generated_string_index = index.clone();
-            let sifr_generated_string_index_normalized = sifr_generated_string_index
-                .normalize_index_or_len(
-                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                    .len(),
-            );
-            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
+            let sifr_generated_string_index_normalized =
+                sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_text.len());
+            sifr_generated_chars_text
                 .get(sifr_generated_string_index_normalized)
                 .copied()
         }
@@ -191,9 +182,7 @@ mod sifr_generated_generated_support {
         quoting: SifrInt,
     ) -> Vec<Vec<String>> {
         let quotechar = quotechar.to_owned();
-        let sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874: Vec<
-            char,
-        > = text.chars().collect::<Vec<char>>();
+        let sifr_generated_chars_text: Vec<char> = text.chars().collect::<Vec<char>>();
         let resolved: SifrGeneratedStdlibSifrX2ecsvX2eDialect = sifr_generated_resolve_dialect(
             dialect,
             delimiter,
@@ -210,27 +199,17 @@ mod sifr_generated_generated_support {
         let mut in_quotes: bool = false;
         let mut field_started: bool = false;
         let mut i: SifrInt = SifrInt::from_i64(0);
-        while &i
-            < &SifrInt::from(
-                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                    .len(),
-            )
-        {
+        while &i < &SifrInt::from(sifr_generated_chars_text.len()) {
             let ch_value: String = sifr_generated_char_at(text, i.clone());
             if in_quotes {
                 if !resolved.escapechar.clone().is_empty()
                     && ch_value == resolved.escapechar.clone()
                 {
                     if &(&i + &SifrInt::from_i64(1))
-                        < &SifrInt::from(
-                            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                .len(),
-                        )
+                        < &SifrInt::from(sifr_generated_chars_text.len())
                     {
-                        let escaped_value: String = sifr_generated_char_at(
-                            text,
-                            &i + &SifrInt::from_i64(1),
-                        );
+                        let escaped_value: String =
+                            sifr_generated_char_at(text, &i + &SifrInt::from_i64(1));
                         field.push_str(escaped_value.as_str());
                         i = &i + &SifrInt::from_i64(2);
                         continue;
@@ -244,12 +223,8 @@ mod sifr_generated_generated_support {
                     let quotechar: String = sifr_generated_quotechar_value(&resolved);
                     if resolved.doublequote
                         && &(&i + &SifrInt::from_i64(1))
-                            < &SifrInt::from(
-                                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                    .len(),
-                            )
-                        && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1))
-                            == quotechar
+                            < &SifrInt::from(sifr_generated_chars_text.len())
+                        && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1)) == quotechar
                     {
                         field.push_str(quotechar.as_str());
                         i = &i + &SifrInt::from_i64(2);
@@ -268,16 +243,9 @@ mod sifr_generated_generated_support {
                 continue;
             }
             if !resolved.escapechar.clone().is_empty() && ch_value == resolved.escapechar.clone() {
-                if &(&i + &SifrInt::from_i64(1))
-                    < &SifrInt::from(
-                        sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                            .len(),
-                    )
-                {
-                    let escaped_plain_value: String = sifr_generated_char_at(
-                        text,
-                        &i + &SifrInt::from_i64(1),
-                    );
+                if &(&i + &SifrInt::from_i64(1)) < &SifrInt::from(sifr_generated_chars_text.len()) {
+                    let escaped_plain_value: String =
+                        sifr_generated_char_at(text, &i + &SifrInt::from_i64(1));
                     field.push_str(escaped_plain_value.as_str());
                     field_started = true;
                     i = &i + &SifrInt::from_i64(2);
@@ -310,10 +278,7 @@ mod sifr_generated_generated_support {
             if ch_value == "\n" || ch_value == "\r" {
                 if ch_value == "\r"
                     && &(&i + &SifrInt::from_i64(1))
-                        < &SifrInt::from(
-                            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                .len(),
-                        )
+                        < &SifrInt::from(sifr_generated_chars_text.len())
                     && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1)) == "\n"
                 {
                     i = &i + &SifrInt::from_i64(1);

--- a/demos/extended_stdlib/emitted.rs
+++ b/demos/extended_stdlib/emitted.rs
@@ -431,9 +431,9 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub struct SifrGeneratedStdlibSifrX2erandomX2eRandom {
-        pub state_words_field: Vec<SifrInt>,
-        pub index_field: SifrInt,
-        pub gauss_next_field: Option<f64>,
+        pub state_words: Vec<SifrInt>,
+        pub index: SifrInt,
+        pub gauss_next: Option<f64>,
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
@@ -446,32 +446,29 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874: Option<f64> =
                 None;
             Self {
-                state_words_field:
-                    sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
-                index_field: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
-                gauss_next_field:
-                    sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
+                state_words: sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
+                index: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
+                gauss_next: sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
             }
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         pub fn sifr_generated_twist(&mut self) {
             let mut i: SifrInt = SifrInt::from_i64(0);
-            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words_field.len()) {
-                let y: SifrInt =
-                    &(&sifr_generated_state_word_at(&self.state_words_field, i.clone())
-                        & &sifr_generated_const_5f4d545f55505045525f4d41534b())
-                        + &(&sifr_generated_state_word_at(
-                            &self.state_words_field,
-                            (&i + &SifrInt::from_i64(1))
-                                .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
-                        ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
+            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words.len()) {
+                let y: SifrInt = &(&sifr_generated_state_word_at(&self.state_words, i.clone())
+                    & &sifr_generated_const_5f4d545f55505045525f4d41534b())
+                    + &(&sifr_generated_state_word_at(
+                        &self.state_words,
+                        (&i + &SifrInt::from_i64(1))
+                            .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
+                    ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
                 let mut x_a: SifrInt = y.floor_div_known_nonzero(&SifrInt::from_i64(2));
                 if &y.floor_mod_known_nonzero(&SifrInt::from_i64(2)) != &SifrInt::from_i64(0) {
                     x_a = &x_a ^ &sifr_generated_const_5f4d545f4d41545249585f41();
                 }
                 let new_word: SifrInt = &sifr_generated_state_word_at(
-                    &self.state_words_field,
+                    &self.state_words,
                     (&i + &sifr_generated_const_5f4d545f4d())
                         .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
                 ) ^ &x_a;
@@ -480,11 +477,10 @@ mod sifr_generated_project_nominals {
                         &new_word & &sifr_generated_const_5f4d545f574f52445f4d41534b();
                     {
                         let sifr_generated_index_raw = i.clone();
-                        let sifr_generated_index_normalized = sifr_generated_index_raw
-                            .normalize_index_or_len(self.state_words_field.len());
-                        if let Some(sifr_generated_elem) = self
-                            .state_words_field
-                            .get_mut(sifr_generated_index_normalized)
+                        let sifr_generated_index_normalized =
+                            sifr_generated_index_raw.normalize_index_or_len(self.state_words.len());
+                        if let Some(sifr_generated_elem) =
+                            self.state_words.get_mut(sifr_generated_index_normalized)
                         {
                             *sifr_generated_elem = sifr_generated_assign_value;
                         }
@@ -492,18 +488,18 @@ mod sifr_generated_project_nominals {
                 }
                 i = &i + &SifrInt::from_i64(1);
             }
-            self.index_field = SifrInt::from_i64(0);
+            self.index = SifrInt::from_i64(0);
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
         pub fn sifr_generated_next_u32(&mut self) -> SifrInt {
-            if &self.index_field.clone() >= &sifr_generated_const_5f4d545f4e() {
+            if &self.index.clone() >= &sifr_generated_const_5f4d545f4e() {
                 self.sifr_generated_twist();
             }
             let mut y: SifrInt =
-                sifr_generated_state_word_at(&self.state_words_field, self.index_field.clone());
-            self.index_field = &self.index_field.clone() + &SifrInt::from_i64(1);
+                sifr_generated_state_word_at(&self.state_words, self.index.clone());
+            self.index = &self.index.clone() + &SifrInt::from_i64(1);
             y = &y ^ &y.floor_div_known_nonzero(&SifrInt::from_i64(2048));
             y = &y ^ &(&(&y * &SifrInt::from_i64(128)) & &SifrInt::from_i64(2_636_928_640));
             y = &y ^ &(&(&y * &SifrInt::from_i64(32768)) & &SifrInt::from_i64(4_022_730_752));
@@ -596,9 +592,9 @@ mod sifr_generated_project_nominals {
         pub fn getstate(&self) -> SifrGeneratedStdlibSifrX2erandomX2eRandomState {
             SifrGeneratedStdlibSifrX2erandomX2eRandomState::new(
                 SifrInt::from_i64(3),
-                sifr_generated_clone_words(&self.state_words_field),
-                self.index_field.clone(),
-                self.gauss_next_field,
+                sifr_generated_clone_words(&self.state_words),
+                self.index.clone(),
+                self.gauss_next,
             )
         }
     }
@@ -633,9 +629,9 @@ mod sifr_generated_project_nominals {
                 }
                 normalized.push(&word & &sifr_generated_const_5f4d545f574f52445f4d41534b());
             }
-            self.state_words_field = normalized;
-            self.index_field = state.index.clone();
-            self.gauss_next_field = state.gauss_next;
+            self.state_words = normalized;
+            self.index = state.index.clone();
+            self.gauss_next = state.gauss_next;
             Ok(())
         }
     }

--- a/demos/filesystem_and_archives/emitted.rs
+++ b/demos/filesystem_and_archives/emitted.rs
@@ -468,32 +468,32 @@ mod sifr_generated_project_nominals {
     use ::sifr_runtime::SifrInt;
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct SifrGeneratedStdlibSifrX2epathlibX2ePath {
-        pub path_field: String,
+        pub path: String,
     }
     impl SifrGeneratedStdlibSifrX2epathlibX2ePath {
         #[must_use]
         pub const fn new(path: String) -> Self {
             let sifr_generated_field_value_0e74a76ec4f48c05_5f70617468: String = path;
             Self {
-                path_field: sifr_generated_field_value_0e74a76ec4f48c05_5f70617468,
+                path: sifr_generated_field_value_0e74a76ec4f48c05_5f70617468,
             }
         }
     }
     impl SifrGeneratedStdlibSifrX2epathlibX2ePath {
         #[must_use]
         pub fn stem(&self) -> String {
-            stem(&self.path_field)
+            stem(&self.path)
         }
     }
     impl SifrGeneratedStdlibSifrX2epathlibX2ePath {
         #[must_use]
         pub fn exists(&self) -> bool {
-            exists(&self.path_field)
+            exists(&self.path)
         }
     }
     impl ::std::fmt::Display for SifrGeneratedStdlibSifrX2epathlibX2ePath {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-            write!(f, "Path(_path={})", self.path_field)
+            write!(f, "Path(_path={})", self.path)
         }
     }
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/demos/generic_stdlib/emitted.rs
+++ b/demos/generic_stdlib/emitted.rs
@@ -1367,9 +1367,9 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub struct SifrGeneratedStdlibSifrX2erandomX2eRandom {
-        pub state_words_field: Vec<SifrInt>,
-        pub index_field: SifrInt,
-        pub gauss_next_field: Option<f64>,
+        pub state_words: Vec<SifrInt>,
+        pub index: SifrInt,
+        pub gauss_next: Option<f64>,
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
@@ -1382,32 +1382,29 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874: Option<f64> =
                 None;
             Self {
-                state_words_field:
-                    sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
-                index_field: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
-                gauss_next_field:
-                    sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
+                state_words: sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
+                index: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
+                gauss_next: sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
             }
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         pub fn sifr_generated_twist(&mut self) {
             let mut i: SifrInt = SifrInt::from_i64(0);
-            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words_field.len()) {
-                let y: SifrInt =
-                    &(&sifr_generated_state_word_at(&self.state_words_field, i.clone())
-                        & &sifr_generated_const_5f4d545f55505045525f4d41534b())
-                        + &(&sifr_generated_state_word_at(
-                            &self.state_words_field,
-                            (&i + &SifrInt::from_i64(1))
-                                .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
-                        ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
+            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words.len()) {
+                let y: SifrInt = &(&sifr_generated_state_word_at(&self.state_words, i.clone())
+                    & &sifr_generated_const_5f4d545f55505045525f4d41534b())
+                    + &(&sifr_generated_state_word_at(
+                        &self.state_words,
+                        (&i + &SifrInt::from_i64(1))
+                            .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
+                    ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
                 let mut x_a: SifrInt = y.floor_div_known_nonzero(&SifrInt::from_i64(2));
                 if &y.floor_mod_known_nonzero(&SifrInt::from_i64(2)) != &SifrInt::from_i64(0) {
                     x_a = &x_a ^ &sifr_generated_const_5f4d545f4d41545249585f41();
                 }
                 let new_word: SifrInt = &sifr_generated_state_word_at(
-                    &self.state_words_field,
+                    &self.state_words,
                     (&i + &sifr_generated_const_5f4d545f4d())
                         .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
                 ) ^ &x_a;
@@ -1416,11 +1413,10 @@ mod sifr_generated_project_nominals {
                         &new_word & &sifr_generated_const_5f4d545f574f52445f4d41534b();
                     {
                         let sifr_generated_index_raw = i.clone();
-                        let sifr_generated_index_normalized = sifr_generated_index_raw
-                            .normalize_index_or_len(self.state_words_field.len());
-                        if let Some(sifr_generated_elem) = self
-                            .state_words_field
-                            .get_mut(sifr_generated_index_normalized)
+                        let sifr_generated_index_normalized =
+                            sifr_generated_index_raw.normalize_index_or_len(self.state_words.len());
+                        if let Some(sifr_generated_elem) =
+                            self.state_words.get_mut(sifr_generated_index_normalized)
                         {
                             *sifr_generated_elem = sifr_generated_assign_value;
                         }
@@ -1428,18 +1424,18 @@ mod sifr_generated_project_nominals {
                 }
                 i = &i + &SifrInt::from_i64(1);
             }
-            self.index_field = SifrInt::from_i64(0);
+            self.index = SifrInt::from_i64(0);
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
         pub fn sifr_generated_next_u32(&mut self) -> SifrInt {
-            if &self.index_field.clone() >= &sifr_generated_const_5f4d545f4e() {
+            if &self.index.clone() >= &sifr_generated_const_5f4d545f4e() {
                 self.sifr_generated_twist();
             }
             let mut y: SifrInt =
-                sifr_generated_state_word_at(&self.state_words_field, self.index_field.clone());
-            self.index_field = &self.index_field.clone() + &SifrInt::from_i64(1);
+                sifr_generated_state_word_at(&self.state_words, self.index.clone());
+            self.index = &self.index.clone() + &SifrInt::from_i64(1);
             y = &y ^ &y.floor_div_known_nonzero(&SifrInt::from_i64(2048));
             y = &y ^ &(&(&y * &SifrInt::from_i64(128)) & &SifrInt::from_i64(2_636_928_640));
             y = &y ^ &(&(&y * &SifrInt::from_i64(32768)) & &SifrInt::from_i64(4_022_730_752));
@@ -1452,9 +1448,9 @@ mod sifr_generated_project_nominals {
         pub fn getstate(&self) -> SifrGeneratedStdlibSifrX2erandomX2eRandomState {
             SifrGeneratedStdlibSifrX2erandomX2eRandomState::new(
                 SifrInt::from_i64(3),
-                sifr_generated_clone_words(&self.state_words_field),
-                self.index_field.clone(),
-                self.gauss_next_field,
+                sifr_generated_clone_words(&self.state_words),
+                self.index.clone(),
+                self.gauss_next,
             )
         }
     }
@@ -1489,9 +1485,9 @@ mod sifr_generated_project_nominals {
                 }
                 normalized.push(&word & &sifr_generated_const_5f4d545f574f52445f4d41534b());
             }
-            self.state_words_field = normalized;
-            self.index_field = state.index.clone();
-            self.gauss_next_field = state.gauss_next;
+            self.state_words = normalized;
+            self.index = state.index.clone();
+            self.gauss_next = state.gauss_next;
             Ok(())
         }
     }

--- a/demos/iterators_and_randomness/emitted.rs
+++ b/demos/iterators_and_randomness/emitted.rs
@@ -1272,9 +1272,9 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub struct SifrGeneratedStdlibSifrX2erandomX2eRandom {
-        pub state_words_field: Vec<SifrInt>,
-        pub index_field: SifrInt,
-        pub gauss_next_field: Option<f64>,
+        pub state_words: Vec<SifrInt>,
+        pub index: SifrInt,
+        pub gauss_next: Option<f64>,
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
@@ -1287,32 +1287,29 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874: Option<f64> =
                 None;
             Self {
-                state_words_field:
-                    sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
-                index_field: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
-                gauss_next_field:
-                    sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
+                state_words: sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
+                index: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
+                gauss_next: sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
             }
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         pub fn sifr_generated_twist(&mut self) {
             let mut i: SifrInt = SifrInt::from_i64(0);
-            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words_field.len()) {
-                let y: SifrInt =
-                    &(&sifr_generated_state_word_at(&self.state_words_field, i.clone())
-                        & &sifr_generated_const_5f4d545f55505045525f4d41534b())
-                        + &(&sifr_generated_state_word_at(
-                            &self.state_words_field,
-                            (&i + &SifrInt::from_i64(1))
-                                .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
-                        ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
+            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words.len()) {
+                let y: SifrInt = &(&sifr_generated_state_word_at(&self.state_words, i.clone())
+                    & &sifr_generated_const_5f4d545f55505045525f4d41534b())
+                    + &(&sifr_generated_state_word_at(
+                        &self.state_words,
+                        (&i + &SifrInt::from_i64(1))
+                            .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
+                    ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
                 let mut x_a: SifrInt = y.floor_div_known_nonzero(&SifrInt::from_i64(2));
                 if &y.floor_mod_known_nonzero(&SifrInt::from_i64(2)) != &SifrInt::from_i64(0) {
                     x_a = &x_a ^ &sifr_generated_const_5f4d545f4d41545249585f41();
                 }
                 let new_word: SifrInt = &sifr_generated_state_word_at(
-                    &self.state_words_field,
+                    &self.state_words,
                     (&i + &sifr_generated_const_5f4d545f4d())
                         .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
                 ) ^ &x_a;
@@ -1321,11 +1318,10 @@ mod sifr_generated_project_nominals {
                         &new_word & &sifr_generated_const_5f4d545f574f52445f4d41534b();
                     {
                         let sifr_generated_index_raw = i.clone();
-                        let sifr_generated_index_normalized = sifr_generated_index_raw
-                            .normalize_index_or_len(self.state_words_field.len());
-                        if let Some(sifr_generated_elem) = self
-                            .state_words_field
-                            .get_mut(sifr_generated_index_normalized)
+                        let sifr_generated_index_normalized =
+                            sifr_generated_index_raw.normalize_index_or_len(self.state_words.len());
+                        if let Some(sifr_generated_elem) =
+                            self.state_words.get_mut(sifr_generated_index_normalized)
                         {
                             *sifr_generated_elem = sifr_generated_assign_value;
                         }
@@ -1333,18 +1329,18 @@ mod sifr_generated_project_nominals {
                 }
                 i = &i + &SifrInt::from_i64(1);
             }
-            self.index_field = SifrInt::from_i64(0);
+            self.index = SifrInt::from_i64(0);
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
         pub fn sifr_generated_next_u32(&mut self) -> SifrInt {
-            if &self.index_field.clone() >= &sifr_generated_const_5f4d545f4e() {
+            if &self.index.clone() >= &sifr_generated_const_5f4d545f4e() {
                 self.sifr_generated_twist();
             }
             let mut y: SifrInt =
-                sifr_generated_state_word_at(&self.state_words_field, self.index_field.clone());
-            self.index_field = &self.index_field.clone() + &SifrInt::from_i64(1);
+                sifr_generated_state_word_at(&self.state_words, self.index.clone());
+            self.index = &self.index.clone() + &SifrInt::from_i64(1);
             y = &y ^ &y.floor_div_known_nonzero(&SifrInt::from_i64(2048));
             y = &y ^ &(&(&y * &SifrInt::from_i64(128)) & &SifrInt::from_i64(2_636_928_640));
             y = &y ^ &(&(&y * &SifrInt::from_i64(32768)) & &SifrInt::from_i64(4_022_730_752));
@@ -1413,9 +1409,9 @@ mod sifr_generated_project_nominals {
         pub fn getstate(&self) -> SifrGeneratedStdlibSifrX2erandomX2eRandomState {
             SifrGeneratedStdlibSifrX2erandomX2eRandomState::new(
                 SifrInt::from_i64(3),
-                sifr_generated_clone_words(&self.state_words_field),
-                self.index_field.clone(),
-                self.gauss_next_field,
+                sifr_generated_clone_words(&self.state_words),
+                self.index.clone(),
+                self.gauss_next,
             )
         }
     }
@@ -1450,9 +1446,9 @@ mod sifr_generated_project_nominals {
                 }
                 normalized.push(&word & &sifr_generated_const_5f4d545f574f52445f4d41534b());
             }
-            self.state_words_field = normalized;
-            self.index_field = state.index.clone();
-            self.gauss_next_field = state.gauss_next;
+            self.state_words = normalized;
+            self.index = state.index.clone();
+            self.gauss_next = state.gauss_next;
             Ok(())
         }
     }

--- a/demos/logging/emitted.rs
+++ b/demos/logging/emitted.rs
@@ -874,7 +874,7 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct SifrGeneratedStdlibSifrX2eloggingX2eLogger {
-        pub name_field: String,
+        pub name: String,
         pub level: SifrInt,
         pub log_path: String,
         pub handler_kind: String,
@@ -898,7 +898,7 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_98e9bbb8fd5643d6_5f68616e646c65725f666d74: String =
                 "%(levelname)s:%(name)s:%(message)s".to_string();
             Self {
-                name_field: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
+                name: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
                 level: sifr_generated_field_value_70fb616fceb1e22c_5f6c6576656c,
                 log_path: sifr_generated_field_value_1fb1dcbc22de0cba_5f6c6f675f70617468,
                 handler_kind:
@@ -940,7 +940,7 @@ mod sifr_generated_project_nominals {
         pub fn sifr_generated_handler_line(&self, level: &str, msg: &str) -> String {
             let formatter: SifrGeneratedStdlibSifrX2eloggingX2eFormatter =
                 SifrGeneratedStdlibSifrX2eloggingX2eFormatter::new(self.handler_fmt.clone());
-            formatter.format(level, &self.name_field.clone(), msg)
+            formatter.format(level, &self.name.clone(), msg)
         }
     }
     impl SifrGeneratedStdlibSifrX2eloggingX2eLogger {
@@ -1000,7 +1000,7 @@ mod sifr_generated_project_nominals {
                 sifr_generated_concat.push('[');
                 sifr_generated_concat.push_str(level);
                 sifr_generated_concat.push_str("] ");
-                sifr_generated_concat.push_str(self.name_field.clone().as_str());
+                sifr_generated_concat.push_str(self.name.clone().as_str());
                 sifr_generated_concat.push_str(": ");
                 sifr_generated_concat.push_str(msg);
                 sifr_generated_concat
@@ -1075,7 +1075,7 @@ mod sifr_generated_project_nominals {
             write!(
                 f,
                 "Logger(_name={}, _level={}, _log_path={}, _handler_kind={}, _handler_path={}, _handler_level={}, _handler_fmt={})",
-                self.name_field,
+                self.name,
                 self.level,
                 self.log_path,
                 self.handler_kind,

--- a/demos/logging_and_timers/emitted.rs
+++ b/demos/logging_and_timers/emitted.rs
@@ -1207,7 +1207,7 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct SifrGeneratedStdlibSifrX2eloggingX2eLogger {
-        pub name_field: String,
+        pub name: String,
         pub level: SifrInt,
         pub log_path: String,
         pub handler_kind: String,
@@ -1231,7 +1231,7 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_98e9bbb8fd5643d6_5f68616e646c65725f666d74: String =
                 "%(levelname)s:%(name)s:%(message)s".to_string();
             Self {
-                name_field: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
+                name: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
                 level: sifr_generated_field_value_70fb616fceb1e22c_5f6c6576656c,
                 log_path: sifr_generated_field_value_1fb1dcbc22de0cba_5f6c6f675f70617468,
                 handler_kind:
@@ -1284,7 +1284,7 @@ mod sifr_generated_project_nominals {
         pub fn sifr_generated_handler_line(&self, level: &str, msg: &str) -> String {
             let formatter: SifrGeneratedStdlibSifrX2eloggingX2eFormatter =
                 SifrGeneratedStdlibSifrX2eloggingX2eFormatter::new(self.handler_fmt.clone());
-            formatter.format(level, &self.name_field.clone(), msg)
+            formatter.format(level, &self.name.clone(), msg)
         }
     }
     impl SifrGeneratedStdlibSifrX2eloggingX2eLogger {
@@ -1344,7 +1344,7 @@ mod sifr_generated_project_nominals {
                 sifr_generated_concat.push('[');
                 sifr_generated_concat.push_str(level);
                 sifr_generated_concat.push_str("] ");
-                sifr_generated_concat.push_str(self.name_field.clone().as_str());
+                sifr_generated_concat.push_str(self.name.clone().as_str());
                 sifr_generated_concat.push_str(": ");
                 sifr_generated_concat.push_str(msg);
                 sifr_generated_concat
@@ -1392,7 +1392,7 @@ mod sifr_generated_project_nominals {
             write!(
                 f,
                 "Logger(_name={}, _level={}, _log_path={}, _handler_kind={}, _handler_path={}, _handler_level={}, _handler_fmt={})",
-                self.name_field,
+                self.name,
                 self.level,
                 self.log_path,
                 self.handler_kind,

--- a/demos/no_runtime_panics/emitted.rs
+++ b/demos/no_runtime_panics/emitted.rs
@@ -1320,9 +1320,9 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub struct SifrGeneratedStdlibSifrX2erandomX2eRandom {
-        pub state_words_field: Vec<SifrInt>,
-        pub index_field: SifrInt,
-        pub gauss_next_field: Option<f64>,
+        pub state_words: Vec<SifrInt>,
+        pub index: SifrInt,
+        pub gauss_next: Option<f64>,
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
@@ -1335,32 +1335,29 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874: Option<f64> =
                 None;
             Self {
-                state_words_field:
-                    sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
-                index_field: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
-                gauss_next_field:
-                    sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
+                state_words: sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
+                index: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
+                gauss_next: sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
             }
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         pub fn sifr_generated_twist(&mut self) {
             let mut i: SifrInt = SifrInt::from_i64(0);
-            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words_field.len()) {
-                let y: SifrInt =
-                    &(&sifr_generated_state_word_at(&self.state_words_field, i.clone())
-                        & &sifr_generated_const_5f4d545f55505045525f4d41534b())
-                        + &(&sifr_generated_state_word_at(
-                            &self.state_words_field,
-                            (&i + &SifrInt::from_i64(1))
-                                .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
-                        ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
+            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words.len()) {
+                let y: SifrInt = &(&sifr_generated_state_word_at(&self.state_words, i.clone())
+                    & &sifr_generated_const_5f4d545f55505045525f4d41534b())
+                    + &(&sifr_generated_state_word_at(
+                        &self.state_words,
+                        (&i + &SifrInt::from_i64(1))
+                            .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
+                    ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
                 let mut x_a: SifrInt = y.floor_div_known_nonzero(&SifrInt::from_i64(2));
                 if &y.floor_mod_known_nonzero(&SifrInt::from_i64(2)) != &SifrInt::from_i64(0) {
                     x_a = &x_a ^ &sifr_generated_const_5f4d545f4d41545249585f41();
                 }
                 let new_word: SifrInt = &sifr_generated_state_word_at(
-                    &self.state_words_field,
+                    &self.state_words,
                     (&i + &sifr_generated_const_5f4d545f4d())
                         .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
                 ) ^ &x_a;
@@ -1369,11 +1366,10 @@ mod sifr_generated_project_nominals {
                         &new_word & &sifr_generated_const_5f4d545f574f52445f4d41534b();
                     {
                         let sifr_generated_index_raw = i.clone();
-                        let sifr_generated_index_normalized = sifr_generated_index_raw
-                            .normalize_index_or_len(self.state_words_field.len());
-                        if let Some(sifr_generated_elem) = self
-                            .state_words_field
-                            .get_mut(sifr_generated_index_normalized)
+                        let sifr_generated_index_normalized =
+                            sifr_generated_index_raw.normalize_index_or_len(self.state_words.len());
+                        if let Some(sifr_generated_elem) =
+                            self.state_words.get_mut(sifr_generated_index_normalized)
                         {
                             *sifr_generated_elem = sifr_generated_assign_value;
                         }
@@ -1381,18 +1377,18 @@ mod sifr_generated_project_nominals {
                 }
                 i = &i + &SifrInt::from_i64(1);
             }
-            self.index_field = SifrInt::from_i64(0);
+            self.index = SifrInt::from_i64(0);
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
         pub fn sifr_generated_next_u32(&mut self) -> SifrInt {
-            if &self.index_field.clone() >= &sifr_generated_const_5f4d545f4e() {
+            if &self.index.clone() >= &sifr_generated_const_5f4d545f4e() {
                 self.sifr_generated_twist();
             }
             let mut y: SifrInt =
-                sifr_generated_state_word_at(&self.state_words_field, self.index_field.clone());
-            self.index_field = &self.index_field.clone() + &SifrInt::from_i64(1);
+                sifr_generated_state_word_at(&self.state_words, self.index.clone());
+            self.index = &self.index.clone() + &SifrInt::from_i64(1);
             y = &y ^ &y.floor_div_known_nonzero(&SifrInt::from_i64(2048));
             y = &y ^ &(&(&y * &SifrInt::from_i64(128)) & &SifrInt::from_i64(2_636_928_640));
             y = &y ^ &(&(&y * &SifrInt::from_i64(32768)) & &SifrInt::from_i64(4_022_730_752));
@@ -1479,9 +1475,9 @@ mod sifr_generated_project_nominals {
         pub fn getstate(&self) -> SifrGeneratedStdlibSifrX2erandomX2eRandomState {
             SifrGeneratedStdlibSifrX2erandomX2eRandomState::new(
                 SifrInt::from_i64(3),
-                sifr_generated_clone_words(&self.state_words_field),
-                self.index_field.clone(),
-                self.gauss_next_field,
+                sifr_generated_clone_words(&self.state_words),
+                self.index.clone(),
+                self.gauss_next,
             )
         }
     }
@@ -1516,9 +1512,9 @@ mod sifr_generated_project_nominals {
                 }
                 normalized.push(&word & &sifr_generated_const_5f4d545f574f52445f4d41534b());
             }
-            self.state_words_field = normalized;
-            self.index_field = state.index.clone();
-            self.gauss_next_field = state.gauss_next;
+            self.state_words = normalized;
+            self.index = state.index.clone();
+            self.gauss_next = state.gauss_next;
             Ok(())
         }
     }

--- a/demos/pure_stdlib/emitted.rs
+++ b/demos/pure_stdlib/emitted.rs
@@ -1866,9 +1866,9 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub struct SifrGeneratedStdlibSifrX2erandomX2eRandom {
-        pub state_words_field: Vec<SifrInt>,
-        pub index_field: SifrInt,
-        pub gauss_next_field: Option<f64>,
+        pub state_words: Vec<SifrInt>,
+        pub index: SifrInt,
+        pub gauss_next: Option<f64>,
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
@@ -1881,32 +1881,29 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874: Option<f64> =
                 None;
             Self {
-                state_words_field:
-                    sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
-                index_field: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
-                gauss_next_field:
-                    sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
+                state_words: sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
+                index: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
+                gauss_next: sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
             }
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         pub fn sifr_generated_twist(&mut self) {
             let mut i: SifrInt = SifrInt::from_i64(0);
-            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words_field.len()) {
-                let y: SifrInt =
-                    &(&sifr_generated_state_word_at(&self.state_words_field, i.clone())
-                        & &sifr_generated_const_5f4d545f55505045525f4d41534b())
-                        + &(&sifr_generated_state_word_at(
-                            &self.state_words_field,
-                            (&i + &SifrInt::from_i64(1))
-                                .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
-                        ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
+            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words.len()) {
+                let y: SifrInt = &(&sifr_generated_state_word_at(&self.state_words, i.clone())
+                    & &sifr_generated_const_5f4d545f55505045525f4d41534b())
+                    + &(&sifr_generated_state_word_at(
+                        &self.state_words,
+                        (&i + &SifrInt::from_i64(1))
+                            .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
+                    ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
                 let mut x_a: SifrInt = y.floor_div_known_nonzero(&SifrInt::from_i64(2));
                 if &y.floor_mod_known_nonzero(&SifrInt::from_i64(2)) != &SifrInt::from_i64(0) {
                     x_a = &x_a ^ &sifr_generated_const_5f4d545f4d41545249585f41();
                 }
                 let new_word: SifrInt = &sifr_generated_state_word_at(
-                    &self.state_words_field,
+                    &self.state_words,
                     (&i + &sifr_generated_const_5f4d545f4d())
                         .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
                 ) ^ &x_a;
@@ -1915,11 +1912,10 @@ mod sifr_generated_project_nominals {
                         &new_word & &sifr_generated_const_5f4d545f574f52445f4d41534b();
                     {
                         let sifr_generated_index_raw = i.clone();
-                        let sifr_generated_index_normalized = sifr_generated_index_raw
-                            .normalize_index_or_len(self.state_words_field.len());
-                        if let Some(sifr_generated_elem) = self
-                            .state_words_field
-                            .get_mut(sifr_generated_index_normalized)
+                        let sifr_generated_index_normalized =
+                            sifr_generated_index_raw.normalize_index_or_len(self.state_words.len());
+                        if let Some(sifr_generated_elem) =
+                            self.state_words.get_mut(sifr_generated_index_normalized)
                         {
                             *sifr_generated_elem = sifr_generated_assign_value;
                         }
@@ -1927,18 +1923,18 @@ mod sifr_generated_project_nominals {
                 }
                 i = &i + &SifrInt::from_i64(1);
             }
-            self.index_field = SifrInt::from_i64(0);
+            self.index = SifrInt::from_i64(0);
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
         pub fn sifr_generated_next_u32(&mut self) -> SifrInt {
-            if &self.index_field.clone() >= &sifr_generated_const_5f4d545f4e() {
+            if &self.index.clone() >= &sifr_generated_const_5f4d545f4e() {
                 self.sifr_generated_twist();
             }
             let mut y: SifrInt =
-                sifr_generated_state_word_at(&self.state_words_field, self.index_field.clone());
-            self.index_field = &self.index_field.clone() + &SifrInt::from_i64(1);
+                sifr_generated_state_word_at(&self.state_words, self.index.clone());
+            self.index = &self.index.clone() + &SifrInt::from_i64(1);
             y = &y ^ &y.floor_div_known_nonzero(&SifrInt::from_i64(2048));
             y = &y ^ &(&(&y * &SifrInt::from_i64(128)) & &SifrInt::from_i64(2_636_928_640));
             y = &y ^ &(&(&y * &SifrInt::from_i64(32768)) & &SifrInt::from_i64(4_022_730_752));
@@ -2011,9 +2007,9 @@ mod sifr_generated_project_nominals {
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
         pub fn gauss(&mut self, mu: f64, sigma: f64) -> f64 {
-            let cached: Option<f64> = self.gauss_next_field;
+            let cached: Option<f64> = self.gauss_next;
             if let Some(cached) = cached {
-                self.gauss_next_field = None;
+                self.gauss_next = None;
                 return mu + sigma * cached;
             }
             let mut u1: f64 = self.random();
@@ -2026,7 +2022,7 @@ mod sifr_generated_project_nominals {
             let z0: f64 = radius * cos(theta);
             let z1: f64 = radius * sin(theta);
             let next_cached: Option<f64> = Some(z1);
-            self.gauss_next_field = next_cached;
+            self.gauss_next = next_cached;
             mu + sigma * z0
         }
     }
@@ -2035,9 +2031,9 @@ mod sifr_generated_project_nominals {
         pub fn getstate(&self) -> SifrGeneratedStdlibSifrX2erandomX2eRandomState {
             SifrGeneratedStdlibSifrX2erandomX2eRandomState::new(
                 SifrInt::from_i64(3),
-                sifr_generated_clone_words(&self.state_words_field),
-                self.index_field.clone(),
-                self.gauss_next_field,
+                sifr_generated_clone_words(&self.state_words),
+                self.index.clone(),
+                self.gauss_next,
             )
         }
     }
@@ -2072,9 +2068,9 @@ mod sifr_generated_project_nominals {
                 }
                 normalized.push(&word & &sifr_generated_const_5f4d545f574f52445f4d41534b());
             }
-            self.state_words_field = normalized;
-            self.index_field = state.index.clone();
-            self.gauss_next_field = state.gauss_next;
+            self.state_words = normalized;
+            self.index = state.index.clone();
+            self.gauss_next = state.gauss_next;
             Ok(())
         }
     }

--- a/demos/random_hashing/emitted.rs
+++ b/demos/random_hashing/emitted.rs
@@ -381,9 +381,9 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub struct SifrGeneratedStdlibSifrX2erandomX2eRandom {
-        pub state_words_field: Vec<SifrInt>,
-        pub index_field: SifrInt,
-        pub gauss_next_field: Option<f64>,
+        pub state_words: Vec<SifrInt>,
+        pub index: SifrInt,
+        pub gauss_next: Option<f64>,
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
@@ -396,32 +396,29 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874: Option<f64> =
                 None;
             Self {
-                state_words_field:
-                    sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
-                index_field: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
-                gauss_next_field:
-                    sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
+                state_words: sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
+                index: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
+                gauss_next: sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
             }
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         pub fn sifr_generated_twist(&mut self) {
             let mut i: SifrInt = SifrInt::from_i64(0);
-            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words_field.len()) {
-                let y: SifrInt =
-                    &(&sifr_generated_state_word_at(&self.state_words_field, i.clone())
-                        & &sifr_generated_const_5f4d545f55505045525f4d41534b())
-                        + &(&sifr_generated_state_word_at(
-                            &self.state_words_field,
-                            (&i + &SifrInt::from_i64(1))
-                                .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
-                        ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
+            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words.len()) {
+                let y: SifrInt = &(&sifr_generated_state_word_at(&self.state_words, i.clone())
+                    & &sifr_generated_const_5f4d545f55505045525f4d41534b())
+                    + &(&sifr_generated_state_word_at(
+                        &self.state_words,
+                        (&i + &SifrInt::from_i64(1))
+                            .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
+                    ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
                 let mut x_a: SifrInt = y.floor_div_known_nonzero(&SifrInt::from_i64(2));
                 if &y.floor_mod_known_nonzero(&SifrInt::from_i64(2)) != &SifrInt::from_i64(0) {
                     x_a = &x_a ^ &sifr_generated_const_5f4d545f4d41545249585f41();
                 }
                 let new_word: SifrInt = &sifr_generated_state_word_at(
-                    &self.state_words_field,
+                    &self.state_words,
                     (&i + &sifr_generated_const_5f4d545f4d())
                         .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
                 ) ^ &x_a;
@@ -430,11 +427,10 @@ mod sifr_generated_project_nominals {
                         &new_word & &sifr_generated_const_5f4d545f574f52445f4d41534b();
                     {
                         let sifr_generated_index_raw = i.clone();
-                        let sifr_generated_index_normalized = sifr_generated_index_raw
-                            .normalize_index_or_len(self.state_words_field.len());
-                        if let Some(sifr_generated_elem) = self
-                            .state_words_field
-                            .get_mut(sifr_generated_index_normalized)
+                        let sifr_generated_index_normalized =
+                            sifr_generated_index_raw.normalize_index_or_len(self.state_words.len());
+                        if let Some(sifr_generated_elem) =
+                            self.state_words.get_mut(sifr_generated_index_normalized)
                         {
                             *sifr_generated_elem = sifr_generated_assign_value;
                         }
@@ -442,18 +438,18 @@ mod sifr_generated_project_nominals {
                 }
                 i = &i + &SifrInt::from_i64(1);
             }
-            self.index_field = SifrInt::from_i64(0);
+            self.index = SifrInt::from_i64(0);
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
         pub fn sifr_generated_next_u32(&mut self) -> SifrInt {
-            if &self.index_field.clone() >= &sifr_generated_const_5f4d545f4e() {
+            if &self.index.clone() >= &sifr_generated_const_5f4d545f4e() {
                 self.sifr_generated_twist();
             }
             let mut y: SifrInt =
-                sifr_generated_state_word_at(&self.state_words_field, self.index_field.clone());
-            self.index_field = &self.index_field.clone() + &SifrInt::from_i64(1);
+                sifr_generated_state_word_at(&self.state_words, self.index.clone());
+            self.index = &self.index.clone() + &SifrInt::from_i64(1);
             y = &y ^ &y.floor_div_known_nonzero(&SifrInt::from_i64(2048));
             y = &y ^ &(&(&y * &SifrInt::from_i64(128)) & &SifrInt::from_i64(2_636_928_640));
             y = &y ^ &(&(&y * &SifrInt::from_i64(32768)) & &SifrInt::from_i64(4_022_730_752));
@@ -540,9 +536,9 @@ mod sifr_generated_project_nominals {
         pub fn getstate(&self) -> SifrGeneratedStdlibSifrX2erandomX2eRandomState {
             SifrGeneratedStdlibSifrX2erandomX2eRandomState::new(
                 SifrInt::from_i64(3),
-                sifr_generated_clone_words(&self.state_words_field),
-                self.index_field.clone(),
-                self.gauss_next_field,
+                sifr_generated_clone_words(&self.state_words),
+                self.index.clone(),
+                self.gauss_next,
             )
         }
     }
@@ -577,9 +573,9 @@ mod sifr_generated_project_nominals {
                 }
                 normalized.push(&word & &sifr_generated_const_5f4d545f574f52445f4d41534b());
             }
-            self.state_words_field = normalized;
-            self.index_field = state.index.clone();
-            self.gauss_next_field = state.gauss_next;
+            self.state_words = normalized;
+            self.index = state.index.clone();
+            self.gauss_next = state.gauss_next;
             Ok(())
         }
     }

--- a/demos/random_state/emitted.rs
+++ b/demos/random_state/emitted.rs
@@ -217,9 +217,9 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub struct SifrGeneratedStdlibSifrX2erandomX2eRandom {
-        pub state_words_field: Vec<SifrInt>,
-        pub index_field: SifrInt,
-        pub gauss_next_field: Option<f64>,
+        pub state_words: Vec<SifrInt>,
+        pub index: SifrInt,
+        pub gauss_next: Option<f64>,
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
@@ -232,32 +232,29 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874: Option<f64> =
                 None;
             Self {
-                state_words_field:
-                    sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
-                index_field: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
-                gauss_next_field:
-                    sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
+                state_words: sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
+                index: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
+                gauss_next: sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
             }
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         pub fn sifr_generated_twist(&mut self) {
             let mut i: SifrInt = SifrInt::from_i64(0);
-            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words_field.len()) {
-                let y: SifrInt =
-                    &(&sifr_generated_state_word_at(&self.state_words_field, i.clone())
-                        & &sifr_generated_const_5f4d545f55505045525f4d41534b())
-                        + &(&sifr_generated_state_word_at(
-                            &self.state_words_field,
-                            (&i + &SifrInt::from_i64(1))
-                                .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
-                        ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
+            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words.len()) {
+                let y: SifrInt = &(&sifr_generated_state_word_at(&self.state_words, i.clone())
+                    & &sifr_generated_const_5f4d545f55505045525f4d41534b())
+                    + &(&sifr_generated_state_word_at(
+                        &self.state_words,
+                        (&i + &SifrInt::from_i64(1))
+                            .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
+                    ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
                 let mut x_a: SifrInt = y.floor_div_known_nonzero(&SifrInt::from_i64(2));
                 if &y.floor_mod_known_nonzero(&SifrInt::from_i64(2)) != &SifrInt::from_i64(0) {
                     x_a = &x_a ^ &sifr_generated_const_5f4d545f4d41545249585f41();
                 }
                 let new_word: SifrInt = &sifr_generated_state_word_at(
-                    &self.state_words_field,
+                    &self.state_words,
                     (&i + &sifr_generated_const_5f4d545f4d())
                         .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
                 ) ^ &x_a;
@@ -266,11 +263,10 @@ mod sifr_generated_project_nominals {
                         &new_word & &sifr_generated_const_5f4d545f574f52445f4d41534b();
                     {
                         let sifr_generated_index_raw = i.clone();
-                        let sifr_generated_index_normalized = sifr_generated_index_raw
-                            .normalize_index_or_len(self.state_words_field.len());
-                        if let Some(sifr_generated_elem) = self
-                            .state_words_field
-                            .get_mut(sifr_generated_index_normalized)
+                        let sifr_generated_index_normalized =
+                            sifr_generated_index_raw.normalize_index_or_len(self.state_words.len());
+                        if let Some(sifr_generated_elem) =
+                            self.state_words.get_mut(sifr_generated_index_normalized)
                         {
                             *sifr_generated_elem = sifr_generated_assign_value;
                         }
@@ -278,18 +274,18 @@ mod sifr_generated_project_nominals {
                 }
                 i = &i + &SifrInt::from_i64(1);
             }
-            self.index_field = SifrInt::from_i64(0);
+            self.index = SifrInt::from_i64(0);
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
         pub fn sifr_generated_next_u32(&mut self) -> SifrInt {
-            if &self.index_field.clone() >= &sifr_generated_const_5f4d545f4e() {
+            if &self.index.clone() >= &sifr_generated_const_5f4d545f4e() {
                 self.sifr_generated_twist();
             }
             let mut y: SifrInt =
-                sifr_generated_state_word_at(&self.state_words_field, self.index_field.clone());
-            self.index_field = &self.index_field.clone() + &SifrInt::from_i64(1);
+                sifr_generated_state_word_at(&self.state_words, self.index.clone());
+            self.index = &self.index.clone() + &SifrInt::from_i64(1);
             y = &y ^ &y.floor_div_known_nonzero(&SifrInt::from_i64(2048));
             y = &y ^ &(&(&y * &SifrInt::from_i64(128)) & &SifrInt::from_i64(2_636_928_640));
             y = &y ^ &(&(&y * &SifrInt::from_i64(32768)) & &SifrInt::from_i64(4_022_730_752));
@@ -382,9 +378,9 @@ mod sifr_generated_project_nominals {
         pub fn getstate(&self) -> SifrGeneratedStdlibSifrX2erandomX2eRandomState {
             SifrGeneratedStdlibSifrX2erandomX2eRandomState::new(
                 SifrInt::from_i64(3),
-                sifr_generated_clone_words(&self.state_words_field),
-                self.index_field.clone(),
-                self.gauss_next_field,
+                sifr_generated_clone_words(&self.state_words),
+                self.index.clone(),
+                self.gauss_next,
             )
         }
     }
@@ -419,9 +415,9 @@ mod sifr_generated_project_nominals {
                 }
                 normalized.push(&word & &sifr_generated_const_5f4d545f574f52445f4d41534b());
             }
-            self.state_words_field = normalized;
-            self.index_field = state.index.clone();
-            self.gauss_next_field = state.gauss_next;
+            self.state_words = normalized;
+            self.index = state.index.clone();
+            self.gauss_next = state.gauss_next;
             Ok(())
         }
     }

--- a/demos/regex_and_filesystem/emitted.rs
+++ b/demos/regex_and_filesystem/emitted.rs
@@ -430,9 +430,7 @@ mod sifr_generated_generated_support {
             >| {
                 let mut i: SifrInt = SifrInt::from_i64(0);
                 while &i < &SifrInt::from(matches.len()) {
-                    let Some(
-                        sifr_generated_checked_value_0_user_736966725f67656e6572617465645f636865636b65645f76616c75655f30,
-                    ) = ({
+                    let Some(sifr_generated_checked_value_0) = ({
                         let sifr_generated_checked_read_collection = &matches;
                         let sifr_generated_checked_read_index = i.clone();
                         let sifr_generated_checked_read_normalized =
@@ -442,15 +440,11 @@ mod sifr_generated_generated_support {
                         sifr_generated_checked_read_collection
                             .get(sifr_generated_checked_read_normalized)
                             .cloned()
-                    })
-                    else {
+                    }) else {
                         break;
                     };
                     sifr_generated_yielder
-                        .suspend(
-                            sifr_generated_checked_value_0_user_736966725f67656e6572617465645f636865636b65645f76616c75655f30
-                                .clone(),
-                        )
+                        .suspend(sifr_generated_checked_value_0.clone())
                         .await;
                     i = &i + &SifrInt::from_i64(1);
                 }

--- a/demos/safe_edge_cases/emitted.rs
+++ b/demos/safe_edge_cases/emitted.rs
@@ -1961,9 +1961,9 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub struct SifrGeneratedStdlibSifrX2erandomX2eRandom {
-        pub state_words_field: Vec<SifrInt>,
-        pub index_field: SifrInt,
-        pub gauss_next_field: Option<f64>,
+        pub state_words: Vec<SifrInt>,
+        pub index: SifrInt,
+        pub gauss_next: Option<f64>,
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
@@ -1976,32 +1976,29 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874: Option<f64> =
                 None;
             Self {
-                state_words_field:
-                    sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
-                index_field: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
-                gauss_next_field:
-                    sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
+                state_words: sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
+                index: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
+                gauss_next: sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
             }
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         pub fn sifr_generated_twist(&mut self) {
             let mut i: SifrInt = SifrInt::from_i64(0);
-            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words_field.len()) {
-                let y: SifrInt =
-                    &(&sifr_generated_state_word_at(&self.state_words_field, i.clone())
-                        & &sifr_generated_const_5f4d545f55505045525f4d41534b())
-                        + &(&sifr_generated_state_word_at(
-                            &self.state_words_field,
-                            (&i + &SifrInt::from_i64(1))
-                                .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
-                        ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
+            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words.len()) {
+                let y: SifrInt = &(&sifr_generated_state_word_at(&self.state_words, i.clone())
+                    & &sifr_generated_const_5f4d545f55505045525f4d41534b())
+                    + &(&sifr_generated_state_word_at(
+                        &self.state_words,
+                        (&i + &SifrInt::from_i64(1))
+                            .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
+                    ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
                 let mut x_a: SifrInt = y.floor_div_known_nonzero(&SifrInt::from_i64(2));
                 if &y.floor_mod_known_nonzero(&SifrInt::from_i64(2)) != &SifrInt::from_i64(0) {
                     x_a = &x_a ^ &sifr_generated_const_5f4d545f4d41545249585f41();
                 }
                 let new_word: SifrInt = &sifr_generated_state_word_at(
-                    &self.state_words_field,
+                    &self.state_words,
                     (&i + &sifr_generated_const_5f4d545f4d())
                         .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
                 ) ^ &x_a;
@@ -2010,11 +2007,10 @@ mod sifr_generated_project_nominals {
                         &new_word & &sifr_generated_const_5f4d545f574f52445f4d41534b();
                     {
                         let sifr_generated_index_raw = i.clone();
-                        let sifr_generated_index_normalized = sifr_generated_index_raw
-                            .normalize_index_or_len(self.state_words_field.len());
-                        if let Some(sifr_generated_elem) = self
-                            .state_words_field
-                            .get_mut(sifr_generated_index_normalized)
+                        let sifr_generated_index_normalized =
+                            sifr_generated_index_raw.normalize_index_or_len(self.state_words.len());
+                        if let Some(sifr_generated_elem) =
+                            self.state_words.get_mut(sifr_generated_index_normalized)
                         {
                             *sifr_generated_elem = sifr_generated_assign_value;
                         }
@@ -2022,18 +2018,18 @@ mod sifr_generated_project_nominals {
                 }
                 i = &i + &SifrInt::from_i64(1);
             }
-            self.index_field = SifrInt::from_i64(0);
+            self.index = SifrInt::from_i64(0);
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
         pub fn sifr_generated_next_u32(&mut self) -> SifrInt {
-            if &self.index_field.clone() >= &sifr_generated_const_5f4d545f4e() {
+            if &self.index.clone() >= &sifr_generated_const_5f4d545f4e() {
                 self.sifr_generated_twist();
             }
             let mut y: SifrInt =
-                sifr_generated_state_word_at(&self.state_words_field, self.index_field.clone());
-            self.index_field = &self.index_field.clone() + &SifrInt::from_i64(1);
+                sifr_generated_state_word_at(&self.state_words, self.index.clone());
+            self.index = &self.index.clone() + &SifrInt::from_i64(1);
             y = &y ^ &y.floor_div_known_nonzero(&SifrInt::from_i64(2048));
             y = &y ^ &(&(&y * &SifrInt::from_i64(128)) & &SifrInt::from_i64(2_636_928_640));
             y = &y ^ &(&(&y * &SifrInt::from_i64(32768)) & &SifrInt::from_i64(4_022_730_752));
@@ -2120,9 +2116,9 @@ mod sifr_generated_project_nominals {
         pub fn getstate(&self) -> SifrGeneratedStdlibSifrX2erandomX2eRandomState {
             SifrGeneratedStdlibSifrX2erandomX2eRandomState::new(
                 SifrInt::from_i64(3),
-                sifr_generated_clone_words(&self.state_words_field),
-                self.index_field.clone(),
-                self.gauss_next_field,
+                sifr_generated_clone_words(&self.state_words),
+                self.index.clone(),
+                self.gauss_next,
             )
         }
     }
@@ -2157,9 +2153,9 @@ mod sifr_generated_project_nominals {
                 }
                 normalized.push(&word & &sifr_generated_const_5f4d545f574f52445f4d41534b());
             }
-            self.state_words_field = normalized;
-            self.index_field = state.index.clone();
-            self.gauss_next_field = state.gauss_next;
+            self.state_words = normalized;
+            self.index = state.index.clone();
+            self.gauss_next = state.gauss_next;
             Ok(())
         }
     }

--- a/demos/stdlib_expansion/emitted.rs
+++ b/demos/stdlib_expansion/emitted.rs
@@ -14,48 +14,32 @@ mod sifr_generated_generated_support {
         false
     }
     pub(crate) fn sifr_generated_split_inline_option(token: &str) -> (bool, String, String) {
-        let sifr_generated_chars_token_user_736966725f67656e6572617465645f63686172735f746f6b656e: Vec<
-            char,
-        > = token.chars().collect::<Vec<char>>();
+        let sifr_generated_chars_token: Vec<char> = token.chars().collect::<Vec<char>>();
         let mut key: String = String::new();
         let mut i: SifrInt = SifrInt::from_i64(0);
-        while &i < &SifrInt::from(
-            sifr_generated_chars_token_user_736966725f67656e6572617465645f63686172735f746f6b656e
-                .len(),
-        ) {
+        while &i < &SifrInt::from(sifr_generated_chars_token.len()) {
             let ch: Option<String> = {
                 let sifr_generated_string_index = i.clone();
                 let sifr_generated_string_index_normalized = sifr_generated_string_index
-                    .normalize_index_or_len(
-                        sifr_generated_chars_token_user_736966725f67656e6572617465645f63686172735f746f6b656e
-                            .len(),
-                    );
-                sifr_generated_chars_token_user_736966725f67656e6572617465645f63686172735f746f6b656e
+                    .normalize_index_or_len(sifr_generated_chars_token.len());
+                sifr_generated_chars_token
                     .get(sifr_generated_string_index_normalized)
                     .copied()
             }
-                .map(|character| character.to_string());
+            .map(|character| character.to_string());
             if ch.is_some() && ch == Some("=".to_string()) {
                 let mut value: String = String::new();
                 let mut j: SifrInt = &i + &SifrInt::from_i64(1);
-                while &j
-                    < &SifrInt::from(
-                        sifr_generated_chars_token_user_736966725f67656e6572617465645f63686172735f746f6b656e
-                            .len(),
-                    )
-                {
+                while &j < &SifrInt::from(sifr_generated_chars_token.len()) {
                     let part: Option<String> = {
                         let sifr_generated_string_index = j.clone();
                         let sifr_generated_string_index_normalized = sifr_generated_string_index
-                            .normalize_index_or_len(
-                                sifr_generated_chars_token_user_736966725f67656e6572617465645f63686172735f746f6b656e
-                                    .len(),
-                            );
-                        sifr_generated_chars_token_user_736966725f67656e6572617465645f63686172735f746f6b656e
+                            .normalize_index_or_len(sifr_generated_chars_token.len());
+                        sifr_generated_chars_token
                             .get(sifr_generated_string_index_normalized)
                             .copied()
                     }
-                        .map(|character| character.to_string());
+                    .map(|character| character.to_string());
                     if let Some(part) = part {
                         value.push_str(part.as_str());
                     }
@@ -265,26 +249,17 @@ mod sifr_generated_generated_support {
         rows.push(row);
     }
     pub(crate) fn sifr_generated_char_at(text: &str, index: SifrInt) -> String {
-        let sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874: Vec<
-            char,
-        > = text.chars().collect::<Vec<char>>();
+        let sifr_generated_chars_text: Vec<char> = text.chars().collect::<Vec<char>>();
         if &index < &SifrInt::from_i64(0)
-            || &index
-                >= &SifrInt::from(
-                    sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                        .len(),
-                )
+            || &index >= &SifrInt::from(sifr_generated_chars_text.len())
         {
             return String::new();
         }
         let ch: Option<String> = {
             let sifr_generated_string_index = index.clone();
-            let sifr_generated_string_index_normalized = sifr_generated_string_index
-                .normalize_index_or_len(
-                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                    .len(),
-            );
-            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
+            let sifr_generated_string_index_normalized =
+                sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_text.len());
+            sifr_generated_chars_text
                 .get(sifr_generated_string_index_normalized)
                 .copied()
         }
@@ -366,9 +341,7 @@ mod sifr_generated_generated_support {
         quoting: SifrInt,
     ) -> Vec<Vec<String>> {
         let quotechar = quotechar.to_owned();
-        let sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874: Vec<
-            char,
-        > = text.chars().collect::<Vec<char>>();
+        let sifr_generated_chars_text: Vec<char> = text.chars().collect::<Vec<char>>();
         let resolved: SifrGeneratedStdlibSifrX2ecsvX2eDialect = sifr_generated_resolve_dialect(
             dialect,
             delimiter,
@@ -385,27 +358,17 @@ mod sifr_generated_generated_support {
         let mut in_quotes: bool = false;
         let mut field_started: bool = false;
         let mut i: SifrInt = SifrInt::from_i64(0);
-        while &i
-            < &SifrInt::from(
-                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                    .len(),
-            )
-        {
+        while &i < &SifrInt::from(sifr_generated_chars_text.len()) {
             let ch_value: String = sifr_generated_char_at(text, i.clone());
             if in_quotes {
                 if !resolved.escapechar.clone().is_empty()
                     && ch_value == resolved.escapechar.clone()
                 {
                     if &(&i + &SifrInt::from_i64(1))
-                        < &SifrInt::from(
-                            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                .len(),
-                        )
+                        < &SifrInt::from(sifr_generated_chars_text.len())
                     {
-                        let escaped_value: String = sifr_generated_char_at(
-                            text,
-                            &i + &SifrInt::from_i64(1),
-                        );
+                        let escaped_value: String =
+                            sifr_generated_char_at(text, &i + &SifrInt::from_i64(1));
                         field.push_str(escaped_value.as_str());
                         i = &i + &SifrInt::from_i64(2);
                         continue;
@@ -419,12 +382,8 @@ mod sifr_generated_generated_support {
                     let quotechar: String = sifr_generated_quotechar_value(&resolved);
                     if resolved.doublequote
                         && &(&i + &SifrInt::from_i64(1))
-                            < &SifrInt::from(
-                                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                    .len(),
-                            )
-                        && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1))
-                            == quotechar
+                            < &SifrInt::from(sifr_generated_chars_text.len())
+                        && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1)) == quotechar
                     {
                         field.push_str(quotechar.as_str());
                         i = &i + &SifrInt::from_i64(2);
@@ -443,16 +402,9 @@ mod sifr_generated_generated_support {
                 continue;
             }
             if !resolved.escapechar.clone().is_empty() && ch_value == resolved.escapechar.clone() {
-                if &(&i + &SifrInt::from_i64(1))
-                    < &SifrInt::from(
-                        sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                            .len(),
-                    )
-                {
-                    let escaped_plain_value: String = sifr_generated_char_at(
-                        text,
-                        &i + &SifrInt::from_i64(1),
-                    );
+                if &(&i + &SifrInt::from_i64(1)) < &SifrInt::from(sifr_generated_chars_text.len()) {
+                    let escaped_plain_value: String =
+                        sifr_generated_char_at(text, &i + &SifrInt::from_i64(1));
                     field.push_str(escaped_plain_value.as_str());
                     field_started = true;
                     i = &i + &SifrInt::from_i64(2);
@@ -485,10 +437,7 @@ mod sifr_generated_generated_support {
             if ch_value == "\n" || ch_value == "\r" {
                 if ch_value == "\r"
                     && &(&i + &SifrInt::from_i64(1))
-                        < &SifrInt::from(
-                            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                .len(),
-                        )
+                        < &SifrInt::from(sifr_generated_chars_text.len())
                     && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1)) == "\n"
                 {
                     i = &i + &SifrInt::from_i64(1);
@@ -1331,9 +1280,7 @@ mod sifr_generated_generated_support {
         normalized
     }
     pub(crate) fn sifr_generated_expand_tabs_impl(text: &str, tabsize: SifrInt) -> String {
-        let sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874: Vec<
-            char,
-        > = text.chars().collect::<Vec<char>>();
+        let sifr_generated_chars_text: Vec<char> = text.chars().collect::<Vec<char>>();
         let mut effective_tabsize: SifrInt = tabsize.clone();
         if &effective_tabsize <= &SifrInt::from_i64(0) {
             effective_tabsize = SifrInt::from_i64(1);
@@ -1344,24 +1291,16 @@ mod sifr_generated_generated_support {
         let mut result: String = String::new();
         let mut column: SifrInt = SifrInt::from_i64(0);
         let mut i: SifrInt = SifrInt::from_i64(0);
-        while &i
-            < &SifrInt::from(
-                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                    .len(),
-            )
-        {
+        while &i < &SifrInt::from(sifr_generated_chars_text.len()) {
             let ch_opt: Option<String> = {
                 let sifr_generated_string_index = i.clone();
                 let sifr_generated_string_index_normalized = sifr_generated_string_index
-                    .normalize_index_or_len(
-                        sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                            .len(),
-                    );
-                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
+                    .normalize_index_or_len(sifr_generated_chars_text.len());
+                sifr_generated_chars_text
                     .get(sifr_generated_string_index_normalized)
                     .copied()
             }
-                .map(|character| character.to_string());
+            .map(|character| character.to_string());
             if let Some(ch_opt) = ch_opt {
                 let ch: String = ch_opt;
                 if ch == "\t" {

--- a/demos/stdlib_fixes/emitted.rs
+++ b/demos/stdlib_fixes/emitted.rs
@@ -2954,7 +2954,7 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct SifrGeneratedStdlibSifrX2eloggingX2eLogger {
-        pub name_field: String,
+        pub name: String,
         pub level: SifrInt,
         pub log_path: String,
         pub handler_kind: String,
@@ -2978,7 +2978,7 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_98e9bbb8fd5643d6_5f68616e646c65725f666d74: String =
                 "%(levelname)s:%(name)s:%(message)s".to_string();
             Self {
-                name_field: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
+                name: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
                 level: sifr_generated_field_value_70fb616fceb1e22c_5f6c6576656c,
                 log_path: sifr_generated_field_value_1fb1dcbc22de0cba_5f6c6f675f70617468,
                 handler_kind:
@@ -3005,7 +3005,7 @@ mod sifr_generated_project_nominals {
         pub fn sifr_generated_handler_line(&self, level: &str, msg: &str) -> String {
             let formatter: SifrGeneratedStdlibSifrX2eloggingX2eFormatter =
                 SifrGeneratedStdlibSifrX2eloggingX2eFormatter::new(self.handler_fmt.clone());
-            formatter.format(level, &self.name_field.clone(), msg)
+            formatter.format(level, &self.name.clone(), msg)
         }
     }
     impl SifrGeneratedStdlibSifrX2eloggingX2eLogger {
@@ -3065,7 +3065,7 @@ mod sifr_generated_project_nominals {
                 sifr_generated_concat.push('[');
                 sifr_generated_concat.push_str(level);
                 sifr_generated_concat.push_str("] ");
-                sifr_generated_concat.push_str(self.name_field.clone().as_str());
+                sifr_generated_concat.push_str(self.name.clone().as_str());
                 sifr_generated_concat.push_str(": ");
                 sifr_generated_concat.push_str(msg);
                 sifr_generated_concat
@@ -3122,7 +3122,7 @@ mod sifr_generated_project_nominals {
             write!(
                 f,
                 "Logger(_name={}, _level={}, _log_path={}, _handler_kind={}, _handler_path={}, _handler_level={}, _handler_fmt={})",
-                self.name_field,
+                self.name,
                 self.level,
                 self.log_path,
                 self.handler_kind,
@@ -3189,9 +3189,9 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub struct SifrGeneratedStdlibSifrX2erandomX2eRandom {
-        pub state_words_field: Vec<SifrInt>,
-        pub index_field: SifrInt,
-        pub gauss_next_field: Option<f64>,
+        pub state_words: Vec<SifrInt>,
+        pub index: SifrInt,
+        pub gauss_next: Option<f64>,
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
@@ -3204,32 +3204,29 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874: Option<f64> =
                 None;
             Self {
-                state_words_field:
-                    sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
-                index_field: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
-                gauss_next_field:
-                    sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
+                state_words: sifr_generated_field_value_7e372b502c45daad_5f73746174655f776f726473,
+                index: sifr_generated_field_value_497043933c8a2d12_5f696e646578,
+                gauss_next: sifr_generated_field_value_88c1b3a412b57c41_5f67617573735f6e657874,
             }
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         pub fn sifr_generated_twist(&mut self) {
             let mut i: SifrInt = SifrInt::from_i64(0);
-            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words_field.len()) {
-                let y: SifrInt =
-                    &(&sifr_generated_state_word_at(&self.state_words_field, i.clone())
-                        & &sifr_generated_const_5f4d545f55505045525f4d41534b())
-                        + &(&sifr_generated_state_word_at(
-                            &self.state_words_field,
-                            (&i + &SifrInt::from_i64(1))
-                                .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
-                        ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
+            while &SifrInt::from_i64(0) <= &i && &i < &SifrInt::from(self.state_words.len()) {
+                let y: SifrInt = &(&sifr_generated_state_word_at(&self.state_words, i.clone())
+                    & &sifr_generated_const_5f4d545f55505045525f4d41534b())
+                    + &(&sifr_generated_state_word_at(
+                        &self.state_words,
+                        (&i + &SifrInt::from_i64(1))
+                            .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
+                    ) & &sifr_generated_const_5f4d545f4c4f5745525f4d41534b());
                 let mut x_a: SifrInt = y.floor_div_known_nonzero(&SifrInt::from_i64(2));
                 if &y.floor_mod_known_nonzero(&SifrInt::from_i64(2)) != &SifrInt::from_i64(0) {
                     x_a = &x_a ^ &sifr_generated_const_5f4d545f4d41545249585f41();
                 }
                 let new_word: SifrInt = &sifr_generated_state_word_at(
-                    &self.state_words_field,
+                    &self.state_words,
                     (&i + &sifr_generated_const_5f4d545f4d())
                         .floor_mod_known_nonzero(&sifr_generated_const_5f4d545f4e()),
                 ) ^ &x_a;
@@ -3238,11 +3235,10 @@ mod sifr_generated_project_nominals {
                         &new_word & &sifr_generated_const_5f4d545f574f52445f4d41534b();
                     {
                         let sifr_generated_index_raw = i.clone();
-                        let sifr_generated_index_normalized = sifr_generated_index_raw
-                            .normalize_index_or_len(self.state_words_field.len());
-                        if let Some(sifr_generated_elem) = self
-                            .state_words_field
-                            .get_mut(sifr_generated_index_normalized)
+                        let sifr_generated_index_normalized =
+                            sifr_generated_index_raw.normalize_index_or_len(self.state_words.len());
+                        if let Some(sifr_generated_elem) =
+                            self.state_words.get_mut(sifr_generated_index_normalized)
                         {
                             *sifr_generated_elem = sifr_generated_assign_value;
                         }
@@ -3250,18 +3246,18 @@ mod sifr_generated_project_nominals {
                 }
                 i = &i + &SifrInt::from_i64(1);
             }
-            self.index_field = SifrInt::from_i64(0);
+            self.index = SifrInt::from_i64(0);
         }
     }
     impl SifrGeneratedStdlibSifrX2erandomX2eRandom {
         #[must_use]
         pub fn sifr_generated_next_u32(&mut self) -> SifrInt {
-            if &self.index_field.clone() >= &sifr_generated_const_5f4d545f4e() {
+            if &self.index.clone() >= &sifr_generated_const_5f4d545f4e() {
                 self.sifr_generated_twist();
             }
             let mut y: SifrInt =
-                sifr_generated_state_word_at(&self.state_words_field, self.index_field.clone());
-            self.index_field = &self.index_field.clone() + &SifrInt::from_i64(1);
+                sifr_generated_state_word_at(&self.state_words, self.index.clone());
+            self.index = &self.index.clone() + &SifrInt::from_i64(1);
             y = &y ^ &y.floor_div_known_nonzero(&SifrInt::from_i64(2048));
             y = &y ^ &(&(&y * &SifrInt::from_i64(128)) & &SifrInt::from_i64(2_636_928_640));
             y = &y ^ &(&(&y * &SifrInt::from_i64(32768)) & &SifrInt::from_i64(4_022_730_752));
@@ -3274,9 +3270,9 @@ mod sifr_generated_project_nominals {
         pub fn getstate(&self) -> SifrGeneratedStdlibSifrX2erandomX2eRandomState {
             SifrGeneratedStdlibSifrX2erandomX2eRandomState::new(
                 SifrInt::from_i64(3),
-                sifr_generated_clone_words(&self.state_words_field),
-                self.index_field.clone(),
-                self.gauss_next_field,
+                sifr_generated_clone_words(&self.state_words),
+                self.index.clone(),
+                self.gauss_next,
             )
         }
     }
@@ -3311,9 +3307,9 @@ mod sifr_generated_project_nominals {
                 }
                 normalized.push(&word & &sifr_generated_const_5f4d545f574f52445f4d41534b());
             }
-            self.state_words_field = normalized;
-            self.index_field = state.index.clone();
-            self.gauss_next_field = state.gauss_next;
+            self.state_words = normalized;
+            self.index = state.index.clone();
+            self.gauss_next = state.gauss_next;
             Ok(())
         }
     }

--- a/demos/structured_parsing_serialization/emitted.rs
+++ b/demos/structured_parsing_serialization/emitted.rs
@@ -159,26 +159,17 @@ mod sifr_generated_generated_support {
         Ok((key, stripped_value))
     }
     pub(crate) fn sifr_generated_char_at(text: &str, index: SifrInt) -> String {
-        let sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874: Vec<
-            char,
-        > = text.chars().collect::<Vec<char>>();
+        let sifr_generated_chars_text: Vec<char> = text.chars().collect::<Vec<char>>();
         if &index < &SifrInt::from_i64(0)
-            || &index
-                >= &SifrInt::from(
-                    sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                        .len(),
-                )
+            || &index >= &SifrInt::from(sifr_generated_chars_text.len())
         {
             return String::new();
         }
         let ch: Option<String> = {
             let sifr_generated_string_index = index.clone();
-            let sifr_generated_string_index_normalized = sifr_generated_string_index
-                .normalize_index_or_len(
-                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                    .len(),
-            );
-            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
+            let sifr_generated_string_index_normalized =
+                sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_text.len());
+            sifr_generated_chars_text
                 .get(sifr_generated_string_index_normalized)
                 .copied()
         }
@@ -414,9 +405,7 @@ mod sifr_generated_generated_support {
         quoting: SifrInt,
     ) -> Vec<Vec<String>> {
         let quotechar = quotechar.to_owned();
-        let sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874: Vec<
-            char,
-        > = text.chars().collect::<Vec<char>>();
+        let sifr_generated_chars_text: Vec<char> = text.chars().collect::<Vec<char>>();
         let resolved: SifrGeneratedStdlibSifrX2ecsvX2eDialect = sifr_generated_resolve_dialect(
             dialect,
             delimiter,
@@ -433,27 +422,17 @@ mod sifr_generated_generated_support {
         let mut in_quotes: bool = false;
         let mut field_started: bool = false;
         let mut i: SifrInt = SifrInt::from_i64(0);
-        while &i
-            < &SifrInt::from(
-                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                    .len(),
-            )
-        {
+        while &i < &SifrInt::from(sifr_generated_chars_text.len()) {
             let ch_value: String = sifr_generated_char_at(text, i.clone());
             if in_quotes {
                 if !resolved.escapechar.clone().is_empty()
                     && ch_value == resolved.escapechar.clone()
                 {
                     if &(&i + &SifrInt::from_i64(1))
-                        < &SifrInt::from(
-                            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                .len(),
-                        )
+                        < &SifrInt::from(sifr_generated_chars_text.len())
                     {
-                        let escaped_value: String = sifr_generated_char_at(
-                            text,
-                            &i + &SifrInt::from_i64(1),
-                        );
+                        let escaped_value: String =
+                            sifr_generated_char_at(text, &i + &SifrInt::from_i64(1));
                         field.push_str(escaped_value.as_str());
                         i = &i + &SifrInt::from_i64(2);
                         continue;
@@ -467,12 +446,8 @@ mod sifr_generated_generated_support {
                     let quotechar: String = sifr_generated_quotechar_value(&resolved);
                     if resolved.doublequote
                         && &(&i + &SifrInt::from_i64(1))
-                            < &SifrInt::from(
-                                sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                    .len(),
-                            )
-                        && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1))
-                            == quotechar
+                            < &SifrInt::from(sifr_generated_chars_text.len())
+                        && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1)) == quotechar
                     {
                         field.push_str(quotechar.as_str());
                         i = &i + &SifrInt::from_i64(2);
@@ -491,16 +466,9 @@ mod sifr_generated_generated_support {
                 continue;
             }
             if !resolved.escapechar.clone().is_empty() && ch_value == resolved.escapechar.clone() {
-                if &(&i + &SifrInt::from_i64(1))
-                    < &SifrInt::from(
-                        sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                            .len(),
-                    )
-                {
-                    let escaped_plain_value: String = sifr_generated_char_at(
-                        text,
-                        &i + &SifrInt::from_i64(1),
-                    );
+                if &(&i + &SifrInt::from_i64(1)) < &SifrInt::from(sifr_generated_chars_text.len()) {
+                    let escaped_plain_value: String =
+                        sifr_generated_char_at(text, &i + &SifrInt::from_i64(1));
                     field.push_str(escaped_plain_value.as_str());
                     field_started = true;
                     i = &i + &SifrInt::from_i64(2);
@@ -533,10 +501,7 @@ mod sifr_generated_generated_support {
             if ch_value == "\n" || ch_value == "\r" {
                 if ch_value == "\r"
                     && &(&i + &SifrInt::from_i64(1))
-                        < &SifrInt::from(
-                            sifr_generated_chars_text_user_736966725f67656e6572617465645f63686172735f74657874
-                                .len(),
-                        )
+                        < &SifrInt::from(sifr_generated_chars_text.len())
                     && sifr_generated_char_at(text, &i + &SifrInt::from_i64(1)) == "\n"
                 {
                     i = &i + &SifrInt::from_i64(1);

--- a/demos/structured_parsing_serialization/emitted.rs
+++ b/demos/structured_parsing_serialization/emitted.rs
@@ -2366,7 +2366,7 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct SifrGeneratedStdlibSifrX2ecsvX2eDictReader {
-        pub fieldnames_field: Vec<String>,
+        pub fieldnames: Vec<String>,
         pub rows: Vec<Vec<String>>,
         pub pos: SifrInt,
         pub restkey: String,
@@ -2462,8 +2462,7 @@ mod sifr_generated_project_nominals {
                 restkey: sifr_generated_field_value_d10323292550fbae_726573746b6579,
                 restval: sifr_generated_field_value_e9b6e328a309fdee_7265737476616c,
                 pos: sifr_generated_field_value_e04b9443eebba9b4_5f706f73,
-                fieldnames_field:
-                    sifr_generated_field_value_efdb691f099ff036_5f6669656c646e616d6573,
+                fieldnames: sifr_generated_field_value_efdb691f099ff036_5f6669656c646e616d6573,
                 rows: sifr_generated_field_value_d742ae5cfb4259e3_5f726f7773,
             }
         }
@@ -2477,7 +2476,7 @@ mod sifr_generated_project_nominals {
                     continue;
                 }
                 result.push(sifr_generated_dict_reader_row(
-                    &self.fieldnames_field,
+                    &self.fieldnames,
                     &row,
                     &self.restkey,
                     &self.restval,

--- a/demos/system_tools/emitted.rs
+++ b/demos/system_tools/emitted.rs
@@ -762,7 +762,7 @@ mod sifr_generated_project_nominals {
     }
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct SifrGeneratedStdlibSifrX2eloggingX2eLogger {
-        pub name_field: String,
+        pub name: String,
         pub level: SifrInt,
         pub log_path: String,
         pub handler_kind: String,
@@ -786,7 +786,7 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_98e9bbb8fd5643d6_5f68616e646c65725f666d74: String =
                 "%(levelname)s:%(name)s:%(message)s".to_string();
             Self {
-                name_field: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
+                name: sifr_generated_field_value_2570757371473f6d_5f6e616d65,
                 level: sifr_generated_field_value_70fb616fceb1e22c_5f6c6576656c,
                 log_path: sifr_generated_field_value_1fb1dcbc22de0cba_5f6c6f675f70617468,
                 handler_kind:
@@ -818,7 +818,7 @@ mod sifr_generated_project_nominals {
         pub fn sifr_generated_handler_line(&self, level: &str, msg: &str) -> String {
             let formatter: SifrGeneratedStdlibSifrX2eloggingX2eFormatter =
                 SifrGeneratedStdlibSifrX2eloggingX2eFormatter::new(self.handler_fmt.clone());
-            formatter.format(level, &self.name_field.clone(), msg)
+            formatter.format(level, &self.name.clone(), msg)
         }
     }
     impl SifrGeneratedStdlibSifrX2eloggingX2eLogger {
@@ -878,7 +878,7 @@ mod sifr_generated_project_nominals {
                 sifr_generated_concat.push('[');
                 sifr_generated_concat.push_str(level);
                 sifr_generated_concat.push_str("] ");
-                sifr_generated_concat.push_str(self.name_field.clone().as_str());
+                sifr_generated_concat.push_str(self.name.clone().as_str());
                 sifr_generated_concat.push_str(": ");
                 sifr_generated_concat.push_str(msg);
                 sifr_generated_concat
@@ -926,7 +926,7 @@ mod sifr_generated_project_nominals {
             write!(
                 f,
                 "Logger(_name={}, _level={}, _log_path={}, _handler_kind={}, _handler_path={}, _handler_level={}, _handler_fmt={})",
-                self.name_field,
+                self.name,
                 self.level,
                 self.log_path,
                 self.handler_kind,

--- a/demos/zipfile_io/emitted.rs
+++ b/demos/zipfile_io/emitted.rs
@@ -147,8 +147,8 @@ mod sifr_generated_project_nominals {
     use ::sifr_runtime::SifrInt;
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct SifrGeneratedStdlibSifrX2etempfileX2eNamedTemporaryFile {
-        pub path_field: String,
-        pub mode_field: String,
+        pub path: String,
+        pub mode: String,
         pub delete: bool,
         pub closed: bool,
         pub cleaned: bool,
@@ -177,8 +177,8 @@ mod sifr_generated_project_nominals {
             let sifr_generated_field_value_8bc7f577e5ffacda_5f636c6f736564: bool = false;
             let sifr_generated_field_value_12032f9cf5c44b7a_5f636c65616e6564: bool = false;
             Self {
-                path_field: sifr_generated_field_value_0e74a76ec4f48c05_5f70617468,
-                mode_field: sifr_generated_field_value_e0efc38c5ec2afd5_5f6d6f6465,
+                path: sifr_generated_field_value_0e74a76ec4f48c05_5f70617468,
+                mode: sifr_generated_field_value_e0efc38c5ec2afd5_5f6d6f6465,
                 delete: sifr_generated_field_value_516ea6609f22db39_5f64656c657465,
                 closed: sifr_generated_field_value_8bc7f577e5ffacda_5f636c6f736564,
                 cleaned: sifr_generated_field_value_12032f9cf5c44b7a_5f636c65616e6564,
@@ -190,7 +190,7 @@ mod sifr_generated_project_nominals {
         pub fn name(&self) -> String {
             {
                 let mut sifr_generated_concat: String = String::new();
-                sifr_generated_concat.push_str(self.path_field.clone().as_str());
+                sifr_generated_concat.push_str(self.path.clone().as_str());
                 sifr_generated_concat.push_str("");
                 sifr_generated_concat
             }
@@ -203,9 +203,9 @@ mod sifr_generated_project_nominals {
             if self.cleaned {
                 return Ok(());
             }
-            if exists(&self.path_field) {
+            if exists(&self.path) {
                 let sifr_generated_try_res: Result<(), IOError> = (|| {
-                    remove_file(&self.path_field)?;
+                    remove_file(&self.path)?;
                     Ok(())
                 })();
                 if let Err(sifr_generated_try_err) = sifr_generated_try_res {
@@ -241,7 +241,7 @@ mod sifr_generated_project_nominals {
             write!(
                 f,
                 "NamedTemporaryFile(_path={}, _mode={}, _delete={}, _closed={}, _cleaned={})",
-                self.path_field, self.mode_field, self.delete, self.closed, self.cleaned
+                self.path, self.mode, self.delete, self.closed, self.cleaned
             )
         }
     }

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -403,8 +403,11 @@ Generated Rust field cleanup runs before identifier and layout cleanup. One
 registry resolves module-qualified nominal declarations, imports and re-exports,
 and typed field receivers across the complete generated project. Field spelling
 and collisions belong to that nominal owner; shorthand pattern/value bindings
-retain their separate local identities. Binary and test-project materialization
-use the same registry. External fields are not renamed, and an unresolved
+retain their separate local identities. Binary bridge sources are generated and
+registered alongside main and support modules before this pass; their finalized
+sources also participate in the artifact cache identity. Binary and test-project
+materialization use the same registry and do not repeat field canonicalization
+while formatting individual files. External fields are not renamed, and an unresolved
 generated-field receiver is a code-generation diagnostic.
 
 The production Sifr formatter is Ruff-backed and in-process. `.sifr` source

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -399,6 +399,14 @@ New crates added as compiler and runtime needs grow:
 
 ## Formatter Architecture
 
+Generated Rust field cleanup runs before identifier and layout cleanup. One
+registry resolves module-qualified nominal declarations, imports and re-exports,
+and typed field receivers across the complete generated project. Field spelling
+and collisions belong to that nominal owner; shorthand pattern/value bindings
+retain their separate local identities. Binary and test-project materialization
+use the same registry. External fields are not renamed, and an unresolved
+generated-field receiver is a code-generation diagnostic.
+
 The production Sifr formatter is Ruff-backed and in-process. `.sifr` source
 flows through `sifr_syntax` into the Sifr Ruff fork parser, AST, comments,
 trivia, and formatter rules, then through the Sifr-owned `sifr_format` wrapper.

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -193,7 +193,7 @@ It does not broaden the active item.
 | 12C | incorporated into 12B | Builtin-registration Clippy blocker | No independent item, review, or gate remains. |
 | 12D | recorded, not started | Native corpus emission dependencies | Adjudicate checked-read control flow and the complete native diagnostic inventory before Item 12B closure. |
 | 12G | merged | Dependency-checker demo path identity | Authoritative DLPack project path and computed-reference regressions merged in PR #3695; exact-SHA validation and Opus review passed. |
-| 12H | authorized: after 12G handoff | Project-wide generated-field identity | Repair declaration/consumer naming consistency across generated files. |
+| 12H | implemented; qualification in progress | Project-wide generated-field identity | Shared nominal/module field registry implemented; inherited compiler qualification and clean-environment bytecode blockers recorded for 12K. |
 | 12I | authorized: after 12H handoff | Macro-defined project support visibility | Repair cancellation task-local visibility without blanket exports. |
 | 12J | authorized: after 12I handoff | Async Python error-channel contract | Resolve the authoritative error contracts and preserve async semantics. |
 | 12K | authorized: integration after dependency qualification | Item 12B and Python dependency integration | Qualify the integrated candidate and merge the preserved work; do not reset Item 12B review history. |
@@ -643,6 +643,20 @@ artifact hashes, package ownership, and missing-input errors remain enforced.
   Helmholtz's retained candidate/index were not modified.
 - Blocker: none. Item12G is complete. Stop this worker after the record update;
   the orchestrator may assign Item12H to a fresh worker. No next-item code was written.
+
+### Item 12H: Project-wide generated-field identity qualification
+
+Item12H's isolated candidate is under qualification in
+`/tmp/sifr-item12h.afJDbk/sifr`, branch
+`codex/emitted-rust-excellence-item-12h`, from fresh main
+`4ce05473f58716a611ac190581bf0737ba15331e`. It preserves Item12B and parent state.
+The [Python owner issue](ad-hoc-python-interop-qualification-dependencies.md#item12h-project-wide-generated-field-identity-implementation)
+records exact commands, mechanism regressions, the original native field failure
+resolved by the candidate, and incomplete qualification. Inherited list-repeat
+test failures and the Item12C builtin-registration Clippy failure require 12K
+integration with preserved Item12B. A newly reached clean-environment bytecode
+immutability failure belongs to Python build/verification and also blocks 12K.
+No assertion, dependency, bytecode rule, or Item12I/12J mechanism was changed.
 
 ### Item 12B: Bounded algorithmic dependency repair
 

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -193,7 +193,7 @@ It does not broaden the active item.
 | 12C | incorporated into 12B | Builtin-registration Clippy blocker | No independent item, review, or gate remains. |
 | 12D | recorded, not started | Native corpus emission dependencies | Adjudicate checked-read control flow and the complete native diagnostic inventory before Item 12B closure. |
 | 12G | merged | Dependency-checker demo path identity | Authoritative DLPack project path and computed-reference regressions merged in PR #3695; exact-SHA validation and Opus review passed. |
-| 12H | implemented; qualification in progress | Project-wide generated-field identity | Shared nominal/module field registry implemented; inherited compiler qualification and clean-environment bytecode blockers recorded for 12K. |
+| 12H | blocked: external qualification; reviewed candidate preserved | Project-wide generated-field identity | Opus remediation approved `9b52ac200`; the one merge gate fails existing SQL coverage classifications. Preserve draft PR #3697 for 12K with compiler/Python qualification blockers. |
 | 12I | authorized: after 12H handoff | Macro-defined project support visibility | Repair cancellation task-local visibility without blanket exports. |
 | 12J | authorized: after 12I handoff | Async Python error-channel contract | Resolve the authoritative error contracts and preserve async semantics. |
 | 12K | authorized: integration after dependency qualification | Item 12B and Python dependency integration | Qualify the integrated candidate and merge the preserved work; do not reset Item 12B review history. |
@@ -657,6 +657,42 @@ test failures and the Item12C builtin-registration Clippy failure require 12K
 integration with preserved Item12B. A newly reached clean-environment bytecode
 immutability failure belongs to Python build/verification and also blocks 12K.
 No assertion, dependency, bytecode rule, or Item12I/12J mechanism was changed.
+
+**Terminal handoff (2026-09-06): blocked, not merged.**
+
+- Preserve [draft PR #3697](https://github.com/sifr-lang/sifr/pull/3697), reviewed
+  implementation `9b52ac20094608c8a31f252db99e49ef7c963384`. Merge SHA: none.
+- The [initial review](https://github.com/sifr-lang/sifr/pull/3697#issuecomment-5555203238)
+  found late bridge generation outside the shared registry. The one remediation
+  batch brings bridge declarations/consumers into the same pass, prevents module
+  identity overwrite, includes bridge sources in cache identity, and removes
+  independent per-file field canonicalization. The
+  [remediation review](https://github.com/sifr-lang/sifr/pull/3697#issuecomment-5555345800)
+  is **SATISFIED**, no blocking findings. Two reviews used; no third review.
+- Evidence: exact-SHA focused driver tests 3/3; final-source driver tests
+  581 passed, 77 existing ignored; unchanged-codegen canonicalizer tests
+  115 passed; rebuilt native binding case prints `binding runtime ok`.
+  Formatting, HIR and file-size guardrails pass. All 264 demo companions pass
+  freshness in the exact-SHA gate; 21 compiler-regenerated companions differ
+  from base. No Sifr demo or reference Rust source changed.
+- The one `scripts/run_all_tests.sh --profile merge` invocation on that clean
+  SHA failed (exit 1, 362.20s) at coverage-matrix readiness: nine unclassified SQL
+  packages, 13 unclassified targets, one stale PostgreSQL `lib` classification.
+  Reached guardrails and Rust interop (10 variants, zero failures) passed.
+  Later Python-area, crate, and E2E qualification was not reached. This is not
+  a merge pass. No create-PR gate or second merge gate ran.
+- [Exact-SHA validation and gate receipt](https://github.com/sifr-lang/sifr/pull/3697#issuecomment-5555393502).
+  Raw logs and copied JSON reports are preserved under `/tmp/sifr-item12h.afJDbk/`.
+  The existing [SQL coverage registry owner](ad-hoc-schema-first-sql-platform-review-follow-ups.md#coverage-registry-blocker-observed-during-naming-cleanup-2026-09-05)
+  records this reproduced failure. Its qualified repair is an additional 12K
+  input alongside the already recorded Item12B/12C and Python build/verification
+  dependencies. No SQL classification or gate requirement was weakened here.
+- Field-resolution suggestions and pre-existing bridge-layout/API maintenance
+  are recorded as unimplemented 12H-F1–F5 in the Python owner issue. The final
+  review found no new blocking mechanism defect. Only record files change after
+  the reviewed/gated SHA; no further tests, reviews or gates are required for
+  this record update. Parent state and preserved Item12B/corpus candidates remain
+  untouched. Stop this worker; no next item is started.
 
 ### Item 12B: Bounded algorithmic dependency repair
 

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -216,6 +216,61 @@ declared method return identities, Result error closures and Err patterns.
 
 ### Item12H pre-review qualification receipt
 
+Initial Opus review of `405e3d3c2adcf018044a2f733ac64ec942f01967` returned
+NOT SATISFIED: generated Rust bridge modules were assembled after the shared
+field pass. The one remediation batch moves their generation into project
+assembly, includes root/child bridge module identities in the registry and cache,
+and writes finalized files without independent field canonicalization. Record
+and error bridges with an underscore field, a same-owner public-name collision,
+an imported consumer, a pattern, and native execution are covered together.
+
+Remediation validation registered before execution (no new broad gate allowance):
+
+```bash
+cargo test -p sifr_driver project_field_identity
+cargo test -p sifr_driver
+cargo clippy -p sifr_codegen -p sifr_driver --all-targets -- -D warnings
+cargo fmt --check
+python3 scripts/check_file_size_guardrails.py
+python3 scripts/check_hir_maintainability_guardrails.py
+cargo build --locked -p sifr
+# cwd: target/verification/areas/python_interop/binding-authoring
+/tmp/sifr-item12h.afJDbk/sifr/target/debug/sifr run src/main.sifr --frozen
+python3 scripts/check_demo_emitted_freshness.py --sifr target/debug/sifr --update
+```
+
+Canonicalizer compiler code is unchanged, so its 115-test evidence is reused.
+The previously failed clean-environment binding suite is not rerun warm as a
+substitute pass. The single merge-profile gate remains reserved for the exact
+final reviewed implementation SHA. The only permitted remediation review follows
+this batch. Initial review suggestions about future macro/inference coverage and
+map key/value receiver identities are deferred to generated-field maintenance;
+they are not implemented as a second mechanism in this batch.
+
+The first remediation refresh exposed listing-only expansion (all pre-existing
+bridge carriers were being appended to every demo). That incidental output
+expansion is removed before review: the source-listing boundary stays unchanged,
+all bridge sources still enter the shared registry before formatting, and only
+the field-free native root module declaration is added at materialization.
+The registered driver/focused/native commands and companion generator are rerun
+for this changed assembly input; the inherited strict-Clippy failure is reused.
+
+Final remediation source inputs pass all 581 active driver tests (77 existing
+ignored tests), including the two new bridge materialization/namespace cases;
+`driver-remediation-final.log`. The rebuilt CLI passes native binding execution
+again (`native-remediation-final.log`, `binding runtime ok`). Formatting, the
+3,758-file size guardrail and HIR guardrail pass. Additional interop contract
+test files only initialize the new generated-project bridge-module collection;
+no async, callback, or other contract behavior is changed. The strict-Clippy
+receipt remains `clippy-remediation.log` (inherited Item12C failure, no pass).
+The final compiler-owned refresh succeeds for all 264 demos. Relative to the
+initial reviewed candidate, only five companions change: `advanced_class_libraries`,
+`csv`, `regex_and_filesystem`, `stdlib_expansion`, and
+`structured_parsing_serialization`. These remove redundant identifier escaping
+from the independent per-file pass and induced reflow; the temporary bridge
+listing expansion is absent. There are 21 changed companions overall relative
+to the item base. Log: `companion-refresh-remediation-final.log`.
+
 Implementation commit `dba6a8f7075ea071058654c85ed1e46e4d1272fa` passed all
 115 canonicalizer tests (including nine focused field regressions), all 579
 active driver tests (77 existing ignored tests), and the direct native
@@ -236,7 +291,34 @@ unchanged. Strict Clippy after that repair reports only the inherited Item12C
 failure (`clippy-clone-repair.log`). Exact-final-candidate focused checks and
 review follow; no gate has yet run and the full binding suite remains blocked.
 
-Binding-authoring fails with eight Rust E0560 diagnostics in generated
+### Item12H deferred maintenance (not implemented)
+
+The [initial exact-candidate Opus review](https://github.com/sifr-lang/sifr/pull/3697#issuecomment-5555203238)
+classified these as suggestions, not blocking findings. Owner: generated-Rust
+field-resolution maintenance after the current dependency/integration sequence.
+They require their own bounded implementation and evidence, not another 12H
+review/gate iteration:
+
+- **12H-F1, macro syntax coverage:** non-expression-list macros other than
+  `vec![element; count]` are not traversed by field cleanup. Require explicit
+  field handling before an emitter adds such field-bearing macro syntax.
+- **12H-F2, receiver inference coverage:** casts, async/unsafe/loop expressions,
+  and additional iterator adapters need typed coverage before expanding emitted
+  receiver forms; unresolved generated-field receivers currently diagnose.
+- **12H-F3, map receiver identity:** the general index-element rule selects the
+  first generic argument. A map needs its value argument instead; qualify this
+  against actual emitted map access and owner-local collision variants before
+  changing the mechanism. No runtime base reproduction was claimed by this review.
+
+The duplicate per-file field pass suggestion is resolved as part of the required
+bridge correction: materialization now only formats already canonical sources.
+The initial review's infrastructure attribution to PyO3 is not stronger evidence
+than the suspected-cause provenance above; the clean-environment failure remains
+unqualified and externally owned.
+
+### Original Item12H diagnostic provenance
+
+Before this implementation, binding-authoring fails with eight Rust E0560 diagnostics in generated
 `binding_authoring/math_python.rs`: initializers use
 `sifr_generated_python_error`, while the imported nominal declares `python_error`.
 

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -139,6 +139,48 @@ same declaration mapping. External fields retain their spelling. Unknown
 generated-field receivers fail with a compiler diagnostic rather than a guessed
 global replacement. No PythonError-specific naming rule is introduced.
 
+### Item12H terminal handoff (2026-09-06)
+
+**Blocked; reviewed implementation preserved, not merged.**
+
+- PR: [#3697](https://github.com/sifr-lang/sifr/pull/3697), remains draft/open.
+  Reviewed/final implementation SHA: `9b52ac20094608c8a31f252db99e49ef7c963384`.
+  Merge SHA: none. Branch/worktree ownership above is unchanged.
+- [Final Opus remediation review](https://github.com/sifr-lang/sifr/pull/3697#issuecomment-5555345800):
+  **SATISFIED**, no blockers. Exactly one initial and one remediation review
+  were used. No further implementation or review is performed after this verdict.
+- Final evidence: exact-SHA focused tests 3/3, final-source driver tests 581/581
+  active (77 existing ignored), unchanged-codegen canonicalizer tests 115/115,
+  and native binding execution (`binding runtime ok`). Formatting, file-size
+  and HIR guardrails pass. All 264 demo emissions/freshness checks pass; 21
+  generated companions differ from base. Full binding-authoring and strict
+  Clippy remain incomplete/failed as recorded below; they are not pass evidence.
+- One exact-clean-SHA merge-profile gate failed after 362.20s at
+  `coverage_matrix:readiness/coverage_matrix_readiness`: nine unclassified SQL
+  packages, 13 unclassified targets, and one stale PostgreSQL library target.
+  The three other coverage variants passed; Rust interop passed 10 variants.
+  Later Python-area, crate and E2E gate stages were not reached. No create-PR
+  gate, second merge gate, or qualification bypass was used.
+- This reproduces the existing
+  [SQL coverage registry blocker](ad-hoc-schema-first-sql-platform-review-follow-ups.md#coverage-registry-blocker-observed-during-naming-cleanup-2026-09-05).
+  **Concrete additional 12K dependency:** SQL compiler/schema-tool verification
+  must reconcile the existing package/target classifications and qualify that
+  repair. 12H changes none of those inputs. The inherited Item12B/12C compiler
+  checks and clean-environment Python bytecode failure remain separate 12K inputs.
+- [Published exact-SHA evidence](https://github.com/sifr-lang/sifr/pull/3697#issuecomment-5555393502).
+  Preserved files under `/tmp/sifr-item12h.afJDbk/`:
+  `merge-9b52ac20094608c8a31f252db99e49ef7c963384.log` and `.json`,
+  `coverage-matrix-9b52ac20094608c8a31f252db99e49ef7c963384.json`,
+  `rust-interop-9b52ac20094608c8a31f252db99e49ef7c963384.json`,
+  `validation-9b52ac20094608c8a31f252db99e49ef7c963384.md`, and the focused/native
+  logs below. The full binding failure report was separately preserved before
+  the gate. Do not reuse any failed or incomplete receipt as a pass.
+- Stop after the record-only update. No12I/12J code was implemented and no next
+  item was started.12K must establish passing integrated evidence before merge;
+  this handoff does not reset any exhausted review or gate allowance.
+
+### Item12H validation history
+
 Exact validation commands registered before test execution:
 
 ```bash
@@ -309,6 +351,15 @@ review/gate iteration:
   first generic argument. A map needs its value argument instead; qualify this
   against actual emitted map access and owner-local collision variants before
   changing the mechanism. No runtime base reproduction was claimed by this review.
+- **12H-F4, pre-existing bridge layout:** the remediation reviewer flagged the
+  bridge module name `mod` as a potential alias of the root `mod.rs` path.
+  Qualify reserved-word handling and physical path identity when bridge layout
+  is next touched; the item-level module-identity check is not a path registry.
+  This was classified as pre-existing, not a new blocking field mechanism defect.
+- **12H-F5, single-source API coverage:** review consolidation of the
+  single-source canonicalization convenience wrapper now that production uses
+  the project entry point. Preserve actual public API requirements and equivalent
+  focused coverage if a later owner changes it; no API is removed here.
 
 The duplicate per-file field pass suggestion is resolved as part of the required
 bridge correction: materialization now only formats already canonical sources.

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -214,6 +214,28 @@ it does not replace the failed full binding-authoring suite. Final mechanism
 regressions also cover generic member chains, enum payloads, loop shadowing,
 declared method return identities, Result error closures and Err patterns.
 
+### Item12H pre-review qualification receipt
+
+Implementation commit `dba6a8f7075ea071058654c85ed1e46e4d1272fa` passed all
+115 canonicalizer tests (including nine focused field regressions), all 579
+active driver tests (77 existing ignored tests), and the direct native
+cross-module regression (`binding runtime ok`). Logs are keyed by that SHA
+under `/tmp/sifr-item12h.afJDbk/`: `canonicalizer-*.log`, `driver-*.log`,
+`build-*.log`, and `native-*.log`. The earlier restricted driver run is not
+used as final driver evidence.
+
+Compiler-owned companions were regenerated with
+`python3 scripts/check_demo_emitted_freshness.py --sifr target/debug/sifr --update`.
+All 264 emissions succeeded; 18 companion files changed through that generator.
+The changes remove field collision suffixes caused by unrelated nominal types
+(Logger, Random, deque, CSV/ZIP carriers). No Sifr demo or reference Rust source
+changed. Refresh log: `companion-refresh-dba6a8f7075ea071058654c85ed1e46e4d1272fa.log`.
+The only subsequent compiler edit replaces an implicit String clone with
+explicit `.clone()` for Clippy; field resolution and generated output are
+unchanged. Strict Clippy after that repair reports only the inherited Item12C
+failure (`clippy-clone-repair.log`). Exact-final-candidate focused checks and
+review follow; no gate has yet run and the full binding suite remains blocked.
+
 Binding-authoring fails with eight Rust E0560 diagnostics in generated
 `binding_authoring/math_python.rs`: initializers use
 `sifr_generated_python_error`, while the imported nominal declares `python_error`.

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -124,7 +124,95 @@ separate from Items12H–12K and not implemented by Item12G:
   start directory. If broader discovery is adopted, make sibling imports work
   under that selected runner as well. The recorded invocation already passes.
 
-## Later Item12H: project-wide generated-field identity
+## Item12H: project-wide generated-field identity (implementation)
+
+Owned worktree: `/tmp/sifr-item12h.afJDbk/sifr`; branch:
+`codex/emitted-rust-excellence-item-12h`; base:
+`4ce05473f58716a611ac190581bf0737ba15331e` (freshly fetched main, including
+12G implementation and record merges). Parent and Item12B state are preserved.
+
+The bounded implementation resolves generated fields through a project registry
+keyed by Rust module and nominal declaration before identifier cleanup. Binary
+and test projects share the registry. Owner-local collisions, import aliases,
+re-exports, nested modules, typed receivers, initializers, and patterns use the
+same declaration mapping. External fields retain their spelling. Unknown
+generated-field receivers fail with a compiler diagnostic rather than a guessed
+global replacement. No PythonError-specific naming rule is introduced.
+
+Exact validation commands registered before test execution:
+
+```bash
+cargo test -p sifr_codegen project_field_identity
+cargo test -p sifr_codegen -p sifr_driver
+uv run --project verification --locked python -m sifr_verify areas run --area python_interop --suite binding-authoring
+cargo clippy -p sifr_codegen -p sifr_driver --all-targets -- -D warnings
+cargo fmt --check
+python3 scripts/check_file_size_guardrails.py
+python3 scripts/check_hir_maintainability_guardrails.py
+scripts/run_all_tests.sh --profile merge
+```
+
+The merge-profile command is reserved for the final reviewed SHA, once only.
+No create-PR gate runs in this merge session. Focused regressions include
+negative external-type/name-collision variants and unresolved-owner rejection.
+12I cancellation visibility and 12J error-channel contracts remain out of scope.
+
+The first crate run reached 1,412 passing codegen tests and three failures.
+The parsing-diagnostic prefix regression belongs to 12H and is corrected.
+Two list-repeat expectations fail upstream of canonicalization in unchanged
+`generate_rust_with_metadata`: `test_list_repeat_lowers_without_vec_mul_shape`
+and `single_element_list_repeat_uses_std_repeat_not_extend_loop`. Their producer
+and tests are outside 12H; Item12K must reconcile them with preserved Item12B
+before integration. This is source-path provenance, not an independent base run.
+Log: `/tmp/sifr-item12h.afJDbk/crate-tests-repair.log`. No assertion was weakened.
+The crate command stopped before driver tests. Follow-up constituent commands:
+
+```bash
+cargo test -p sifr_codegen rejects_invalid_assembled_source
+cargo test -p sifr_driver
+```
+
+Strict affected-crate Clippy reached the unchanged
+`crates/sifr_codegen/src/project_stdlib_nominals.rs:45` `expect_used` failure.
+This is the builtin-registration blocker already incorporated as Item12C into
+preserved Item12B; Item12K owns bringing that repair into the integrated base.
+Log: `/tmp/sifr-item12h.afJDbk/clippy.log`. No allowance or duplicate repair was
+added by 12H. The failed command is not passing qualification evidence.
+
+After the typed Result/closure repair, binding-authoring passed its native
+`binding runtime ok` assertion and the subsequent frozen binding/check
+immutability checks, then failed at `binding_authoring.py:362`: bytecode cache
+state changed in the initially clean area environment. Remaining assertions
+after that line were not reached. Log:
+`/tmp/sifr-item12h.afJDbk/binding-authoring-error-flow.log`.
+The only observed cache files are `_virtualenv.cpython-314.pyc` and
+`_distutils_hack/__init__.cpython-314.pyc`. The unchanged Sifr probes use `-B`
+and the unchanged embedded runtime sets `PyConfig.write_bytecode = 0`.
+The unchanged PyO3 build-config interpreter launcher lacks `-B`; startup during
+native dependency building is a suspected cause, not an independently proven
+base reproduction. Owner: Python build/verification, required 12K integration
+input. Do not disable the bytecode assertion or count a warmed-environment
+rerun as proof of clean-environment immutability. No repair is included in 12H.
+
+The restricted driver run was interrupted after native Cargo probes repeatedly
+failed under sandbox restrictions. One exact failed bridge-signature probe
+passed with required permissions (1/1); this is diagnostic evidence only.
+The affected driver command will use those permissions for final qualification.
+
+Additional focused final-candidate commands (registered before execution):
+
+```bash
+cargo test -p sifr_codegen generated_rust_canonicalizer
+cargo test -p sifr_driver project_field_identity
+cargo build --locked -p sifr
+# cwd: target/verification/areas/python_interop/binding-authoring
+/tmp/sifr-item12h.afJDbk/sifr/target/debug/sifr run src/main.sifr --frozen
+```
+
+The direct native command qualifies the original cross-module field mechanism;
+it does not replace the failed full binding-authoring suite. Final mechanism
+regressions also cover generic member chains, enum payloads, loop shadowing,
+declared method return identities, Result error closures and Err patterns.
 
 Binding-authoring fails with eight Rust E0560 diagnostics in generated
 `binding_authoring/math_python.rs`: initializers use

--- a/plans/issues/active/ad-hoc-schema-first-sql-platform-review-follow-ups.md
+++ b/plans/issues/active/ad-hoc-schema-first-sql-platform-review-follow-ups.md
@@ -77,6 +77,25 @@ All 264 demo emitted companions passed freshness, along with the file-size,
 HIR, Rust interop, and naming checks. No SQL classifications changed.
 Evidence: `target/demo-layout/merge-gate.log`.
 
+Item12H's one exact-SHA merge-profile gate reproduced this existing blocker on
+2026-09-06, after its bounded field-identity remediation was approved by Opus.
+Candidate: `9b52ac20094608c8a31f252db99e49ef7c963384`,
+[draft PR #3697](https://github.com/sifr-lang/sifr/pull/3697). The gate failed at
+`coverage_matrix:readiness/coverage_matrix_readiness` with nine unclassified SQL
+packages, 13 unclassified targets, and one stale PostgreSQL `lib` classification.
+The other three coverage variants passed. All 264 demo companions, reached
+guardrails and Rust interop checks passed before the failure; later gate stages
+were not reached. No SQL source, Cargo target, coverage classification, or skip
+policy was changed by12H, and no second gate was run.
+
+[Exact-SHA evidence and disposition](https://github.com/sifr-lang/sifr/pull/3697#issuecomment-5555393502).
+Logs and copied reports: `/tmp/sifr-item12h.afJDbk/merge-9b52ac20094608c8a31f252db99e49ef7c963384.log`
+and `.json`, plus `coverage-matrix-9b52ac20094608c8a31f252db99e49ef7c963384.json`
+in that directory. The candidate remains unmerged. Reconciling and qualifying
+these existing SQL coverage classifications is a concrete dependency for
+Item12K integration; this receipt does not authorize12H to implement the repair
+or merge an unqualified candidate.
+
 The abbreviated-label cleanup also ran its final merge gate once on 2026-09-05.
 It reproduced the SQL package/target classification failures above. Demo
 freshness, Rust interop matrix checks, naming checks, HIR, and file-size checks


### PR DESCRIPTION
Item12H implements project-wide generated-field identity through one module-qualified nominal registry, including binary/test projects and generated Rust bridge declarations/consumers. It covers imported literals, patterns, member accesses, owner-local field collisions and module-identity rejection without a PythonError-specific or untyped global substitution. Bridge sources participate in artifact cache identity; materialization does not run another field-renaming pass.

**Disposition: blocked, draft/unmerged.** Reviewed implementation SHA: `9b52ac20094608c8a31f252db99e49ef7c963384`; base: `4ce05473f58716a611ac190581bf0737ba15331e`. Subsequent changes are owner/phase records only.

The [sole remediation Opus review](https://github.com/sifr-lang/sifr/pull/3697#issuecomment-5555345800) is SATISFIED with no blockers. Exact-SHA focused tests pass3/3; final-source driver tests pass581 with77 existing ignored; unchanged-codegen canonicalizer evidence passes115 tests. Native binding execution succeeds, and all264 demo companions pass freshness in the gate. Formatting, HIR and file-size guardrails pass.

The one exact-SHA merge-profile gate failed on the existing SQL coverage registry:9 unclassified packages,13 unclassified targets and1 stale library classification. Later gate stages were not reached. Strict Clippy and the clean-environment binding-authoring suite also remain blocked by the separately recorded12B/12C and Python build/verification dependencies. No qualification was weakened and no failed receipt is a pass.

[Complete validation, review and gate evidence](https://github.com/sifr-lang/sifr/pull/3697#issuecomment-5555393502). The phase, Python dependency issue and SQL coverage owner contain the terminal handoff and concrete12K dependency. Two reviews and one merge gate used; no third review, second gate or create-pr gate. No12I/12J code was implemented. Preserve this candidate for qualified12K integration; do not merge it unqualified.
