### PR TITLE
Preserve error ancestry and complete nominal error conversions (12J/R1)

### DIFF
--- a/crates/sifr_codegen/src/class_field_emitter.rs
+++ b/crates/sifr_codegen/src/class_field_emitter.rs
@@ -22,7 +22,7 @@ impl RustEmitter {
             name: class.name.clone(),
             fields: class.fields.clone(),
             methods: Vec::new(),
-            parent_class: class.parent_class.clone(),
+            parent_class: class.semantic_parent_chain(),
         }
         .is_python_error_contract()
     }

--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -86,7 +86,7 @@ pub(crate) fn generate_rust_test_with_project_policy(
     emitter.emit_named_module(module, false, true, Some(module_name));
     // Expression lowering can introduce canonical intermediate error unions.
     emitter.generate_enum_definitions();
-    let support_demand = ModuleSupportDemand::from_emitter(module, &emitter);
+    let support_demand = ModuleSupportDemand::from_emitter(module, &emitter, Some(module_name));
 
     let mut module_import_items: Vec<RustItem> = Vec::new();
     for import in &module.imports {

--- a/crates/sifr_codegen/src/error_refs.rs
+++ b/crates/sifr_codegen/src/error_refs.rs
@@ -3,6 +3,24 @@ use sifr_type_system::Type;
 use std::collections::HashSet;
 
 mod checked_places;
+mod conversions;
+pub(crate) use conversions::ErrorConversionDemand;
+
+#[derive(Default)]
+struct ErrorReferences {
+    builtins: HashSet<String>,
+    conversions: ErrorConversionDemand,
+}
+
+pub(crate) fn collect_error_conversion_demand(
+    module: &HirModule,
+    module_name: Option<&str>,
+) -> ErrorConversionDemand {
+    let mut conversions =
+        collect_error_references(module, "", &HashSet::new(), false, &[]).conversions;
+    conversions.record_classes(module, module_name);
+    conversions
+}
 
 pub(crate) fn collect_referenced_builtin_error_classes(
     module: &HirModule,
@@ -11,7 +29,24 @@ pub(crate) fn collect_referenced_builtin_error_classes(
     needs_file_handles: bool,
     builtin_error_classes: &[&str],
 ) -> HashSet<String> {
-    let mut referenced = HashSet::new();
+    collect_error_references(
+        module,
+        stdlib_preamble,
+        intrinsic_functions,
+        needs_file_handles,
+        builtin_error_classes,
+    )
+    .builtins
+}
+
+fn collect_error_references(
+    module: &HirModule,
+    stdlib_preamble: &str,
+    intrinsic_functions: &HashSet<String>,
+    needs_file_handles: bool,
+    builtin_error_classes: &[&str],
+) -> ErrorReferences {
+    let mut referenced = ErrorReferences::default();
 
     for func in &module.functions {
         for param in &func.params {
@@ -51,7 +86,7 @@ pub(crate) fn collect_referenced_builtin_error_classes(
     collect_text_error_refs(stdlib_preamble, &mut referenced, builtin_error_classes);
 
     if needs_file_handles {
-        referenced.insert("IOError".to_string());
+        referenced.builtins.insert("IOError".to_string());
     }
 
     // Intrinsics can produce these builtin errors through generated helper code.
@@ -68,7 +103,7 @@ pub(crate) fn collect_referenced_builtin_error_classes(
             "TimeoutError",
             "ScopeFailure",
         ] {
-            referenced.insert(error_name.to_string());
+            referenced.builtins.insert(error_name.to_string());
         }
     }
 
@@ -135,13 +170,14 @@ pub(crate) fn collect_module_intrinsic_function_names(module: &HirModule) -> Has
 
 fn collect_type_error_refs(
     ty: &Type,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
+    referenced.conversions.record_type(ty);
     match ty {
         Type::Class { name, .. } | Type::Protocol { name, .. } | Type::Enum { name, .. } => {
             if builtin_error_classes.contains(&name.as_str()) {
-                referenced.insert(name.clone());
+                referenced.builtins.insert(name.clone());
             }
         }
         Type::List(inner)
@@ -177,7 +213,7 @@ fn collect_type_error_refs(
         Type::Failure(err) => {
             collect_type_error_refs(err, referenced, builtin_error_classes);
             if builtin_error_classes.contains(&"SecondaryError") {
-                referenced.insert("SecondaryError".to_string());
+                referenced.builtins.insert("SecondaryError".to_string());
             }
         }
         Type::TimeoutResult(err) => {
@@ -233,7 +269,7 @@ fn collect_type_error_refs(
 
 fn collect_stmt_error_refs(
     stmts: &[HirStmt],
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
     for stmt in stmts {
@@ -337,7 +373,7 @@ fn collect_stmt_error_refs(
                 for handler in handlers {
                     if let Some(error_type) = &handler.error_type {
                         if builtin_error_classes.contains(&error_type.as_str()) {
-                            referenced.insert(error_type.clone());
+                            referenced.builtins.insert(error_type.clone());
                         }
                     }
                     collect_stmt_error_refs(&handler.body, referenced, builtin_error_classes);
@@ -356,7 +392,7 @@ fn collect_stmt_error_refs(
             HirStmt::AsyncWith { kind, body, .. } => {
                 match kind {
                     sifr_ir::HirAsyncWithKind::TaskTimeout { duration } => {
-                        referenced.insert("TimeoutError".to_string());
+                        referenced.builtins.insert("TimeoutError".to_string());
                         collect_expr_error_refs(duration, referenced, builtin_error_classes);
                     }
                     sifr_ir::HirAsyncWithKind::UserDefined { context, .. }
@@ -366,12 +402,12 @@ fn collect_stmt_error_refs(
                     sifr_ir::HirAsyncWithKind::TaskGroup {
                         context: Some(context),
                     } => {
-                        referenced.insert("ScopeFailure".to_string());
+                        referenced.builtins.insert("ScopeFailure".to_string());
                         collect_expr_error_refs(context, referenced, builtin_error_classes);
                     }
                     sifr_ir::HirAsyncWithKind::TaskScope
                     | sifr_ir::HirAsyncWithKind::TaskGroup { context: None } => {
-                        referenced.insert("ScopeFailure".to_string());
+                        referenced.builtins.insert("ScopeFailure".to_string());
                     }
                 }
                 collect_stmt_error_refs(body, referenced, builtin_error_classes);
@@ -395,7 +431,7 @@ fn collect_stmt_error_refs(
 
 fn collect_expr_error_refs(
     expr: &HirExpr,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
     collect_type_error_refs(expr.ty(), referenced, builtin_error_classes);
@@ -405,7 +441,7 @@ fn collect_expr_error_refs(
         | HirExpr::GenericCall { func, args, .. }
         | HirExpr::PythonCall { func, args, .. } => {
             if builtin_error_classes.contains(&func.as_str()) {
-                referenced.insert(func.clone());
+                referenced.builtins.insert(func.clone());
             }
             for arg in args {
                 collect_expr_error_refs(arg, referenced, builtin_error_classes);
@@ -420,7 +456,7 @@ fn collect_expr_error_refs(
             class_name, args, ..
         } => {
             if builtin_error_classes.contains(&class_name.as_str()) {
-                referenced.insert(class_name.clone());
+                referenced.builtins.insert(class_name.clone());
             }
             for arg in args {
                 collect_expr_error_refs(arg, referenced, builtin_error_classes);
@@ -595,7 +631,7 @@ fn collect_expr_error_refs(
 
 fn collect_text_error_refs(
     text: &str,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
     let mut token = String::new();
@@ -606,13 +642,13 @@ fn collect_text_error_refs(
         }
         if !token.is_empty() {
             if builtin_error_classes.contains(&token.as_str()) {
-                referenced.insert(token.clone());
+                referenced.builtins.insert(token.clone());
             }
             token.clear();
         }
     }
     if !token.is_empty() && builtin_error_classes.contains(&token.as_str()) {
-        referenced.insert(token);
+        referenced.builtins.insert(token);
     }
 }
 
@@ -620,9 +656,9 @@ pub(crate) fn collect_source_builtin_error_classes(
     source: &str,
     builtin_error_classes: &[&str],
 ) -> HashSet<String> {
-    let mut referenced = HashSet::new();
+    let mut referenced = ErrorReferences::default();
     collect_text_error_refs(source, &mut referenced, builtin_error_classes);
-    referenced
+    referenced.builtins
 }
 
 #[cfg(test)]

--- a/crates/sifr_codegen/src/error_refs/checked_places.rs
+++ b/crates/sifr_codegen/src/error_refs/checked_places.rs
@@ -1,9 +1,9 @@
+use super::ErrorReferences;
 use sifr_ir::HirStmt;
-use std::collections::HashSet;
 
 pub(super) fn collect_checked_place_stmt_error_refs(
     stmt: &HirStmt,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) -> bool {
     match stmt {
@@ -71,7 +71,7 @@ pub(super) fn collect_checked_place_stmt_error_refs(
 
 fn collect_expr(
     expr: &sifr_ir::HirExpr,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
     super::collect_expr_error_refs(expr, referenced, builtin_error_classes);
@@ -79,7 +79,7 @@ fn collect_expr(
 
 fn collect_failure(
     failure: Option<&sifr_type_system::Type>,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
     if let Some(failure) = failure {

--- a/crates/sifr_codegen/src/error_refs/conversions.rs
+++ b/crates/sifr_codegen/src/error_refs/conversions.rs
@@ -110,7 +110,7 @@ impl ErrorConversionDemand {
                     type_params, items, ..
                 } = &mut item
                 {
-                    *type_params = error.type_params.clone();
+                    type_params.clone_from(&error.type_params);
                     // A transitive error owns its parent value. Consume that value via
                     // the existing inheritance impl, rather than moving through Deref
                     // or cloning the inherited message.

--- a/crates/sifr_codegen/src/error_refs/conversions.rs
+++ b/crates/sifr_codegen/src/error_refs/conversions.rs
@@ -1,0 +1,159 @@
+use crate::{RustEmitter, RustExpr, RustItem, RustStmt, RustTypeParam};
+use sifr_ir::HirModule;
+use sifr_type_system::{Type, class_rust_name};
+use std::collections::{BTreeMap, HashMap};
+
+/// Conversion authority follows semantic ancestry, never an error's basename.
+#[derive(Clone, Default)]
+pub(crate) struct ErrorConversionDemand(BTreeMap<String, NominalError>);
+
+#[derive(Clone)]
+struct NominalError {
+    rust_name: String,
+    type_arguments: String,
+    type_params: Vec<RustTypeParam>,
+    ancestors: Vec<String>,
+    declaration: bool,
+    owns_message: bool,
+}
+
+impl ErrorConversionDemand {
+    pub(super) fn record_classes(&mut self, module: &HirModule, module_name: Option<&str>) {
+        for class in &module.classes {
+            let Some(chain) = class
+                .semantic_parent_chain()
+                .filter(|_| class.is_error_type)
+            else {
+                continue;
+            };
+            if !chain.split('|').any(is_root_error) {
+                continue;
+            }
+            let rust_name = sifr_type_system::source_class_rust_name(&class.name);
+            let target = RustEmitter::class_impl_target(class);
+            self.0.insert(
+                class.identity.clone().unwrap_or_else(|| {
+                    module_name.map_or_else(
+                        || class.name.clone(),
+                        |module| format!("{module}.{}", class.name),
+                    )
+                }),
+                NominalError {
+                    type_arguments: target[rust_name.len()..].to_string(),
+                    rust_name,
+                    type_params: RustEmitter::class_impl_type_params(class),
+                    ancestors: chain.split('|').map(str::to_string).collect(),
+                    declaration: true,
+                    owns_message: class.fields.iter().any(|(name, _)| name == "message"),
+                },
+            );
+        }
+    }
+
+    pub(super) fn record_type(&mut self, ty: &Type) {
+        let Type::Class {
+            identity,
+            name,
+            fields,
+            parent_class: Some(chain),
+            ..
+        } = ty.resolve_alias()
+        else {
+            return;
+        };
+        if !chain.split('|').any(is_root_error)
+            || (crate::BUILTIN_ERROR_CLASSES.contains(&name.as_str())
+                && identity.as_deref().is_none_or(|id| {
+                    id.starts_with("sifr.builtin.")
+                        || sifr_type_system::is_global_rust_nominal_identity(id)
+                }))
+        {
+            return;
+        }
+        let rust_name = class_rust_name(identity.as_deref(), name);
+        let rendered = crate::render_type(&crate::sifr_type_to_rust_type(ty));
+        self.0
+            .entry(identity.clone().unwrap_or_else(|| name.clone()))
+            .or_insert_with(|| NominalError {
+                type_arguments: rendered[rust_name.len()..].to_string(),
+                rust_name,
+                type_params: Vec::new(),
+                ancestors: chain.split('|').map(str::to_string).collect(),
+                declaration: false,
+                owns_message: fields.iter().any(|(name, _)| name == "message"),
+            });
+    }
+
+    pub(crate) fn merge(&mut self, other: &Self) {
+        for (identity, error) in &other.0 {
+            if error.declaration || !self.0.contains_key(identity) {
+                self.0.insert(identity.clone(), error.clone());
+            }
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn render(&self, paths: &HashMap<String, String>) -> Vec<RustItem> {
+        self.0
+            .iter()
+            .map(|(identity, error)| {
+                let source = format!(
+                    "{}{}",
+                    paths.get(identity).unwrap_or(&error.rust_name),
+                    error.type_arguments
+                );
+                let mut item = crate::build_error_into_error_impl(&source);
+                if let RustItem::Impl {
+                    type_params, items, ..
+                } = &mut item
+                {
+                    *type_params = error.type_params.clone();
+                    // A transitive error owns its parent value. Consume that value via
+                    // the existing inheritance impl, rather than moving through Deref
+                    // or cloning the inherited message.
+                    if !error.owns_message
+                        && error
+                            .ancestors
+                            .first()
+                            .is_some_and(|ancestor| !is_root_error(ancestor))
+                    {
+                        let mut value = RustExpr::Ident("err".to_string());
+                        for ancestor in &error.ancestors {
+                            let target = if is_root_error(ancestor) {
+                                "Error".to_string()
+                            } else if let Some(path) = paths.get(ancestor) {
+                                path.clone()
+                            } else {
+                                let name = ancestor.rsplit('.').next().unwrap_or(ancestor);
+                                class_rust_name(
+                                    ancestor.contains('.').then_some(ancestor.as_str()),
+                                    name,
+                                )
+                            };
+                            value = RustExpr::FnCall {
+                                func: Box::new(RustExpr::Path(vec![format!(
+                                    "::std::convert::Into::<{target}>::into"
+                                )])),
+                                args: vec![value],
+                            };
+                            if is_root_error(ancestor) {
+                                break;
+                            }
+                        }
+                        if let RustItem::Fn { body, .. } = &mut items[0] {
+                            *body = vec![RustStmt::Return(Some(value))];
+                        }
+                    }
+                }
+                item
+            })
+            .collect()
+    }
+}
+
+fn is_root_error(identity: &str) -> bool {
+    matches!(identity, "Error" | "sifr.builtin.Error")
+}

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -245,7 +245,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
         );
     }
     emitter.generate_enum_definitions();
-    let support_demand = ModuleSupportDemand::from_emitter(module, &emitter);
+    let support_demand = ModuleSupportDemand::from_emitter(module, &emitter, module_name);
     if support_emission == SupportEmission::Deferred {
         return deferred_codegen_result(
             module,

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -406,6 +406,7 @@ pub fn generate_rust_multi_with_metadata(
         required_features.extend(codegen_result.required_features);
     }
 
+    project_support_demand.set_error_conversion_paths(&nominal_type_paths);
     let rendered_support = render_support(&project_support_demand, stdlib_code);
     used_stdlib_modules.extend(rendered_support.used_stdlib_modules.iter().cloned());
     required_features.extend(rendered_support.required_features.iter().copied());

--- a/crates/sifr_codegen/src/lib_project_signatures.rs
+++ b/crates/sifr_codegen/src/lib_project_signatures.rs
@@ -140,7 +140,7 @@ fn module_func_signatures(module: &HirModule) -> ModuleFuncSignatures {
                         name: class.name.clone(),
                         fields: class.fields.clone(),
                         methods: Vec::new(),
-                        parent_class: class.parent_class.clone(),
+                        parent_class: class.semantic_parent_chain(),
                     },
                 ),
             );

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -166,6 +166,7 @@ pub fn generate_rust_test_project_with_metadata(
         required_features.extend(generated.required_features);
     }
 
+    project_support_demand.set_error_conversion_paths(&nominal_type_paths);
     let rendered_support = render_support(&project_support_demand, stdlib_code);
     used_stdlib_modules.extend(rendered_support.used_stdlib_modules.iter().cloned());
     required_features.extend(rendered_support.required_features.iter().copied());

--- a/crates/sifr_codegen/src/python_interop_common.rs
+++ b/crates/sifr_codegen/src/python_interop_common.rs
@@ -28,12 +28,6 @@ pub(crate) fn rust_source_uses_python_runtime(source: &str) -> bool {
     source.contains("::sifr_stdlib::python::") || source.contains("::sifr_runtime::python::")
 }
 
-pub(crate) fn python_error_contract_rust_types(
-    module: &HirModule,
-) -> std::collections::BTreeSet<String> {
-    python_error_contract_types(module).into_keys().collect()
-}
-
 pub(crate) fn python_error_contract_types(
     module: &HirModule,
 ) -> std::collections::BTreeMap<String, Type> {

--- a/crates/sifr_codegen/src/support_plan.rs
+++ b/crates/sifr_codegen/src/support_plan.rs
@@ -41,14 +41,19 @@ pub(crate) struct ModuleSupportDemand {
     suppressed_union_definitions: HashSet<String>,
     locally_shadowed_error_classes: HashSet<String>,
     referenced_error_classes: HashSet<String>,
-    python_error_rust_types: BTreeSet<String>,
+    error_conversions: crate::error_refs::ErrorConversionDemand,
+    error_conversion_paths: HashMap<String, String>,
     required_features: HashSet<StdlibFeature>,
     needs_file_handle_struct: bool,
     structural_interop_enabled: bool,
 }
 
 impl ModuleSupportDemand {
-    pub(crate) fn from_emitter(module: &HirModule, emitter: &RustEmitter) -> Self {
+    pub(crate) fn from_emitter(
+        module: &HirModule,
+        emitter: &RustEmitter,
+        module_name: Option<&str>,
+    ) -> Self {
         let runtime = RuntimeSupportDemand::for_module(module);
         let needs_file_handles = emitter.runtime_needs.file_handles();
         let user_defined_error_classes = module
@@ -79,9 +84,11 @@ impl ModuleSupportDemand {
                 .map(str::to_string)
                 .collect(),
             referenced_error_classes,
-            python_error_rust_types: crate::python_interop_common::python_error_contract_rust_types(
+            error_conversions: crate::error_refs::collect_error_conversion_demand(
                 module,
+                module_name,
             ),
+            error_conversion_paths: HashMap::new(),
             required_features: emitter.intrinsic_registry_features.clone(),
             needs_file_handle_struct: needs_file_handles
                 && !module
@@ -118,12 +125,15 @@ impl ModuleSupportDemand {
             .extend(other.suppressed_union_definitions.iter().cloned());
         self.referenced_error_classes
             .extend(other.referenced_error_classes.iter().cloned());
-        self.python_error_rust_types
-            .extend(other.python_error_rust_types.iter().cloned());
+        self.error_conversions.merge(&other.error_conversions);
         self.required_features
             .extend(other.required_features.iter().copied());
         self.needs_file_handle_struct |= other.needs_file_handle_struct;
         self.structural_interop_enabled |= other.structural_interop_enabled;
+    }
+
+    pub(crate) fn set_error_conversion_paths(&mut self, paths: &HashMap<String, String>) {
+        self.error_conversion_paths.clone_from(paths);
     }
 
     pub(crate) fn needs_support(&self) -> bool {
@@ -131,7 +141,7 @@ impl ModuleSupportDemand {
             || self.runtime_needs.file_handles()
             || !self.directly_used_stdlib_modules.is_empty()
             || !self.referenced_error_classes.is_empty()
-            || !self.python_error_rust_types.is_empty()
+            || !self.error_conversions.is_empty()
     }
 
     pub(crate) fn directly_used_stdlib_modules(&self) -> HashSet<String> {
@@ -191,12 +201,11 @@ pub(crate) fn render_support(
             }
         }
     }
-    if demand.runtime.async_python && referenced_error_classes.contains("Error") {
+    if referenced_error_classes.contains("Error") {
         items.extend(
             demand
-                .python_error_rust_types
-                .iter()
-                .map(|rust_type| build_error_into_error_impl(rust_type)),
+                .error_conversions
+                .render(&demand.error_conversion_paths),
         );
     }
 

--- a/crates/sifr_codegen/src/union_type_helpers.rs
+++ b/crates/sifr_codegen/src/union_type_helpers.rs
@@ -191,7 +191,7 @@ impl RustEmitter {
                             name: class.name.clone(),
                             fields: class.fields.clone(),
                             methods: Vec::new(),
-                            parent_class: class.parent_class.clone(),
+                            parent_class: class.semantic_parent_chain(),
                         },
                     ),
                 );

--- a/crates/sifr_driver/src/stdlib/bootstrap.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap.rs
@@ -300,7 +300,7 @@ fn compile_stdlib_sources_with_sysroot(
                         name: class.name.clone(),
                         fields: class.fields.clone(),
                         methods,
-                        parent_class: class.parent_class.clone(),
+                        parent_class: class.semantic_parent_chain(),
                     },
                     &local_classes,
                 );
@@ -419,7 +419,7 @@ fn compile_stdlib_sources_with_sysroot(
                                 name: class.name.clone(),
                                 fields: class.fields.clone(),
                                 methods: Vec::new(),
-                                parent_class: class.parent_class.clone(),
+                                parent_class: class.semantic_parent_chain(),
                             },
                         ),
                     );

--- a/crates/sifr_driver/src/tests/async_python_error_channel.rs
+++ b/crates/sifr_driver/src/tests/async_python_error_channel.rs
@@ -1,0 +1,129 @@
+use super::support::parse_suite;
+use crate::{collect_project_hir_modules, compile_stdlib, type_check_source};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_lowering::{LoweringOptions, PythonBridgeTargetAuthority};
+use sifr_type_system::Type;
+use std::collections::{BTreeMap, HashMap};
+
+const HTTP: &str = include_str!(
+    "../../../../verification/areas/python_interop/fixtures/async_declaration/httpx2_client.sifr"
+);
+const CONTEXT: &str = include_str!(
+    "../../../../verification/areas/python_interop/fixtures/async_context/aiosqlite_session.sifr"
+);
+
+fn check_example(source: &str, bridge_module: &str) -> Vec<sifr_ir::HirDiagnostic> {
+    let stdlib = compile_stdlib().expect("stdlib must compile");
+    sifr_lowering::lower_module_with_externals_name_and_options(
+        "main",
+        &parse_suite(source),
+        &stdlib.defs,
+        LoweringOptions {
+            python_bridge_authorities: BTreeMap::from([(
+                "main".to_string(),
+                PythonBridgeTargetAuthority {
+                    runtime_package: "__sifr_bridge__.p_error_channel_test".to_string(),
+                    modules: [bridge_module.to_string()].into_iter().collect(),
+                },
+            )]),
+            ..LoweringOptions::default()
+        },
+    )
+    .err()
+    .unwrap_or_default()
+}
+
+#[test]
+fn async_python_error_channel_preserves_both_original_examples() {
+    for (source, bridge) in [(HTTP, "client"), (CONTEXT, "session")] {
+        let errors = check_example(source, bridge);
+        assert!(errors.is_empty(), "original async contract: {errors:?}");
+    }
+}
+
+#[test]
+fn async_python_error_channel_rejects_unrelated_return_errors() {
+    for (source, bridge, count) in [(HTTP, "client", 1), (CONTEXT, "session", 3)] {
+        let source = source.replace(
+            "async def main() -> Result[None, Error]:",
+            "async def main() -> Result[None, ValueError]:",
+        );
+        let errors = check_example(&source, bridge);
+        assert_eq!(errors.len(), count, "{errors:?}");
+        assert!(
+            errors.iter().all(|error| {
+                error.code == Some(DiagnosticCode::RESULT_INVALID_RAISE)
+                    && error.message.contains("PythonError")
+            }),
+            "{errors:?}"
+        );
+    }
+}
+
+#[test]
+fn async_python_error_channel_retains_stdlib_ancestry_without_data_parent() {
+    let stdlib = compile_stdlib().expect("stdlib must compile");
+    let error = &stdlib.defs.classes["sifr.python"]["PythonError"];
+    let Type::Class {
+        identity,
+        parent_class,
+        fields,
+        ..
+    } = error
+    else {
+        panic!("PythonError must be a nominal class");
+    };
+    assert_eq!(identity.as_deref(), Some("_sifr.python.PythonError"));
+    assert_eq!(parent_class.as_deref(), Some("Error"));
+    assert_eq!(fields.len(), 5);
+    assert!(fields.iter().all(|(_, ty)| *ty == Type::Str));
+}
+
+#[test]
+fn async_python_error_channel_preserves_local_and_imported_error_ancestry() {
+    let modules = HashMap::from([
+        (
+            "errors".to_string(),
+            parse_suite(
+                "class DomainError(Error):\n    message: str\n\nclass DetailedError(DomainError):\n    detail: str\n\n    def __init__(self, message: str, detail: str):\n        super().__init__(message)\n        self.detail = detail\n",
+            ),
+        ),
+        (
+            "main".to_string(),
+            parse_suite(
+                "from errors import DomainError, DetailedError\n\ndef direct(own error: DomainError) -> Result[None, Error]:\n    raise error\n\ndef inherited(own error: DetailedError) -> Result[None, Error]:\n    raise error\n\ndef main():\n    pass\n",
+            ),
+        ),
+    ]);
+    let stdlib = compile_stdlib().expect("stdlib must compile");
+    let lowered = collect_project_hir_modules(&modules, stdlib.defs)
+        .expect("exported errors must retain their declared ancestry");
+    let root = &lowered.hir_modules["errors"].classes[0];
+    assert!(root.parent_class.is_none());
+    assert!(root.parent_type.is_none());
+    assert_eq!(root.semantic_parent_chain().as_deref(), Some("Error"));
+    assert_eq!(root.fields.len(), 1);
+}
+
+#[test]
+fn async_python_error_channel_rejects_same_named_nominal_target() {
+    let source = "from sifr.python import PythonError\n\nclass Error(ValueError):\n    message: str\n\ndef fail(own error: PythonError) -> Result[None, Error]:\n    raise error\n\ndef main():\n    pass\n";
+    let errors = type_check_source(source);
+    assert!(
+        errors
+            .iter()
+            .any(|error| { error.code == DiagnosticCode::RESULT_INVALID_RAISE.code() }),
+        "same-name target must remain nominal: {errors:?}"
+    );
+}
+
+#[test]
+fn async_python_error_channel_preserves_same_named_stdlib_root_ancestry() {
+    for module in ["sifr.csv", "sifr.configparser"] {
+        let source = format!(
+            "from {module} import Error as ImportedError\n\ndef propagate(own error: ImportedError) -> Result[None, Error]:\n    raise error\n\ndef main():\n    pass\n"
+        );
+        let errors = type_check_source(&source);
+        assert!(errors.is_empty(), "{module}: {errors:?}");
+    }
+}

--- a/crates/sifr_driver/src/tests/async_python_error_channel_native.rs
+++ b/crates/sifr_driver/src/tests/async_python_error_channel_native.rs
@@ -1,0 +1,190 @@
+use super::project_build_check::mktemp_dir;
+use crate::{CompileResult, build, build_project, compile, emit_project};
+use std::path::Path;
+
+fn emitted(result: CompileResult) -> String {
+    match result {
+        CompileResult::Success { rust_source } => rust_source,
+        CompileResult::Errors { errors } => panic!("error conversion must emit: {errors:?}"),
+    }
+}
+
+fn run(binary: &Path) {
+    let output = std::process::Command::new(binary)
+        .output()
+        .expect("run native regression");
+    assert!(output.status.success(), "native regression: {output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "error-conversions-ok"
+    );
+}
+
+#[test]
+fn async_python_error_channel_native_local_and_transitive_conversions() {
+    let source = r#"
+class DomainError(Error):
+    message: str
+
+class DetailedError(DomainError):
+    detail: str
+
+    def __init__(self, message: str, detail: str):
+        super().__init__(message)
+        self.detail = detail
+
+def direct(own error: DomainError) -> Result[None, Error]:
+    raise error
+
+def inherited() -> Result[None, DetailedError]:
+    raise DetailedError("inherited", "detail")
+
+def propagate() -> Result[None, Error]:
+    return inherited()
+
+def main():
+    try:
+        _direct: None = direct(DomainError("direct"))
+        assert False
+    except Error as error:
+        assert error.message == "direct"
+    try:
+        _propagated: None = propagate()
+        assert False
+    except Error as error:
+        assert error.message == "inherited"
+    print("error-conversions-ok")
+"#;
+    let rust = emitted(compile(source));
+    assert!(rust.contains("From<DomainError> for Error"), "{rust}");
+    assert!(rust.contains("From<DetailedError> for Error"), "{rust}");
+    let dir = mktemp_dir("error_channel_local_native");
+    let binary = build(source, &dir).expect("local/transitive errors must compile natively");
+    run(&binary);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn async_python_error_channel_native_stdlib_nominal_collisions() {
+    let source = r#"
+from sifr.csv import Error as CsvError
+from sifr.configparser import Error as ConfigError
+
+def csv(own error: CsvError) -> Result[None, Error]:
+    raise error
+
+def config(own error: ConfigError) -> Result[None, Error]:
+    raise error
+
+def main():
+    try:
+        _csv: None = csv(CsvError("csv"))
+        assert False
+    except Error as error:
+        assert error.message == "csv"
+    try:
+        _config: None = config(ConfigError("config"))
+        assert False
+    except Error as error:
+        assert error.message == "config"
+    print("error-conversions-ok")
+"#;
+    let rust = emitted(compile(source));
+    for identity in ["sifr.csv.Error", "sifr.configparser.Error"] {
+        let name = sifr_type_system::class_rust_name(Some(identity), "Error");
+        assert_eq!(
+            rust.matches(&format!("From<{name}> for Error")).count(),
+            1,
+            "{rust}"
+        );
+    }
+    let dir = mktemp_dir("error_channel_stdlib_native");
+    let binary = build(source, &dir).expect("distinct stdlib errors must compile natively");
+    run(&binary);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn async_python_error_channel_native_project_aliases_and_collisions() {
+    let dir = mktemp_dir("error_channel_project_native");
+    for (name, source) in [
+        (
+            "left",
+            "class DomainError(Error):\n    message: str\n\nclass DetailedError(DomainError):\n    detail: str\n\n    def __init__(self, message: str, detail: str):\n        super().__init__(message)\n        self.detail = detail\n",
+        ),
+        ("right", "class DomainError(Error):\n    message: str\n"),
+        ("api", "from left import DomainError as PublicError\n"),
+        ("shadow", "class ValueError(Error):\n    message: str\n"),
+        (
+            "main",
+            r#"
+from api import PublicError as LeftError
+from left import DetailedError as LeftDetailedError
+from right import DomainError as RightError
+from shadow import ValueError as ShadowError
+
+def left(own error: LeftError) -> Result[None, Error]:
+    raise error
+
+def right(own error: RightError) -> Result[None, Error]:
+    raise error
+
+def detailed(own error: LeftDetailedError) -> Result[None, Error]:
+    raise error
+
+def shadow(own error: ShadowError) -> Result[None, Error]:
+    raise error
+
+def main():
+    try:
+        _left: None = left(LeftError("left"))
+        assert False
+    except Error as error:
+        assert error.message == "left"
+    try:
+        _right: None = right(RightError("right"))
+        assert False
+    except Error as error:
+        assert error.message == "right"
+    try:
+        _detailed: None = detailed(LeftDetailedError("detailed", "detail"))
+        assert False
+    except Error as error:
+        assert error.message == "detailed"
+    try:
+        _shadow: None = shadow(ShadowError("shadow"))
+        assert False
+    except Error as error:
+        assert error.message == "shadow"
+    print("error-conversions-ok")
+"#,
+        ),
+    ] {
+        std::fs::write(dir.join(format!("{name}.sifr")), source).expect("write source");
+    }
+    let main = dir.join("main.sifr");
+    let rust = emitted(emit_project(
+        &main,
+        &mut sifr_frontend::DiskSourceProvider::new(),
+    ));
+    for name in [
+        "crate::left::DomainError",
+        "crate::left::DetailedError",
+        "crate::right::DomainError",
+        "crate::shadow::ValueError",
+    ] {
+        assert_eq!(
+            rust.matches(&format!("From<{name}> for Error")).count(),
+            1,
+            "{rust}"
+        );
+    }
+    let binary = build_project(
+        &main,
+        &dir.join("out"),
+        &mut sifr_frontend::DiskSourceProvider::new(),
+    )
+    .expect("project error identities must compile natively");
+    run(&binary);
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod adapter_defaults;
 mod async_python_error_channel;
+mod async_python_error_channel_native;
 mod attached_api_aliases;
 mod attached_api_audit;
 mod attached_api_codegen;

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod adapter_defaults;
+mod async_python_error_channel;
 mod attached_api_aliases;
 mod attached_api_audit;
 mod attached_api_codegen;

--- a/crates/sifr_frontend/src/callable_identities.rs
+++ b/crates/sifr_frontend/src/callable_identities.rs
@@ -533,7 +533,7 @@ fn class_type(module_name: &str, class: &HirClass) -> Type {
         name: class.name.clone(),
         fields: class.fields.clone(),
         methods: Vec::new(),
-        parent_class: class.parent_class.clone(),
+        parent_class: class.semantic_parent_chain(),
     }
 }
 

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -321,11 +321,15 @@ pub fn collect_module_exports(
                         name: class.name.clone(),
                         fields: exported_class_fields(class),
                         methods,
-                        parent_class: exported_parent_chain(
-                            class.parent_class.as_deref(),
-                            module,
-                            &imported_ancestry,
-                        ),
+                        parent_class: if class.is_error_type {
+                            class.semantic_parent_chain()
+                        } else {
+                            exported_parent_chain(
+                                class.parent_class.as_deref(),
+                                module,
+                                &imported_ancestry,
+                            )
+                        },
                     },
                 }
             };

--- a/crates/sifr_frontend/src/slot_table.rs
+++ b/crates/sifr_frontend/src/slot_table.rs
@@ -408,7 +408,7 @@ fn owner_type_for_identity(
                 name: class.name.clone(),
                 fields: class.fields.clone(),
                 methods: Vec::new(),
-                parent_class: class.parent_class.clone(),
+                parent_class: class.semantic_parent_chain(),
             });
         }
     }

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -50,7 +50,7 @@ pub(crate) fn run_specializations(
             name: class.name.clone(),
             fields: class.fields.clone(),
             methods: Vec::new(),
-            parent_class: class.parent_class.clone(),
+            parent_class: class.semantic_parent_chain(),
         };
         if !class.type_params.is_empty() {
             errors.push(malformed(

--- a/crates/sifr_ir/src/class_ancestry.rs
+++ b/crates/sifr_ir/src/class_ancestry.rs
@@ -1,0 +1,31 @@
+use crate::HirClass;
+use sifr_type_system::Type;
+
+impl HirClass {
+    /// Nominal ancestry for type checking, separate from the stored data parent.
+    /// The builtin Error marker has no embedded parent field.
+    #[must_use]
+    pub fn semantic_parent_chain(&self) -> Option<String> {
+        if !self.is_error_type {
+            return self.parent_class.clone();
+        }
+        if let Some(Type::Class {
+            identity,
+            name,
+            parent_class,
+            ..
+        }) = self.parent_type.as_ref().map(Type::resolve_alias)
+        {
+            let parent = identity.as_ref().unwrap_or(name);
+            return Some(match parent_class {
+                Some(chain) => format!("{parent}|{chain}"),
+                None => parent.clone(),
+            });
+        }
+        Some(
+            self.parent_class
+                .clone()
+                .unwrap_or_else(|| "Error".to_string()),
+        )
+    }
+}

--- a/crates/sifr_ir/src/lib.rs
+++ b/crates/sifr_ir/src/lib.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 pub mod cfg;
+mod class_ancestry;
 pub mod diagnostic_types;
 pub mod flow_graph;
 mod hir_expr;

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -306,7 +306,7 @@ pub(in crate::lower) fn collect_class_type(
     // Inherit parent fields and methods for single inheritance
     let parent_class_name =
         crate::lower::descriptor_declarations::data_parent_name(&class_name, ctx);
-    let mut parent_class_chain: Option<String> = None;
+    let mut parent_class_chain = is_error.then(|| "Error".to_string());
     let mut inherited_field_defaults = Vec::new();
     if let Some(ref parent_name) = parent_class_name {
         if let Some(parent_ty) =

--- a/crates/sifr_lowering/src/lower/imported_class_identity.rs
+++ b/crates/sifr_lowering/src/lower/imported_class_identity.rs
@@ -480,6 +480,11 @@ fn set_canonical_identities(ty: &mut Type, local_classes: &HashMap<String, Strin
                         .map(|parent| {
                             local_classes
                                 .get(parent)
+                                // A same-named base refers to the prior declaration
+                                // (notably builtin Error), never the class itself.
+                                .filter(|parent_identity| {
+                                    Some(*parent_identity) != identity.as_ref()
+                                })
                                 .map_or_else(|| parent.to_string(), Clone::clone)
                         })
                         .collect::<Vec<_>>()

--- a/demos/error_safety/emitted.rs
+++ b/demos/error_safety/emitted.rs
@@ -73,6 +73,11 @@ mod sifr_generated_project_nominals {
             Self::new(err.message)
         }
     }
+    impl From<crate::AppError> for Error {
+        fn from(err: crate::AppError) -> Self {
+            Self::new(err.message)
+        }
+    }
 }
 pub use sifr_generated_project_nominals::DivisionError;
 pub use sifr_generated_project_nominals::Error;

--- a/demos/stdlib/emitted.rs
+++ b/demos/stdlib/emitted.rs
@@ -2574,6 +2574,11 @@ mod sifr_generated_project_nominals {
             Self::new(err.message)
         }
     }
+    impl From<SifrGeneratedStdlibSifrX2egraphlibX2eCycleError> for Error {
+        fn from(err: SifrGeneratedStdlibSifrX2egraphlibX2eCycleError) -> Self {
+            Self::new(err.message)
+        }
+    }
 }
 pub use sifr_generated_project_nominals::Error;
 pub use sifr_generated_project_nominals::FloatOverflowError;

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -193,9 +193,9 @@ It does not broaden the active item.
 | 12C | incorporated into 12B | Builtin-registration Clippy blocker | No independent item, review, or gate remains. |
 | 12D | recorded, not started | Native corpus emission dependencies | Adjudicate checked-read control flow and the complete native diagnostic inventory before Item 12B closure. |
 | 12G | merged | Dependency-checker demo path identity | Authoritative DLPack project path and computed-reference regressions merged in PR #3695; exact-SHA validation and Opus review passed. |
-| 12H | authorized: after 12G handoff | Project-wide generated-field identity | Repair declaration/consumer naming consistency across generated files. |
-| 12I | authorized: after 12H handoff | Macro-defined project support visibility | Repair cancellation task-local visibility without blanket exports. |
-| 12J | authorized: after 12I handoff | Async Python error-channel contract | Resolve the authoritative error contracts and preserve async semantics. |
+| 12H | blocked: reviewed candidate preserved | Project-wide generated-field identity | Draft #3697, reviewed `9b52ac20094608c8a31f252db99e49ef7c963384`; sole gate failed SQL coverage. Retained record `b6e6210a97598fb631b929b2d4daf4012b41bb16` owns details and follow-ups. |
+| 12I | blocked: reviewed candidate preserved | Macro-defined project support visibility | Draft #3698, reviewed `f6e8afd964bb214a44c50271dcb2014ee8e828b4`; sole gate failed SQL coverage. Retained record `19ad69969a672d7b741122ded4dd879f2bdaf9ab` owns details and follow-ups. |
+| 12J | implementing | Async Python error-channel contract | Preserve declared error ancestry separately from descriptor data parents; retain original async fixtures and error contracts. |
 | 12K | authorized: integration after dependency qualification | Item 12B and Python dependency integration | Qualify the integrated candidate and merge the preserved work; do not reset Item 12B review history. |
 | 12A | pending | Phase closure and whole-phase review | Review the fully merged phase once, reconcile architecture/roadmap/evidence, and archive only when no actionable row remains. |
 

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -1678,3 +1678,120 @@ companion freshness checks and reached guardrails, then reproduced the
 existing SQL coverage-classification blocker. Logs are under
 `target/demo-name-followup/`. Existing Clippy baseline debt and its unresolved
 migration were not refreshed.
+
+### 2026-09-06 Item12J-M1 orchestration scope
+
+The 12J-R1 worker is closed. Draft PR #3699 preserves implementation
+`4bc432f3474134b1a1d43202d39fd147893bb014` and record
+`c430ed3331169f06eb148122f681e7d2a457d2ee` in
+`/private/tmp/sifr-item12j-r1.9j9Uhf/sifr`. Its terminal evidence and the
+separate Item12J-M1 mechanism are recorded in that commit's Python dependency
+issue. Nine focused and 587 driver tests pass, but the second review is
+NOT SATISFIED. Neither 12J nor R1 is qualified; no gate or merge occurred.
+
+Assign one fresh worker to 12J-M1, before integration. Its dependencies are the
+preserved candidate, both review findings, and the existing nominal error
+language/representation contract. First establish that contract from repository
+authorities. Then repair the distinct message-storage and conversion-demand
+mechanism: an unrelated root Error reference must not generate invalid unused
+conversions for specific errors; legitimate root upcasts must have sound native
+representations. Cover absent, integer, own-string and inherited message storage,
+with specific and root channels, local/imported identities and project modes.
+Preserve previously valid specific-error programs. Do not invent a message
+fallback, silently narrow accepted language, or weaken fixtures. If the existing
+contract cannot decide a necessary language behavior, return needs-new-scope
+with the precise user choice before implementing that policy.
+
+This is a separately bounded mechanism item under the user's instruction to
+record second-review defects as later work. It does not reopen 12J/R1 for a
+third review or waive the repeated, unresolved conversion obligation. M1 has
+one initial exact-SHA review and at most one remediation review, limited to
+this contract/mechanism and its interactions, and one final-candidate merge
+gate if approval and prerequisite qualification permit. Preserve every prior
+failed review/gate and do not present a changed scope as approval of old code.
+
+Named validation: `cargo test -p sifr_driver async_python_error_channel`,
+`cargo test -p sifr_codegen`, `cargo test -p sifr_driver`,
+`cargo build --locked -p sifr`, demo freshness update/check with that compiler,
+the original `async-declaration-examples` and `async-context-examples` Python
+interop command, `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`,
+HIR and file-size guards, and the single `scripts/run_all_tests.sh --profile merge`.
+Register focused named regressions before testing; reuse unchanged evidence.
+If a frontend/lowering/IR change is necessary to this representation contract,
+register its affected original Item12J crate test command before implementation.
+Implement the complete bounded correction before testing. Keep 12I native
+qualification, 12B/12C, SQL coverage, TypeVar #3667, and other follow-ups outside
+this worker. Preserve an approved candidate for 12K if an external dependency
+prevents standalone merge; never integrate an unapproved candidate as-is.
+
+### Item12J-M1 contract adjudication handoff (2026-09-06)
+
+State: **needs-new-scope; not implemented, not reviewed, not merged**.
+The section above was copied verbatim from the parent's new orchestration
+scope, preserving all historical records in retained record `c430ed3331169f06eb148122f681e7d2a457d2ee`.
+This session owns the independent checkout `/private/tmp/sifr-item12j-m1.VO82Kk/sifr`
+and branch `codex/emitted-rust-excellence-item-12j-m1`. It retains all original
+12J/R1 commits. The parent and the two closed worker worktrees, indexes, targets,
+and evidence were read only. Fetched latest main remains
+`4ce05473f58716a611ac190581bf0737ba15331e`; there are no intervening base changes.
+Draft [PR #3699](https://github.com/sifr-lang/sifr/pull/3699) remains unapproved.
+
+Repository contract evidence at the retained candidate:
+
+- `internal_docs/architecture.md:762-769,829-864` says every error inherits
+  `message: str`, supplied by a user error's constructor. `AppError(Error): pass`
+  is documented as accepting a message. No absent-message initialization or
+  integer-message root projection is specified.
+- `docs/language/error-handling.mdx:31-46` describes custom errors as plain
+  structs with typed fields; examples declare their own string message. It
+  does not decide message-less upcasts.
+- `crates/sifr_type_system/src/types/error_contracts.rs:9-24` recognizes root
+  Error only with exactly one string `message`; codegen's
+  `preamble/types_and_errors.rs:367-410` stores that string and requires it in
+  `new`. Root storage cannot represent an absent message today.
+- `crates/sifr_lowering/src/lower/descriptor_declarations.rs:341-350,460-465` treats
+  Error as a special base, bypassing ordinary embedded-parent storage.
+  `classes/class_type_collection.rs:304-309` retains an unimplemented comment
+  promising message insertion; `:863-875` actually derives the default
+  constructor from collected fields. This explains accepted `CodeError(3)`,
+  `EmptyError()`, and integer `message` declarations without supplying a
+  hidden root string.
+- `crates/sifr_codegen/src/class_emitter.rs:460-475` can format a specific
+  error's own message (including integers), or use Debug when absent. That
+  existing Display rule does not say a root upcast must store this formatting
+  as its message. Treating it as conversion policy would be a new decision,
+  including for inherited/custom formatting.
+- `error_refs/conversions.rs:99-130` and `preamble/error_conversion.rs:17-23`
+  assume a field and string type that ancestry does not establish. Suppressing
+  invalid unused impls alone leaves the accepted explicit root upcast broken.
+
+The [R1 review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5556273003)
+already supplies exact-binary evidence: the own-channel code-only example built
+before R1 and now fails E0609 when unrelated code mentions Error; explicit
+root upcasts check successfully but fail native E0277 before R1 / E0609 after.
+Absent and integer message cases fail too. No additional compiler probe was run.
+
+Required owner/user decision (none selected by this worker):
+
+| Contract direction | Concrete behavior and tradeoff |
+| --- | --- |
+| Enforce inherited required string storage | Require a message in every error constructor and reject incompatible field overrides. This follows the documented architecture, but changes accepted `CodeError(3)`, `EmptyError()`, and `message: int` programs; explicit authorization must relax M1's preservation requirement. |
+| Define root conversion from existing Display | Preserve specific constructors and define the root string for message-less/integer errors from their existing Display output, while retaining real string storage where present. Requires an explicit new conversion policy for own/inherited/custom formatting, allocation, and observable root messages; it is not authorized as a fallback. |
+| Allow root errors without a string message | Preserve message-less structured payloads through a new root representation and define absent-message access/formatting and field collisions. This changes the root language/API contract and has substantially wider compiler/runtime/interop scope. |
+
+Do not choose rejection, default text, blanket formatting, or a new root
+representation implicitly. Resume only after the contract direction and its
+scope adjustment are explicit. The complete correction, reaching regression
+registration, named compiler/native validation, review, and gate are **unreached**.
+M1 used zero Opus reviews and zero gates; old 12J's two NOT SATISFIED reviews
+remain exhausted. No approved implementation SHA exists for M1.
+
+Only the phase and Python dependency Markdown records change. Documentation
+diff checking and the named file-size guard are recorded in external evidence
+`/private/tmp/sifr-item12j-m1.VO82Kk/evidence.md`, which will identify the final
+record SHA. Prior unchanged-input evidence remains historical evidence for
+unapproved `4bc432f3474134b1a1d43202d39fd147893bb014`, not an M1 pass:
+focused 9 / driver 587 pass; codegen two 12B failures; strict Clippy 12B/12C
+failure; native async suites blocked by 12I E0425 with runtime assertions
+unreached; lowering two #3667 failures. SQL and other integration dependencies
+remain separately owned. No next item or integration work was started.

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -196,6 +196,7 @@ It does not broaden the active item.
 | 12H | blocked: reviewed candidate preserved | Project-wide generated-field identity | Draft #3697, reviewed `9b52ac20094608c8a31f252db99e49ef7c963384`; sole gate failed SQL coverage. Retained record `b6e6210a97598fb631b929b2d4daf4012b41bb16` owns details and follow-ups. |
 | 12I | blocked: reviewed candidate preserved | Macro-defined project support visibility | Draft #3698, reviewed `f6e8afd964bb214a44c50271dcb2014ee8e828b4`; sole gate failed SQL coverage. Retained record `19ad69969a672d7b741122ded4dd879f2bdaf9ab` owns details and follow-ups. |
 | 12J | blocked: unapproved candidate preserved | Async Python error-channel contract | Draft #3699, reviewed `f720a342edd87004975355b478948f7eb5c8b406` NOT SATISFIED (12J-R1); native suites blocked by 12I. Terminal handoff at user checkpoint, zero remediation reviews and zero gates used. |
+| 12J-R1 | in progress: remaining remediation | Complete Item 12J non-builtin error conversions | Connect semantic error ancestry to conversion demand without resetting Item 12J's review or gate budget. |
 | 12K | authorized: integration after dependency qualification | Item 12B and Python dependency integration | Qualify the integrated candidate and merge the preserved work; do not reset Item 12B review history. |
 | 12A | pending | Phase closure and whole-phase review | Review the fully merged phase once, reconcile architecture/roadmap/evidence, and archive only when no actionable row remains. |
 
@@ -678,6 +679,35 @@ integration.** Owned branch `codex/emitted-rust-excellence-item-12j`, worktree
   owns12J-R1 and separate12J-F1–F3 follow-ups. A separately assigned continuation
   must resolve12J-R1 and preserve the remaining one-remediation/one-gate caps.
   12K integration and all next-item implementation remain unstarted by this worker.
+
+### 2026-09-06 dependency handoff and bounded remediation
+
+12G is merged (PRs #3695/#3696). 12H and 12I are approved but unmerged
+candidates in draft PRs #3697/#3698; their sole gates failed externally owned
+SQL coverage classifications. Their complete handoffs and deferred findings
+remain in record commits `b6e6210a97598fb631b929b2d4daf4012b41bb16` and
+`19ad69969a672d7b741122ded4dd879f2bdaf9ab`.
+
+12J is unapproved, not merged: draft PR #3699, implementation
+`f720a342edd87004975355b478948f7eb5c8b406`, record
+`60219b080eadb519a813d9a84568552824be0754`. Its initial review found missing
+non-builtin error conversions (12J-R1); native async validation also depends
+on 12I. The original worker is closed. Assign a fresh worker to 12J-R1 before
+12K. This is the remaining remediation of 12J, not a new initial-review cycle.
+
+12J-R1 scope: connect semantic error ancestry to conversion demand for local,
+project-imported and stdlib errors, preserving nominal identity and the original
+runtime/error contract. Dependencies are the preserved 12J candidate and its
+initial review; 12I remains a separate native qualification dependency.
+Use the exact named validation in the Python owner issue at record `60219b0`,
+including `cargo test -p sifr_driver async_python_error_channel` and the
+`async-declaration-examples`/`async-context-examples` suites. Register focused
+emission/compilation regressions before testing. Finish this in-scope correction
+without absorbing known external failures. At most one remediation review and
+one final-candidate merge gate remain for 12J; no third review or budget reset.
+If external qualification still blocks merge, preserve the corrected reviewed
+candidate for 12K. New second-review mechanism defects become later bounded
+items. Do not integrate the unapproved 12J candidate as-is.
 
 ### Item 12B: Bounded algorithmic dependency repair
 

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -195,8 +195,9 @@ It does not broaden the active item.
 | 12G | merged | Dependency-checker demo path identity | Authoritative DLPack project path and computed-reference regressions merged in PR #3695; exact-SHA validation and Opus review passed. |
 | 12H | blocked: reviewed candidate preserved | Project-wide generated-field identity | Draft #3697, reviewed `9b52ac20094608c8a31f252db99e49ef7c963384`; sole gate failed SQL coverage. Retained record `b6e6210a97598fb631b929b2d4daf4012b41bb16` owns details and follow-ups. |
 | 12I | blocked: reviewed candidate preserved | Macro-defined project support visibility | Draft #3698, reviewed `f6e8afd964bb214a44c50271dcb2014ee8e828b4`; sole gate failed SQL coverage. Retained record `19ad69969a672d7b741122ded4dd879f2bdaf9ab` owns details and follow-ups. |
-| 12J | blocked: unapproved candidate preserved | Async Python error-channel contract | Draft #3699, reviewed `f720a342edd87004975355b478948f7eb5c8b406` NOT SATISFIED (12J-R1); native suites blocked by 12I. Terminal handoff at user checkpoint, zero remediation reviews and zero gates used. |
-| 12J-R1 | in progress: remaining remediation | Complete Item 12J non-builtin error conversions | Connect semantic error ancestry to conversion demand without resetting Item 12J's review or gate budget. |
+| 12J | blocked: both reviews exhausted, unapproved | Async Python error-channel contract | Draft #3699 preserves final reviewed candidate `4bc432f3474134b1a1d43202d39fd147893bb014`; initial and remediation reviews are NOT SATISFIED. No gate or merge. Message-storage follow-up 12J-M1 requires adjudication; 12I remains external. |
+| 12J-R1 | blocked: second-review mechanism defect | Complete Item 12J non-builtin error conversions | Named local/project/stdlib native regressions pass, but the sole remediation review found invalid demand for errors without a string message and a remaining accepted-upcast omission. Stop; no third review or gate. |
+| 12J-M1 | recorded: requires adjudication, not started | Error message storage and root-upcast admissibility | Resolve the second-review storage/demand defect and remaining conversion contract without breaking valid specific-error channels or resetting 12J's exhausted review budget. |
 | 12K | authorized: integration after dependency qualification | Item 12B and Python dependency integration | Qualify the integrated candidate and merge the preserved work; do not reset Item 12B review history. |
 | 12A | pending | Phase closure and whole-phase review | Review the fully merged phase once, reconcile architecture/roadmap/evidence, and archive only when no actionable row remains. |
 
@@ -708,6 +709,61 @@ one final-candidate merge gate remain for 12J; no third review or budget reset.
 If external qualification still blocks merge, preserve the corrected reviewed
 candidate for 12K. New second-review mechanism defects become later bounded
 items. Do not integrate the unapproved 12J candidate as-is.
+
+### Item12J-R1 terminal handoff (2026-09-06)
+
+State: **blocked, NOT APPROVED, NOT MERGED**. Draft
+[PR #3699](https://github.com/sifr-lang/sifr/pull/3699) retains reviewed
+implementation `4bc432f3474134b1a1d43202d39fd147893bb014`, following preserved
+`f720a342` / record `60219b0` and remediation implementation `3ba19e49a`.
+Owned worktree `/private/tmp/sifr-item12j-r1.9j9Uhf/sifr`, branch
+`codex/emitted-rust-excellence-item-12j-r1`. The PR was updated by normal
+fast-forward push; the original worker's rollback worktree and parent index/
+intentional dirty documents remain unchanged. Base is still main
+`4ce05473f58716a611ac190581bf0737ba15331e`.
+
+- Final-candidate focused regressions: **9 pass**, including emission, native
+  build and execution for local/transitive errors, project aliases/transitive
+  errors/same-basename identities/builtin-name shadows, and distinct CSV and
+  configparser Error classes. Full driver: **587 pass, 77 existing ignored**.
+- All **264 companions are fresh**; only `demos/error_safety/emitted.rs` and
+  `demos/stdlib/emitted.rs` were regenerated. Formatting, HIR and file-size
+  checks pass (3758 files, 900-line cap). No original Sifr fixture, lockfile,
+  workflow, runtime assertion, architecture or roadmap change was made.
+- Codegen remains **1407 pass / 2 pre-existing 12B list-repeat failures**.
+  Strict Clippy fails only at the unchanged 12B/12C-owned
+  `project_stdlib_nominals.rs:45` expect. Unchanged original IR/frontend passes
+  and #3667-owned lowering failures are reused with explicit input provenance.
+- Both original named async suites fail native build at the **12I-owned
+  cancellation task-local E0425** (HTTP one Rust error; context 58, with retained
+  E0425 stderr tail). Neither runtime marker was observed; cleanup/cancellation
+  runtime preservation remains unqualified. No external repair was absorbed.
+- The [sole remediation Opus review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5556273003)
+  returned **NOT SATISFIED**. New mechanism: broad nominal demand emits
+  `Self::new(err.message)` even for errors without a string message, including
+  errors never converted to the root Error. The reviewer verified a previously
+  compiling `CodeError(Error)` with only `code: int` now fails E0609 merely when
+  an unrelated function mentions Error. Empty errors and `message: int` also
+  fail. Accepted message-less root upcasts remain uncompilable (E0277 before R1,
+  E0609 now), so the original conversion obligation also remains unresolved.
+- This is later bounded **Item12J-M1**, owned by nominal error representation
+  and conversion-demand/ancestry admissibility. The
+  [Python owner record](ad-hoc-python-interop-qualification-dependencies.md#later-item12j-m1-error-message-storage-and-root-upcast-admissibility)
+  records its scope and the required adjudication. No later-item code was
+  written. The review's mapping-cleanup suggestion is separate 12J-F5.
+- Cumulative Item12J budget: **one initial review + one remediation review used;
+  both NOT SATISFIED. Zero create-PR gates, zero merge-profile gates, no merge.**
+  The user's second-review stop rule prevents another fix/review cycle. The
+  unused gate was not run without an approved candidate. Do not integrate this
+  candidate as-is or reset any original review/gate history.
+
+Exact evidence is preserved outside the reviewed Git tree at
+`/private/tmp/sifr-item12j-r1.9j9Uhf/evidence-4bc432f3474134b1a1d43202d39fd147893bb014.md`,
+with SHA-keyed review and native JSON reports. The compiler hash is
+`12adc00c7d5111550f893a20b1b3c3936ece888a13e3bf14b22e67f2d4e7fe09`.
+The final handoff is documentation-only and receives no extra review or gate.
+Next action: adjudicate 12J-M1 and the unresolved conversion obligation before
+any 12J qualification/integration; this worker stops after publishing records.
 
 ### Item 12B: Bounded algorithmic dependency repair
 

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -195,7 +195,7 @@ It does not broaden the active item.
 | 12G | merged | Dependency-checker demo path identity | Authoritative DLPack project path and computed-reference regressions merged in PR #3695; exact-SHA validation and Opus review passed. |
 | 12H | blocked: reviewed candidate preserved | Project-wide generated-field identity | Draft #3697, reviewed `9b52ac20094608c8a31f252db99e49ef7c963384`; sole gate failed SQL coverage. Retained record `b6e6210a97598fb631b929b2d4daf4012b41bb16` owns details and follow-ups. |
 | 12I | blocked: reviewed candidate preserved | Macro-defined project support visibility | Draft #3698, reviewed `f6e8afd964bb214a44c50271dcb2014ee8e828b4`; sole gate failed SQL coverage. Retained record `19ad69969a672d7b741122ded4dd879f2bdaf9ab` owns details and follow-ups. |
-| 12J | implementing | Async Python error-channel contract | Preserve declared error ancestry separately from descriptor data parents; retain original async fixtures and error contracts. |
+| 12J | blocked: unapproved candidate preserved | Async Python error-channel contract | Draft #3699, reviewed `f720a342edd87004975355b478948f7eb5c8b406` NOT SATISFIED (12J-R1); native suites blocked by 12I. Terminal handoff at user checkpoint, zero remediation reviews and zero gates used. |
 | 12K | authorized: integration after dependency qualification | Item 12B and Python dependency integration | Qualify the integrated candidate and merge the preserved work; do not reset Item 12B review history. |
 | 12A | pending | Phase closure and whole-phase review | Review the fully merged phase once, reconcile architecture/roadmap/evidence, and archive only when no actionable row remains. |
 
@@ -643,6 +643,41 @@ artifact hashes, package ownership, and missing-input errors remain enforced.
   Helmholtz's retained candidate/index were not modified.
 - Blocker: none. Item12G is complete. Stop this worker after the record update;
   the orchestrator may assign Item12H to a fresh worker. No next-item code was written.
+
+### Item12J terminal handoff (2026-09-06)
+
+Draft [PR #3699](https://github.com/sifr-lang/sifr/pull/3699) preserves candidate
+`f720a342edd87004975355b478948f7eb5c8b406`, based on freshly fetched main
+`4ce05473f58716a611ac190581bf0737ba15331e`. **Not merged; not approved for
+integration.** Owned branch `codex/emitted-rust-excellence-item-12j`, worktree
+`/private/tmp/sifr-item12j.pT6Xkk/sifr`; parent records/index and retained
+12B/12H/12I worktrees were not mutated.
+
+- The ancestry repair preserves the original async fixtures and removes their
+  source-check failures. Six focused regressions, IR (4), frontend (132 unit +
+  7 integration), and driver (584 passed, 77 existing ignored) pass. All 264
+  generated companions remain byte-identical; fmt, HIR and file-size guards pass.
+- Both named native suites fail at 12I-owned cancellation task-local visibility
+  E0425 after source checking; runtime assertions did not execute. Lowering
+  retains two TypeVar assertion failures owned by #3667; codegen retains two
+  12B-owned list-repeat failures; strict Clippy fails on the preserved12B/12C
+  builtin-registration expect. None is a passing command or full certification.
+- The [initial exact-SHA Opus review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5555927728)
+  is **NOT SATISFIED**: 12J-R1, the newly accepted non-builtin error ancestry lacks
+  generated `From<T> for Error` conversions. Opus reproduced E0277 for a local
+  DomainError and imported CSV Error. This is an unresolved in-scope omission,
+  not an external blocker to be waived. No remediation code was written.
+- [Validation/terminal receipt and changed paths](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5555929816)
+  are keyed to the candidate outside the Git tree. Raw logs, JSON reports and
+  review are retained in `/private/tmp/sifr-item12j.pT6Xkk/`.
+- The user's orchestration checkpoint required terminal handoff once an external
+  blocker was established. Stop after these records; remediation reviews used
+  **0**, merge-profile gates **0**, create-PR gates **0**. There is no final
+  reviewer-approved candidate to gate. No review/gate history is reset.
+- The [Python owner record](ad-hoc-python-interop-qualification-dependencies.md#item12j-terminal-evidence-and-unresolved-review)
+  owns12J-R1 and separate12J-F1–F3 follow-ups. A separately assigned continuation
+  must resolve12J-R1 and preserve the remaining one-remediation/one-gate caps.
+  12K integration and all next-item implementation remain unstarted by this worker.
 
 ### Item 12B: Bounded algorithmic dependency repair
 

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -287,16 +287,99 @@ under the R1 evidence root contain the diagnostics. The final native collision
 case uses `ValueError(Error)` and retains the original negative Error-target
 test. This source ancestry issue is not repaired by the conversion item.
 
+## Item12J-R1 terminal evidence (2026-09-06)
+
+State: **blocked, unapproved, not merged**. Draft
+[PR #3699](https://github.com/sifr-lang/sifr/pull/3699) preserves reviewed
+implementation `4bc432f3474134b1a1d43202d39fd147893bb014` on the original base
+`4ce05473f58716a611ac190581bf0737ba15331e`. History retains original `f720a342`,
+record `60219b0`, R1 implementation `3ba19e49a`, then its one-line Clippy fix.
+The final record is a separate documentation-only commit. Original/parent
+worktrees and indexes remain untouched; only the existing PR branch was
+fast-forwarded from this isolated worker's branch.
+
+Final candidate evidence, outside the reviewed tree:
+`/private/tmp/sifr-item12j-r1.9j9Uhf/evidence-4bc432f3474134b1a1d43202d39fd147893bb014.md`.
+Compiler SHA256:
+`12adc00c7d5111550f893a20b1b3c3936ece888a13e3bf14b22e67f2d4e7fe09`.
+
+- Focused command: 9 pass, including all three emission/native build/run groups
+  and the transitive imported case. Full driver: 587 pass, 77 existing ignored.
+- Build, formatting, HIR, canonical file-size guard (3758 files) and freshness
+  of all 264 companions pass. Two companions were producer-regenerated; no
+  original fixture, lockfile, workflow, assertion or runtime contract was edited.
+- Codegen: 1407 pass / 2 existing 12B list-repeat failures. Strict Clippy retains
+  only the 12B/12C `project_stdlib_nominals.rs:45` expect failure. Original
+  unchanged-input IR4 and frontend132+7 passes, and lowering1114 pass /2 stale
+  TypeVar assertions /1 ignored (#3667), are explicitly reused, not rerun passes.
+- Both exact named async suites exit 1 at 12I-owned native task-local E0425.
+  HTTP reports one Rust error; context 58, with a retained E0425 tail. Runtime
+  output markers are false for both. No native async runtime pass or complete
+  area certification is claimed. SHA-keyed JSON archives and logs are retained.
+- The [only remaining remediation review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5556273003)
+  returned **NOT SATISFIED**. Its full response is
+  `review-4bc432f3474134b1a1d43202d39fd147893bb014.md` under the evidence root,
+  SHA256 `ab616b0a0917bac3c269ece9f24ea9d82f0bb7124f685241ac860af6a34e8b42`.
+  It verified the new message-storage mechanism defect and remaining conversion
+  omission described in Item12J-M1 below. No third review or post-review code
+  repair was attempted.
+- Cumulative 12J allowance consumed: one initial review and one remediation
+  review, both NOT SATISFIED; zero create-PR gates and zero merge-profile gates.
+  There is no approved final candidate to gate or merge. The unused gate is not
+  a new review allowance. All 12B/12H/12I histories remain unchanged.
+
+## Later Item12J-M1: error message storage and root-upcast admissibility
+
+Status: recorded only; requires adjudication, not started by R1.
+Owners: nominal error representation, error conversion demand, ancestry
+admissibility. This is a new second-review mechanism, not a third R1 review.
+
+The sole remediation review found two related blocking consequences at
+`crates/sifr_codegen/src/error_refs/conversions.rs:99-130`, using
+`preamble/error_conversion.rs:17-23` and the broadened render guard in
+`support_plan.rs:204`:
+
+1. **New regression:** `class CodeError(Error): code: int`, raised only into its
+   own `Result[None, CodeError]` channel, compiled before R1. Adding an unrelated
+   function returning `Result[None, Error]` now demands an invalid
+   `From<CodeError> for Error` whose body reads absent `err.message`, producing
+   E0609. The reviewer verified native success with preserved compiler
+   `36640bf...9b61940` and failure with the exact candidate compiler above.
+   `class EmptyError(Error): pass` and `message: int` similarly expose absent or
+   non-string storage (E0609/E0308). These classes need not be upcast themselves
+   for the regression to occur.
+2. **Remaining in-scope omission:** explicitly raising that CodeError into
+   `Result[None, Error]` source-checks on both original 12J and R1. Native build
+   changes from E0277 to E0609, not to success. The original obligation remains
+   unresolved for this representation, so repeated-finding adjudication is
+   required in addition to recording the new mechanism.
+
+Later bounded work must establish a shared, typed message-storage/conversion
+contract: own string message versus consuming a valid ancestor conversion,
+without assuming a `message` field from ancestry alone. Preserve previously
+compiling specific-error channels; do not emit invalid unused conversions when
+an unrelated Error reference appears. Reconcile root-Error source admissibility
+with actual conversion ability instead of accepting backend-invalid programs.
+Register emission and native compilation regressions for absent, non-string,
+and inherited message storage, inside and outside root-Error channels. No
+invented message fallback, fixture weakening or unrelated dependency repair is
+authorized by this record. Resolve the contract/adjudication before defining
+any later item's review/gate allowance; do not reset 12J's two consumed reviews.
+
+Separate non-blocking **12J-F5**, owner codegen nominal-path mapping: the review
+suggests consolidating `render()`'s ancestor-name derivation with the project
+nominal-path authority to remove duplicate mapping logic. This is not another
+R1 implementation step. Prior 12J-F1–F4 and retained H/I findings remain owned.
+
 ## Required next action
 
-Item12G is merged. Items12H/12I have terminal blocked, approved-candidate handoffs;
-Item12J now has the terminal blocked, **unapproved** candidate below. Stop12J's
-worker after publishing records. The orchestrator must assign the unresolved
-12J-R1 correction explicitly and preserve its remaining at-most-one remediation
-review and one final-candidate gate, with no reset of12B/H/I history. Item12K's
-separate integration allowance follows dependency qualification; this12J
-candidate must not be treated as approved or integrated as-is. No next-item
-code, integration, external repair, or gate bypass was written by12J.
+Stop the R1 worker after publishing this terminal record. Adjudicate Item12J-M1
+and the unresolved conversion obligation before treating Item12J as qualified.
+Candidate `4bc432f3474134b1a1d43202d39fd147893bb014` is unapproved and must not be
+integrated as-is. No third review, gate, merge, 12K integration, external repair,
+or next-item code is performed by this worker. 12K's separately approved
+integration allowance follows dependency qualification and does not reset any
+12B/H/I/J history.
 
 ### Item12J terminal evidence and unresolved review
 

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -161,6 +161,71 @@ Do not add blanket exports, suppressions, or substitute cancellation behavior.
 
 ## Later Item12J: async Python error-channel contract
 
+### Item12J implementation (2026-09-06)
+
+Owned worktree `/private/tmp/sifr-item12j.pT6Xkk/sifr`, branch
+`codex/emitted-rust-excellence-item-12j`, freshly fetched base
+`4ce05473f58716a611ac190581bf0737ba15331e`. Parent's two intentional dirty
+records and retained 12B/12H/12I worktrees are read-only to this worker.
+
+12H and 12I have terminal blocked handoffs, satisfying the execution order.
+They are not merged: 12H draft [#3697](https://github.com/sifr-lang/sifr/pull/3697)
+retains reviewed `9b52ac20094608c8a31f252db99e49ef7c963384`, record
+`b6e6210a97598fb631b929b2d4daf4012b41bb16`; 12I draft
+[#3698](https://github.com/sifr-lang/sifr/pull/3698) retains reviewed
+`f6e8afd964bb214a44c50271dcb2014ee8e828b4`, record
+`19ad69969a672d7b741122ded4dd879f2bdaf9ab`. Both sole gates failed SQL
+coverage. Their detailed evidence and deferred 12H-F1–F5 / 12I-F1–F3 remain in
+those commits and PRs; integration belongs to 12K, with no budget reset.
+
+Authoritative contracts: `stdlib/_sifr/python.sifr` declares
+`PythonError(Error)` with five string fields; architecture error semantics
+retain ordinary error inheritance and Result covariance. Python protocol
+architecture preserves same-loop async execution, original error replay, and
+ordered cleanup/cancellation. The existing examples' `Result[None, Error]`
+channels are valid under that inheritance contract and remain unchanged.
+
+Root cause: descriptor data-parent selection intentionally excludes the builtin
+Error marker, but class type collection and HIR-to-Type exports reused the
+data-parent metadata as complete nominal ancestry. The implementation preserves
+semantic error ancestry separately from data storage and uses that ancestry
+at each HIR-to-Type reconstruction. It does not add an embedded Error field,
+change the five-field Python boundary, or make unrelated nominal errors assignable.
+
+Exact commands registered before test execution:
+
+```bash
+cargo test -p sifr_driver async_python_error_channel
+cargo build --locked -p sifr
+python3 scripts/check_demo_emitted_freshness.py --sifr target/debug/sifr --update
+python3 scripts/check_demo_emitted_freshness.py --sifr target/debug/sifr
+uv run --project verification --locked python -m sifr_verify areas run --area python_interop --suite async-declaration-examples --suite async-context-examples
+cargo test -p sifr_ir
+cargo test -p sifr_lowering
+cargo test -p sifr_frontend
+cargo test -p sifr_codegen
+cargo test -p sifr_driver
+cargo clippy --workspace -- -D warnings
+cargo fmt --check
+python3 scripts/check_hir_maintainability_guardrails.py
+python3 scripts/check_file_size_guardrails.py
+scripts/run_all_tests.sh --profile merge
+```
+
+Focused regressions cover both unchanged original examples, rejection of
+unrelated return channels (one/three diagnostics), imported PythonError's exact
+identity/shape/ancestry, local and imported transitive error ancestry without
+data-parent storage, and rejection of a same-named nominal Error target.
+The sixth regression covers imported CSV/configparser classes named Error:
+canonical export must not rewrite their builtin ancestor to their own identity.
+All six focused regressions pass before the candidate is frozen. The first
+attempt lacked fresh-worktree submodules; early regression failures identified
+test bridge/constructor setup and the repaired project-export ancestry path.
+Those attempts are historical failures, not final candidate evidence.
+The merge-profile gate is reserved for the final reviewed SHA, once only;
+create-PR is omitted. Outer filtered-suite certification failures are not passes.
+No 12K implementation, runner bypass, external repair, or history rewrite is allowed.
+
 Both fixtures fail SIFR-RESULT-0003 during checking:
 `verification/areas/python_interop/fixtures/async_declaration/httpx2_client.sifr`
 and `verification/areas/python_interop/fixtures/async_context/aiosqlite_session.sifr`.

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -240,6 +240,53 @@ contract before repairing all affected fixtures or the appropriate compiler
 mechanism. Preserve original assertions, async cleanup/cancellation, and
 error propagation. Do not broaden accepted errors or suppress diagnostics.
 
+## Item12J-R1 bounded remediation plan (2026-09-06)
+
+Owned worktree `/private/tmp/sifr-item12j-r1.9j9Uhf/sifr`, branch
+`codex/emitted-rust-excellence-item-12j-r1`, retaining implementation `f720a342`
+and record `60219b0` unchanged in history. Fetched `origin/main` is still
+`4ce05473f58716a611ac190581bf0737ba15331e`, the original reviewed base.
+The parent's intentional dirty records and every retained worker are read-only.
+The 2026-09-06 parent amendment is carried into this worktree's phase record.
+
+Implement only the initial review's 12J-R1 conversion omission. Conversion
+demand follows semantic ancestry and canonical nominal identities; project
+and test-project support use the project nominal path registry. Existing
+consuming inheritance conversions preserve inherited messages without cloning.
+No 12I integration or next-item implementation is authorized here.
+
+Register these focused native regressions before running tests, all selected by
+the original named `cargo test -p sifr_driver async_python_error_channel` command:
+
+- `async_python_error_channel_native_local_and_transitive_conversions`: emit,
+  build and run local root/transitive errors using direct raise and propagation.
+- `async_python_error_channel_native_stdlib_nominal_collisions`: emit, build and
+  run distinct CSV/configparser Error declarations with original message assertions.
+- `async_python_error_channel_native_project_aliases_and_collisions`: emit,
+  build and run re-exported aliases, a transitive imported error, two same-named
+  project errors, and a local
+  nominal named ValueError distinct from the builtin. The existing negative
+  regression retains rejection of a same-named nominal Error target.
+
+Run only the exact Item12J command list above, reusing original IR, lowering,
+and frontend evidence where their complete crate inputs remain unchanged.
+Run affected codegen/driver tests, compiler build, freshness, named async suites,
+strict Clippy and formatting/HIR/file-size checks after the complete correction.
+Freeze the corrected SHA before the sole remaining remediation Opus review.
+One exact-final-candidate merge-profile gate remains; create-PR is omitted.
+Known external failures remain owned and honestly failed. If they prevent
+independent merge, preserve the corrected reviewed candidate for 12K and stop.
+
+Deferred **12J-F4**, owner nominal error export ancestry: the native test setup
+also tried project-imported `class Error(ValueError)` and `class Error(Error)`
+as positive source cases. Both remain rejected with SIFR-RESULT-0003 when raised
+into builtin Error. R1 changes no lowering/frontend/export inputs relative to
+`60219b0`, so this is unchanged-input source-check evidence, not an independent
+base runtime run. The retained `focused-corrected.log` and `focused-native.log`
+under the R1 evidence root contain the diagnostics. The final native collision
+case uses `ValueError(Error)` and retains the original negative Error-target
+test. This source ancestry issue is not repaired by the conversion item.
+
 ## Required next action
 
 Item12G is merged. Items12H/12I have terminal blocked, approved-candidate handoffs;

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -226,24 +226,100 @@ The merge-profile gate is reserved for the final reviewed SHA, once only;
 create-PR is omitted. Outer filtered-suite certification failures are not passes.
 No 12K implementation, runner bypass, external repair, or history rewrite is allowed.
 
-Both fixtures fail SIFR-RESULT-0003 during checking:
+Historical pre-12J observation: both fixtures failed SIFR-RESULT-0003 during checking:
 `verification/areas/python_interop/fixtures/async_declaration/httpx2_client.sifr`
 and `verification/areas/python_interop/fixtures/async_context/aiosqlite_session.sifr`.
 Their raised PythonError is incompatible with the declared Result[None, Error]
 channel; the latter fixture produces three diagnostics.
 
-Frontend/lowering/type-system, stdlib, and all Python-interop fixtures/runners
-are unchanged from exact base. This is input-identity evidence, not a repeated
-base qualification run. Determine the authoritative source/error-identity
+At that historical observation, frontend/lowering/type-system, stdlib, and all
+Python-interop fixtures/runners were unchanged from the observing candidate's
+base. This is input-identity evidence, not a repeated base qualification run.
+It does not describe the present12J compiler diff. Determine the authoritative source/error-identity
 contract before repairing all affected fixtures or the appropriate compiler
 mechanism. Preserve original assertions, async cleanup/cancellation, and
 error propagation. Do not broaden accepted errors or suppress diagnostics.
 
 ## Required next action
 
-Item12G is merged and complete. Stop its worker after publishing the closure
-record. The orchestrator may next assign bounded Item12H to a fresh isolated
-worker, then Item12I and Item12J in order. Use the named validation mapping
-above and preserve each item's review/gate limits. Item12K's expressly approved
-integration allowance follows dependency qualification; it does not reset
-Item12B's exhausted history. No Item12H–12K code was written by Item12G.
+Item12G is merged. Items12H/12I have terminal blocked, approved-candidate handoffs;
+Item12J now has the terminal blocked, **unapproved** candidate below. Stop12J's
+worker after publishing records. The orchestrator must assign the unresolved
+12J-R1 correction explicitly and preserve its remaining at-most-one remediation
+review and one final-candidate gate, with no reset of12B/H/I history. Item12K's
+separate integration allowance follows dependency qualification; this12J
+candidate must not be treated as approved or integrated as-is. No next-item
+code, integration, external repair, or gate bypass was written by12J.
+
+### Item12J terminal evidence and unresolved review
+
+State: **blocked**, draft [PR #3699](https://github.com/sifr-lang/sifr/pull/3699).
+Reviewed implementation `f720a342edd87004975355b478948f7eb5c8b406`; merge SHA:
+none. The final record is a separate documentation-only commit after that SHA.
+The initial [Opus review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5555927728)
+returned **NOT SATISFIED**. The user's orchestration checkpoint then requested
+terminal handoff because external failure was already established. No remediation
+code or review was started; no final-approved candidate exists to gate.
+Allowances consumed: one initial review, zero remediation reviews, zero merge
+gates, zero create-PR gates. Do not relabel this as a qualified candidate.
+
+[Exact-candidate evidence and changed paths](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5555929816)
+are published outside the reviewed Git tree. Evidence root:
+`/private/tmp/sifr-item12j.pT6Xkk/`, receipt
+`evidence-f720a342edd87004975355b478948f7eb5c8b406.md`, review
+`review-f720a342edd87004975355b478948f7eb5c8b406.md`. Compiler SHA256:
+`36640bfbb7c29f7d0019d86ed9539c20311db434c326bf31bada4319b9d61940`.
+
+- Six focused lowering/export regressions pass; IR4, frontend132 unit +7
+  integration, driver584 active (77 existing ignored) pass. These focused tests
+  do not prove generated conversions for local/imported error classes.
+- Lowering1114 pass /2 fail /1 ignored, existing TypeVar message assertions
+  [owner #3667 notified](https://github.com/sifr-lang/sifr/issues/3667#issuecomment-5555882691).
+  Codegen1407 pass /2 existing12B-owned list-repeat failures. Strict Clippy
+  fails at unchanged `project_stdlib_nominals.rs:45` (`expect_used`), owner12B/12C.
+- All264 generated companions remain byte-identical. Formatting, HIR and
+  canonical file-size guard (3756 files) pass. No fixture/assertion changes.
+- The exact two-suite command exits1: both examples pass source checking and
+  fail native build at12I-owned inaccessible cancellation task-local E0425.
+  HTTP has one reported Rust error; context reports58 errors with retained tail
+  naming that task-local and E0425. No runtime output markers were observed;
+  original cleanup/cancellation/assertions did not execute. This is neither
+  a native pass nor complete-area certification; no bypass flag was used.
+- Native report files are `async-declaration-<candidate>.json`,
+  `async-context-<candidate>.json`, and `python-results-<candidate>.json` under
+  the evidence root; receipt records their SHA256s and log names. Final native
+  TMPDIR is private; driver used `RUST_TEST_THREADS=1` without changing selection
+  or internal concurrency. Interrupted earlier cache/scheduling attempts are
+  explicitly incomplete in the receipt, never passing evidence.
+
+**Unresolved in-scope finding12J-R1 (not implemented):** `support_plan.rs:184–200`
+generates conversions only for builtin errors and async PythonError, while the
+new ancestry also accepts non-builtin local/imported errors into builtinError.
+Opus emitted local DomainError and imported `sifr.csv.Error` examples and
+verified E0277, missing `From<T> for Error`. The bounded correction must connect
+semantic ancestry to conversion demand and add emission/compilation regressions
+for local, project-imported and stdlib errors, preserving nominal identity and
+the original runtime contract. The first review remains NOT SATISFIED until
+the sole permitted remediation review approves a corrected exact SHA. A new
+mechanism defect on that second review must be deferred and stopped, not trigger
+a third review. This terminal worker does not implement that continuation.
+
+Separate review follow-ups, not implementation or new blockers:
+
+- **12J-F1**, owner nominal error inheritance: pre-existing mixed data-base plus
+  Error-marker ancestry (`MixedError(Payload, Error)`) overwrites the marker and
+  still rejects propagation. Review classifies this as unchanged from base;
+  no independent base-runtime result is claimed here.
+- **12J-F2**, owner nominal export diagnostics: already-diagnosed unresolved
+  parent paths can fall back to a noncanonical/nontransitive parent string.
+  Evaluate separately; do not add a compatibility fallback in12J.
+- **12J-F3**, owner codegen maintainability: the class-field PythonError-contract
+  reconstruction does not currently consult ancestry, making that converted
+  field a harmless consistency-only change. Cleanup is optional later work.
+
+The review's infrastructure observation remains owned by12I: runtime async
+cleanup/cancellation cannot be certified before its visibility repair is
+integrated and qualified. Detailed12H-F1–F5 and12I-F1–F3 remain in their retained
+record commits/PRs above; none was copied over with stale statuses or discarded.
+The known SQL coverage failure remains an external owner and was not rerun
+or newly claimed as a12J gate result. This item stops without merging or starting12K.

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -453,3 +453,39 @@ integrated and qualified. Detailed12H-F1–F5 and12I-F1–F3 remain in their ret
 record commits/PRs above; none was copied over with stale statuses or discarded.
 The known SQL coverage failure remains an external owner and was not rerun
 or newly claimed as a12J gate result. This item stops without merging or starting12K.
+
+## Item12J-M1 contract adjudication (2026-09-06)
+
+Status: **needs-new-scope; no implementation, approval, or merge**. The new
+bounded M1 scope and full authority audit are preserved in the
+[phase handoff](ad-hoc-emitted-rust-excellence.md#item12j-m1-contract-adjudication-handoff-2026-09-06).
+Owned checkout `/private/tmp/sifr-item12j-m1.VO82Kk/sifr`, branch
+`codex/emitted-rust-excellence-item-12j-m1`, retains `c430ed3331169f06eb148122f681e7d2a457d2ee`
+and all reviewed 12J/R1 lineage. Fetched main remains `4ce05473f58716a611ac190581bf0737ba15331e`.
+The parent and all prior worker workspaces/evidence remain unchanged.
+
+Architecture requires inherited `message: str` supplied at construction, while
+the implementation treats root Error as a special base without embedded
+storage and constructs custom errors from only their declared fields. Root
+Error itself requires a string. The source/representation authorities do not
+define a root message for accepted `CodeError(3)`, `EmptyError()`, or
+`message: int` values. Existing specific-error Display behavior is not an
+authorized root-conversion policy. The prior native regression and unresolved
+root-upcast failures are reused from the sole R1 remediation review; no new
+compiler probe or test was run before resolving this contract conflict.
+
+The required explicit choice is between enforcing inherited required string
+storage (breaking existing constructors/overrides), defining how existing
+Display output supplies a root string (new observable conversion semantics),
+or allowing absent-message payloads in a wider root representation (larger
+language/runtime scope). No option was implemented. Suppressing only invalid
+unused conversions would leave the repeated root-upcast obligation unresolved.
+
+M1 used **zero reviews, zero gates**. Complete implementation, registered
+regressions, compiler/native tests, and merge are unreached. Old 12J/R1 remains
+NOT SATISFIED, not qualified, with both reviews consumed and no gate. Named
+historical external failures retain their owners and statuses; no 12K input
+was integrated. Only the two Markdown records change, with documentation diff
+and file-size results retained at `/private/tmp/sifr-item12j-m1.VO82Kk/evidence.md`.
+Draft PR #3699 remains the linked unapproved predecessor. Next action: explicit
+owner/user contract adjudication before resuming M1; this worker stops here.


### PR DESCRIPTION
**Terminal status: BLOCKED, NOT APPROVED, NOT MERGED.** The initial and sole remediation Opus reviews both returned NOT SATISFIED. Reviewed implementation: `4bc432f3474134b1a1d43202d39fd147893bb014`; final documentation-only record: `c430ed3331169f06eb148122f681e7d2a457d2ee`. No third review, merge gate, or merge was run. Later bounded Item12J-M1 is recorded for adjudication; this candidate must not be integrated as-is.

The original async Python examples validly propagate PythonError into Result[None, Error], but lowering lost the builtin Error ancestry. Preserve that semantic ancestry separately from stored parent data. R1 connects nominal ancestry to specific conversion demand for local, project-imported and stdlib errors using canonical identities and project paths, and consumes inherited parent values instead of cloning their messages. The original `f720a342` implementation and `60219b0` handoff remain intact in the fast-forward history, based on `4ce05473f58716a611ac190581bf0737ba15331e`.

The [sole remediation review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5556273003) found a new message-storage regression: broad demand generates `Self::new(err.message)` for errors without a string message, even when those errors are only used in their own Result channel and an unrelated function mentions root Error. It verified pre-remediation native success versus candidate E0609 for a code-only error. Empty errors and non-string messages also fail. Explicit root upcasts for these shapes still source-check but fail native compilation (E0277 before R1, E0609 now), so the original conversion obligation remains unresolved. Item12J-M1 records the storage/admissibility contract and required adjudication; no later-item implementation was started.

[Exact-candidate validation, budget history, changed paths and terminal handoff](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5556293264): 9 focused tests including native local/transitive, project alias/collision/transitive, and CSV/configparser cases pass. Full driver: 587 pass, 77 existing ignores. All264 companions are fresh; formatting, HIR and3758-file size guards pass. Two companions were regenerated. Original async fixtures/assertions, lockfiles and workflows are unchanged.

External qualification also remains failed: both original named async suites reach native build and fail with12I's inaccessible cancellation task-local E0425; runtime assertions did not execute. Codegen retains the two12B list-repeat failures (1407 pass); strict Clippy retains only12B/12C's project_stdlib_nominals.rs:45 expect_used failure. Original unchanged-input IR/frontend passes and #3667-owned lowering failures are reused with explicit provenance.

[Initial review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5555927728) remains historical NOT SATISFIED. Cumulative12J usage is one initial review plus one remediation review; zero create-PR gates and zero merge-profile gates. The user-directed second-review stop was enforced.12H/12I/12B repairs and12K integration remain separately owned; none was absorbed or given a reset review/gate budget.
