### PR TITLE
Enforce required error string messages (12J-M1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7723,6 +7723,7 @@ name = "sifr_lowering"
 version = "0.0.0"
 dependencies = [
  "bigdecimal",
+ "insta",
  "num-bigint 0.5.1",
  "ruff_python_ast",
  "ruff_python_parser",

--- a/crates/sifr/tests/e2e/pass/parallel_try_map_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/parallel_try_map_basic.sifr
@@ -7,7 +7,7 @@ class MapError(Error):
 
 def stringify(value: int) -> Result[str, MapError]:
     if value < 0:
-        raise MapError()
+        raise MapError("negative item")
     return str(value)
 
 

--- a/crates/sifr_codegen/src/class_emitter.rs
+++ b/crates/sifr_codegen/src/class_emitter.rs
@@ -458,19 +458,11 @@ impl RustEmitter {
     }
 
     pub(crate) fn build_display_impl_for_error(class: &HirClass) -> RustItem {
-        let display_expr = if class.fields.iter().any(|(name, _)| name == "message") {
-            RustExpr::Field {
-                expr: Box::new(RustExpr::Ident("self".to_string())),
-                field: "message".to_string(),
-            }
-        } else {
-            RustExpr::Ident("self".to_string())
+        let display_expr = RustExpr::Field {
+            expr: Box::new(RustExpr::Ident("self".to_string())),
+            field: "message".to_string(),
         };
-        let format_spec = if class.fields.iter().any(|(name, _)| name == "message") {
-            "{}"
-        } else {
-            "{:?}"
-        };
+        let format_spec = "{}";
 
         RustItem::Impl {
             target: Self::class_impl_target(class),

--- a/crates/sifr_codegen/src/class_field_emitter.rs
+++ b/crates/sifr_codegen/src/class_field_emitter.rs
@@ -22,7 +22,7 @@ impl RustEmitter {
             name: class.name.clone(),
             fields: class.fields.clone(),
             methods: Vec::new(),
-            parent_class: class.parent_class.clone(),
+            parent_class: class.semantic_parent_chain(),
         }
         .is_python_error_contract()
     }

--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -86,7 +86,7 @@ pub(crate) fn generate_rust_test_with_project_policy(
     emitter.emit_named_module(module, false, true, Some(module_name));
     // Expression lowering can introduce canonical intermediate error unions.
     emitter.generate_enum_definitions();
-    let support_demand = ModuleSupportDemand::from_emitter(module, &emitter);
+    let support_demand = ModuleSupportDemand::from_emitter(module, &emitter, Some(module_name));
 
     let mut module_import_items: Vec<RustItem> = Vec::new();
     for import in &module.imports {

--- a/crates/sifr_codegen/src/error_refs.rs
+++ b/crates/sifr_codegen/src/error_refs.rs
@@ -3,6 +3,24 @@ use sifr_type_system::Type;
 use std::collections::HashSet;
 
 mod checked_places;
+mod conversions;
+pub(crate) use conversions::ErrorConversionDemand;
+
+#[derive(Default)]
+struct ErrorReferences {
+    builtins: HashSet<String>,
+    conversions: ErrorConversionDemand,
+}
+
+pub(crate) fn collect_error_conversion_demand(
+    module: &HirModule,
+    module_name: Option<&str>,
+) -> ErrorConversionDemand {
+    let mut conversions =
+        collect_error_references(module, "", &HashSet::new(), false, &[]).conversions;
+    conversions.record_classes(module, module_name);
+    conversions
+}
 
 pub(crate) fn collect_referenced_builtin_error_classes(
     module: &HirModule,
@@ -11,7 +29,24 @@ pub(crate) fn collect_referenced_builtin_error_classes(
     needs_file_handles: bool,
     builtin_error_classes: &[&str],
 ) -> HashSet<String> {
-    let mut referenced = HashSet::new();
+    collect_error_references(
+        module,
+        stdlib_preamble,
+        intrinsic_functions,
+        needs_file_handles,
+        builtin_error_classes,
+    )
+    .builtins
+}
+
+fn collect_error_references(
+    module: &HirModule,
+    stdlib_preamble: &str,
+    intrinsic_functions: &HashSet<String>,
+    needs_file_handles: bool,
+    builtin_error_classes: &[&str],
+) -> ErrorReferences {
+    let mut referenced = ErrorReferences::default();
 
     for func in &module.functions {
         for param in &func.params {
@@ -51,7 +86,7 @@ pub(crate) fn collect_referenced_builtin_error_classes(
     collect_text_error_refs(stdlib_preamble, &mut referenced, builtin_error_classes);
 
     if needs_file_handles {
-        referenced.insert("IOError".to_string());
+        referenced.builtins.insert("IOError".to_string());
     }
 
     // Intrinsics can produce these builtin errors through generated helper code.
@@ -68,7 +103,7 @@ pub(crate) fn collect_referenced_builtin_error_classes(
             "TimeoutError",
             "ScopeFailure",
         ] {
-            referenced.insert(error_name.to_string());
+            referenced.builtins.insert(error_name.to_string());
         }
     }
 
@@ -135,13 +170,14 @@ pub(crate) fn collect_module_intrinsic_function_names(module: &HirModule) -> Has
 
 fn collect_type_error_refs(
     ty: &Type,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
+    referenced.conversions.record_type(ty);
     match ty {
         Type::Class { name, .. } | Type::Protocol { name, .. } | Type::Enum { name, .. } => {
             if builtin_error_classes.contains(&name.as_str()) {
-                referenced.insert(name.clone());
+                referenced.builtins.insert(name.clone());
             }
         }
         Type::List(inner)
@@ -177,7 +213,7 @@ fn collect_type_error_refs(
         Type::Failure(err) => {
             collect_type_error_refs(err, referenced, builtin_error_classes);
             if builtin_error_classes.contains(&"SecondaryError") {
-                referenced.insert("SecondaryError".to_string());
+                referenced.builtins.insert("SecondaryError".to_string());
             }
         }
         Type::TimeoutResult(err) => {
@@ -233,7 +269,7 @@ fn collect_type_error_refs(
 
 fn collect_stmt_error_refs(
     stmts: &[HirStmt],
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
     for stmt in stmts {
@@ -337,7 +373,7 @@ fn collect_stmt_error_refs(
                 for handler in handlers {
                     if let Some(error_type) = &handler.error_type {
                         if builtin_error_classes.contains(&error_type.as_str()) {
-                            referenced.insert(error_type.clone());
+                            referenced.builtins.insert(error_type.clone());
                         }
                     }
                     collect_stmt_error_refs(&handler.body, referenced, builtin_error_classes);
@@ -356,7 +392,7 @@ fn collect_stmt_error_refs(
             HirStmt::AsyncWith { kind, body, .. } => {
                 match kind {
                     sifr_ir::HirAsyncWithKind::TaskTimeout { duration } => {
-                        referenced.insert("TimeoutError".to_string());
+                        referenced.builtins.insert("TimeoutError".to_string());
                         collect_expr_error_refs(duration, referenced, builtin_error_classes);
                     }
                     sifr_ir::HirAsyncWithKind::UserDefined { context, .. }
@@ -366,12 +402,12 @@ fn collect_stmt_error_refs(
                     sifr_ir::HirAsyncWithKind::TaskGroup {
                         context: Some(context),
                     } => {
-                        referenced.insert("ScopeFailure".to_string());
+                        referenced.builtins.insert("ScopeFailure".to_string());
                         collect_expr_error_refs(context, referenced, builtin_error_classes);
                     }
                     sifr_ir::HirAsyncWithKind::TaskScope
                     | sifr_ir::HirAsyncWithKind::TaskGroup { context: None } => {
-                        referenced.insert("ScopeFailure".to_string());
+                        referenced.builtins.insert("ScopeFailure".to_string());
                     }
                 }
                 collect_stmt_error_refs(body, referenced, builtin_error_classes);
@@ -395,7 +431,7 @@ fn collect_stmt_error_refs(
 
 fn collect_expr_error_refs(
     expr: &HirExpr,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
     collect_type_error_refs(expr.ty(), referenced, builtin_error_classes);
@@ -405,7 +441,7 @@ fn collect_expr_error_refs(
         | HirExpr::GenericCall { func, args, .. }
         | HirExpr::PythonCall { func, args, .. } => {
             if builtin_error_classes.contains(&func.as_str()) {
-                referenced.insert(func.clone());
+                referenced.builtins.insert(func.clone());
             }
             for arg in args {
                 collect_expr_error_refs(arg, referenced, builtin_error_classes);
@@ -420,7 +456,7 @@ fn collect_expr_error_refs(
             class_name, args, ..
         } => {
             if builtin_error_classes.contains(&class_name.as_str()) {
-                referenced.insert(class_name.clone());
+                referenced.builtins.insert(class_name.clone());
             }
             for arg in args {
                 collect_expr_error_refs(arg, referenced, builtin_error_classes);
@@ -595,7 +631,7 @@ fn collect_expr_error_refs(
 
 fn collect_text_error_refs(
     text: &str,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
     let mut token = String::new();
@@ -606,13 +642,13 @@ fn collect_text_error_refs(
         }
         if !token.is_empty() {
             if builtin_error_classes.contains(&token.as_str()) {
-                referenced.insert(token.clone());
+                referenced.builtins.insert(token.clone());
             }
             token.clear();
         }
     }
     if !token.is_empty() && builtin_error_classes.contains(&token.as_str()) {
-        referenced.insert(token);
+        referenced.builtins.insert(token);
     }
 }
 
@@ -620,9 +656,9 @@ pub(crate) fn collect_source_builtin_error_classes(
     source: &str,
     builtin_error_classes: &[&str],
 ) -> HashSet<String> {
-    let mut referenced = HashSet::new();
+    let mut referenced = ErrorReferences::default();
     collect_text_error_refs(source, &mut referenced, builtin_error_classes);
-    referenced
+    referenced.builtins
 }
 
 #[cfg(test)]

--- a/crates/sifr_codegen/src/error_refs/checked_places.rs
+++ b/crates/sifr_codegen/src/error_refs/checked_places.rs
@@ -1,9 +1,9 @@
+use super::ErrorReferences;
 use sifr_ir::HirStmt;
-use std::collections::HashSet;
 
 pub(super) fn collect_checked_place_stmt_error_refs(
     stmt: &HirStmt,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) -> bool {
     match stmt {
@@ -71,7 +71,7 @@ pub(super) fn collect_checked_place_stmt_error_refs(
 
 fn collect_expr(
     expr: &sifr_ir::HirExpr,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
     super::collect_expr_error_refs(expr, referenced, builtin_error_classes);
@@ -79,7 +79,7 @@ fn collect_expr(
 
 fn collect_failure(
     failure: Option<&sifr_type_system::Type>,
-    referenced: &mut HashSet<String>,
+    referenced: &mut ErrorReferences,
     builtin_error_classes: &[&str],
 ) {
     if let Some(failure) = failure {

--- a/crates/sifr_codegen/src/error_refs/conversions.rs
+++ b/crates/sifr_codegen/src/error_refs/conversions.rs
@@ -110,7 +110,7 @@ impl ErrorConversionDemand {
                     type_params, items, ..
                 } = &mut item
                 {
-                    *type_params = error.type_params.clone();
+                    type_params.clone_from(&error.type_params);
                     // A transitive error owns its parent value. Consume that value via
                     // the existing inheritance impl, rather than moving through Deref
                     // or cloning the inherited message.

--- a/crates/sifr_codegen/src/error_refs/conversions.rs
+++ b/crates/sifr_codegen/src/error_refs/conversions.rs
@@ -1,0 +1,159 @@
+use crate::{RustEmitter, RustExpr, RustItem, RustStmt, RustTypeParam};
+use sifr_ir::HirModule;
+use sifr_type_system::{Type, class_rust_name};
+use std::collections::{BTreeMap, HashMap};
+
+/// Conversion authority follows semantic ancestry, never an error's basename.
+#[derive(Clone, Default)]
+pub(crate) struct ErrorConversionDemand(BTreeMap<String, NominalError>);
+
+#[derive(Clone)]
+struct NominalError {
+    rust_name: String,
+    type_arguments: String,
+    type_params: Vec<RustTypeParam>,
+    ancestors: Vec<String>,
+    declaration: bool,
+    owns_message: bool,
+}
+
+impl ErrorConversionDemand {
+    pub(super) fn record_classes(&mut self, module: &HirModule, module_name: Option<&str>) {
+        for class in &module.classes {
+            let Some(chain) = class
+                .semantic_parent_chain()
+                .filter(|_| class.is_error_type)
+            else {
+                continue;
+            };
+            if !chain.split('|').any(is_root_error) {
+                continue;
+            }
+            let rust_name = sifr_type_system::source_class_rust_name(&class.name);
+            let target = RustEmitter::class_impl_target(class);
+            self.0.insert(
+                class.identity.clone().unwrap_or_else(|| {
+                    module_name.map_or_else(
+                        || class.name.clone(),
+                        |module| format!("{module}.{}", class.name),
+                    )
+                }),
+                NominalError {
+                    type_arguments: target[rust_name.len()..].to_string(),
+                    rust_name,
+                    type_params: RustEmitter::class_impl_type_params(class),
+                    ancestors: chain.split('|').map(str::to_string).collect(),
+                    declaration: true,
+                    owns_message: class.fields.iter().any(|(name, _)| name == "message"),
+                },
+            );
+        }
+    }
+
+    pub(super) fn record_type(&mut self, ty: &Type) {
+        let Type::Class {
+            identity,
+            name,
+            fields,
+            parent_class: Some(chain),
+            ..
+        } = ty.resolve_alias()
+        else {
+            return;
+        };
+        if !chain.split('|').any(is_root_error)
+            || (crate::BUILTIN_ERROR_CLASSES.contains(&name.as_str())
+                && identity.as_deref().is_none_or(|id| {
+                    id.starts_with("sifr.builtin.")
+                        || sifr_type_system::is_global_rust_nominal_identity(id)
+                }))
+        {
+            return;
+        }
+        let rust_name = class_rust_name(identity.as_deref(), name);
+        let rendered = crate::render_type(&crate::sifr_type_to_rust_type(ty));
+        self.0
+            .entry(identity.clone().unwrap_or_else(|| name.clone()))
+            .or_insert_with(|| NominalError {
+                type_arguments: rendered[rust_name.len()..].to_string(),
+                rust_name,
+                type_params: Vec::new(),
+                ancestors: chain.split('|').map(str::to_string).collect(),
+                declaration: false,
+                owns_message: fields.iter().any(|(name, _)| name == "message"),
+            });
+    }
+
+    pub(crate) fn merge(&mut self, other: &Self) {
+        for (identity, error) in &other.0 {
+            if error.declaration || !self.0.contains_key(identity) {
+                self.0.insert(identity.clone(), error.clone());
+            }
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn render(&self, paths: &HashMap<String, String>) -> Vec<RustItem> {
+        self.0
+            .iter()
+            .map(|(identity, error)| {
+                let source = format!(
+                    "{}{}",
+                    paths.get(identity).unwrap_or(&error.rust_name),
+                    error.type_arguments
+                );
+                let mut item = crate::build_error_into_error_impl(&source);
+                if let RustItem::Impl {
+                    type_params, items, ..
+                } = &mut item
+                {
+                    *type_params = error.type_params.clone();
+                    // A transitive error owns its parent value. Consume that value via
+                    // the existing inheritance impl, rather than moving through Deref
+                    // or cloning the inherited message.
+                    if !error.owns_message
+                        && error
+                            .ancestors
+                            .first()
+                            .is_some_and(|ancestor| !is_root_error(ancestor))
+                    {
+                        let mut value = RustExpr::Ident("err".to_string());
+                        for ancestor in &error.ancestors {
+                            let target = if is_root_error(ancestor) {
+                                "Error".to_string()
+                            } else if let Some(path) = paths.get(ancestor) {
+                                path.clone()
+                            } else {
+                                let name = ancestor.rsplit('.').next().unwrap_or(ancestor);
+                                class_rust_name(
+                                    ancestor.contains('.').then_some(ancestor.as_str()),
+                                    name,
+                                )
+                            };
+                            value = RustExpr::FnCall {
+                                func: Box::new(RustExpr::Path(vec![format!(
+                                    "::std::convert::Into::<{target}>::into"
+                                )])),
+                                args: vec![value],
+                            };
+                            if is_root_error(ancestor) {
+                                break;
+                            }
+                        }
+                        if let RustItem::Fn { body, .. } = &mut items[0] {
+                            *body = vec![RustStmt::Return(Some(value))];
+                        }
+                    }
+                }
+                item
+            })
+            .collect()
+    }
+}
+
+fn is_root_error(identity: &str) -> bool {
+    matches!(identity, "Error" | "sifr.builtin.Error")
+}

--- a/crates/sifr_codegen/src/error_refs/conversions.rs
+++ b/crates/sifr_codegen/src/error_refs/conversions.rs
@@ -5,21 +5,52 @@ use std::collections::{BTreeMap, HashMap};
 
 /// Conversion authority follows semantic ancestry, never an error's basename.
 #[derive(Clone, Default)]
-pub(crate) struct ErrorConversionDemand(BTreeMap<String, NominalError>);
+pub(crate) struct ErrorConversionDemand {
+    errors: BTreeMap<String, NominalError>,
+    storage: BTreeMap<String, MessageStorage>,
+}
+
+#[derive(Clone)]
+struct MessageStorage {
+    owns_message: bool,
+    parent: Option<(String, String)>,
+}
 
 #[derive(Clone)]
 struct NominalError {
     rust_name: String,
     type_arguments: String,
     type_params: Vec<RustTypeParam>,
-    ancestors: Vec<String>,
     declaration: bool,
-    owns_message: bool,
 }
 
 impl ErrorConversionDemand {
     pub(super) fn record_classes(&mut self, module: &HirModule, module_name: Option<&str>) {
         for class in &module.classes {
+            let identity = class.identity.clone().unwrap_or_else(|| {
+                module_name.map_or_else(
+                    || class.name.clone(),
+                    |module| format!("{module}.{}", class.name),
+                )
+            });
+            let parent = class.parent_type.as_ref().and_then(|ty| {
+                let Type::Class { identity, name, .. } = ty.resolve_alias() else {
+                    return None;
+                };
+                Some((
+                    identity.clone().unwrap_or_else(|| name.clone()),
+                    class.parent_class.as_ref()?.to_lowercase(),
+                ))
+            });
+            self.storage.insert(
+                identity.clone(),
+                MessageStorage {
+                    owns_message: class.fields.iter().any(|(name, ty)| {
+                        name == "message" && matches!(ty.resolve_alias(), Type::Str)
+                    }),
+                    parent,
+                },
+            );
             let Some(chain) = class
                 .semantic_parent_chain()
                 .filter(|_| class.is_error_type)
@@ -31,20 +62,13 @@ impl ErrorConversionDemand {
             }
             let rust_name = sifr_type_system::source_class_rust_name(&class.name);
             let target = RustEmitter::class_impl_target(class);
-            self.0.insert(
-                class.identity.clone().unwrap_or_else(|| {
-                    module_name.map_or_else(
-                        || class.name.clone(),
-                        |module| format!("{module}.{}", class.name),
-                    )
-                }),
+            self.errors.insert(
+                identity,
                 NominalError {
                     type_arguments: target[rust_name.len()..].to_string(),
                     rust_name,
                     type_params: RustEmitter::class_impl_type_params(class),
-                    ancestors: chain.split('|').map(str::to_string).collect(),
                     declaration: true,
-                    owns_message: class.fields.iter().any(|(name, _)| name == "message"),
                 },
             );
         }
@@ -54,7 +78,6 @@ impl ErrorConversionDemand {
         let Type::Class {
             identity,
             name,
-            fields,
             parent_class: Some(chain),
             ..
         } = ty.resolve_alias()
@@ -72,32 +95,31 @@ impl ErrorConversionDemand {
         }
         let rust_name = class_rust_name(identity.as_deref(), name);
         let rendered = crate::render_type(&crate::sifr_type_to_rust_type(ty));
-        self.0
+        self.errors
             .entry(identity.clone().unwrap_or_else(|| name.clone()))
             .or_insert_with(|| NominalError {
                 type_arguments: rendered[rust_name.len()..].to_string(),
                 rust_name,
                 type_params: Vec::new(),
-                ancestors: chain.split('|').map(str::to_string).collect(),
                 declaration: false,
-                owns_message: fields.iter().any(|(name, _)| name == "message"),
             });
     }
 
     pub(crate) fn merge(&mut self, other: &Self) {
-        for (identity, error) in &other.0 {
-            if error.declaration || !self.0.contains_key(identity) {
-                self.0.insert(identity.clone(), error.clone());
+        self.storage.extend(other.storage.clone());
+        for (identity, error) in &other.errors {
+            if error.declaration || !self.errors.contains_key(identity) {
+                self.errors.insert(identity.clone(), error.clone());
             }
         }
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.errors.is_empty()
     }
 
     pub(crate) fn render(&self, paths: &HashMap<String, String>) -> Vec<RustItem> {
-        self.0
+        self.errors
             .iter()
             .map(|(identity, error)| {
                 let source = format!(
@@ -111,41 +133,43 @@ impl ErrorConversionDemand {
                 } = &mut item
                 {
                     type_params.clone_from(&error.type_params);
-                    // A transitive error owns its parent value. Consume that value via
-                    // the existing inheritance impl, rather than moving through Deref
-                    // or cloning the inherited message.
-                    if !error.owns_message
-                        && error
-                            .ancestors
-                            .first()
-                            .is_some_and(|ancestor| !is_root_error(ancestor))
-                    {
-                        let mut value = RustExpr::Ident("err".to_string());
-                        for ancestor in &error.ancestors {
-                            let target = if is_root_error(ancestor) {
-                                "Error".to_string()
-                            } else if let Some(path) = paths.get(ancestor) {
-                                path.clone()
-                            } else {
-                                let name = ancestor.rsplit('.').next().unwrap_or(ancestor);
-                                class_rust_name(
-                                    ancestor.contains('.').then_some(ancestor.as_str()),
-                                    name,
-                                )
-                            };
-                            value = RustExpr::FnCall {
-                                func: Box::new(RustExpr::Path(vec![format!(
-                                    "::std::convert::Into::<{target}>::into"
-                                )])),
-                                args: vec![value],
-                            };
-                            if is_root_error(ancestor) {
-                                break;
-                            }
+                    // Project through owned embedded fields, never through Deref.
+                    // Data parents can themselves be non-errors: semantic ancestry
+                    // is not authority for where the message is physically stored.
+                    let mut value = RustExpr::Ident("err".to_string());
+                    let mut owner = identity.as_str();
+                    let mut visited = std::collections::HashSet::new();
+                    while let Some(storage) = self.storage.get(owner) {
+                        if storage.owns_message {
+                            break;
                         }
-                        if let RustItem::Fn { body, .. } = &mut items[0] {
-                            *body = vec![RustStmt::Return(Some(value))];
-                        }
+                        assert!(
+                            visited.insert(owner),
+                            "checked class storage must be acyclic"
+                        );
+                        let Some((parent, field)) = &storage.parent else {
+                            unreachable!(
+                                "checked error must have owned or inherited string storage"
+                            );
+                        };
+                        value = RustExpr::Field {
+                            expr: Box::new(value),
+                            field: field.clone(),
+                        };
+                        owner = parent;
+                    }
+                    value = RustExpr::Field {
+                        expr: Box::new(value),
+                        field: "message".to_string(),
+                    };
+                    if let RustItem::Fn { body, .. } = &mut items[0] {
+                        *body = vec![RustStmt::Return(Some(RustExpr::FnCall {
+                            func: Box::new(RustExpr::Path(vec![
+                                "Self".to_string(),
+                                "new".to_string(),
+                            ])),
+                            args: vec![value],
+                        }))];
                     }
                 }
                 item

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -245,7 +245,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
         );
     }
     emitter.generate_enum_definitions();
-    let support_demand = ModuleSupportDemand::from_emitter(module, &emitter);
+    let support_demand = ModuleSupportDemand::from_emitter(module, &emitter, module_name);
     if support_emission == SupportEmission::Deferred {
         return deferred_codegen_result(
             module,

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -6,8 +6,8 @@ use super::{
 };
 use crate::lib_project_signatures::{project_class_fields, project_func_signatures};
 use crate::project_stdlib_nominals::{
-    extract_project_stdlib_nominal_prelude, project_stdlib_nominal_plan,
-    relocate_project_stdlib_nominals,
+    extract_project_stdlib_nominal_prelude, project_module_binding_names,
+    project_stdlib_nominal_plan, relocate_project_stdlib_nominals,
 };
 use crate::project_union_prelude::render_project_union_prelude;
 use crate::render_project_structural_record_prelude;
@@ -379,11 +379,7 @@ pub fn generate_rust_multi_with_metadata(
             module_name,
             &stdlib_nominal_plan,
             &crate_root_modules,
-            &module
-                .classes
-                .iter()
-                .map(|class| source_class_rust_name(&class.name))
-                .collect(),
+            &project_module_binding_names(module),
         );
         let imports = [local_imports, union_imports]
             .into_iter()

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -406,6 +406,7 @@ pub fn generate_rust_multi_with_metadata(
         required_features.extend(codegen_result.required_features);
     }
 
+    project_support_demand.set_error_conversion_paths(&nominal_type_paths);
     let rendered_support = render_support(&project_support_demand, stdlib_code);
     used_stdlib_modules.extend(rendered_support.used_stdlib_modules.iter().cloned());
     required_features.extend(rendered_support.required_features.iter().copied());

--- a/crates/sifr_codegen/src/lib_project_signatures.rs
+++ b/crates/sifr_codegen/src/lib_project_signatures.rs
@@ -140,7 +140,7 @@ fn module_func_signatures(module: &HirModule) -> ModuleFuncSignatures {
                         name: class.name.clone(),
                         fields: class.fields.clone(),
                         methods: Vec::new(),
-                        parent_class: class.parent_class.clone(),
+                        parent_class: class.semantic_parent_chain(),
                     },
                 ),
             );

--- a/crates/sifr_codegen/src/lib_runtime_needs.rs
+++ b/crates/sifr_codegen/src/lib_runtime_needs.rs
@@ -158,7 +158,7 @@ impl<T: Clone> Channel<T> {
     fn push(&mut self, value: T) -> Result<(), ClosedError> {
         self.__sifr_with_state(|state| {
             if state.closed || !state.receiver_alive {
-                return Err(ClosedError::new());
+                return Err(ClosedError::new("channel is closed".to_string()));
             }
             state.buffer.push_back(value);
             self._recv_notify.notify_one();
@@ -182,7 +182,7 @@ impl<T: Clone> Channel<T> {
     fn pop(&mut self) -> Result<T, ClosedError> {
         match self.try_pop() {
             __SifrChannelPopState::Item(value) => Ok(value),
-            __SifrChannelPopState::Empty | __SifrChannelPopState::Closed => Err(ClosedError::new()),
+            __SifrChannelPopState::Empty | __SifrChannelPopState::Closed => Err(ClosedError::new("channel is closed".to_string())),
         }
     }
 }
@@ -212,7 +212,7 @@ impl<T: Clone> ChannelSender<T> {
             notified.as_mut().enable();
             match self._channel.try_push(value) {
                 __SifrChannelPushState::Sent => return Ok(()),
-                __SifrChannelPushState::Closed(_) => return Err(ClosedError::new()),
+                __SifrChannelPushState::Closed(_) => return Err(ClosedError::new("channel is closed".to_string())),
                 __SifrChannelPushState::Full(pending) => {
                     value = pending;
                     notified.await;
@@ -262,7 +262,7 @@ impl<T: Clone> ChannelReceiver<T> {
             notified.as_mut().enable();
             match self._channel.try_pop() {
                 __SifrChannelPopState::Item(value) => return Ok(value),
-                __SifrChannelPopState::Closed => return Err(ClosedError::new()),
+                __SifrChannelPopState::Closed => return Err(ClosedError::new("channel is closed".to_string())),
                 __SifrChannelPopState::Empty => notified.await,
             }
         }

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -131,11 +131,7 @@ pub fn generate_rust_test_project_with_metadata(
             module_name,
             &stdlib_nominal_plan,
             &crate_root_modules,
-            &module
-                .classes
-                .iter()
-                .map(|class| sifr_type_system::source_class_rust_name(&class.name))
-                .collect(),
+            &crate::project_stdlib_nominals::project_module_binding_names(module),
         );
         support_rust_files.insert(
             (*module_name).to_string(),

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -166,6 +166,7 @@ pub fn generate_rust_test_project_with_metadata(
         required_features.extend(generated.required_features);
     }
 
+    project_support_demand.set_error_conversion_paths(&nominal_type_paths);
     let rendered_support = render_support(&project_support_demand, stdlib_code);
     used_stdlib_modules.extend(rendered_support.used_stdlib_modules.iter().cloned());
     required_features.extend(rendered_support.required_features.iter().copied());

--- a/crates/sifr_codegen/src/project_stdlib_nominals.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals.rs
@@ -7,7 +7,9 @@ use sifr_ir::HirFunction;
 use sifr_type_system::{FunctionType, Type, class_rust_name, is_crate_root_rust_nominal_identity};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+mod module_bindings;
 mod project_union_relocation;
+pub(crate) use module_bindings::project_module_binding_names;
 
 use project_union_relocation::{relocate_project_unions, shared_nominal_reexport_names};
 
@@ -360,6 +362,14 @@ fn collect_hir_function_nominals(
     for ty in crate::hir_analysis::queries::collect_let_declared_types(&function.body) {
         collect_shared_nominals(&ty, declarations, builtin_types);
     }
+    // Constructor-only references still need the same canonical project owner
+    // as annotations and bindings (notably consuming error upcasts).
+    crate::hir_analysis::traversal::walk_stmts(
+        &function.body,
+        crate::hir_analysis::traversal::TraversalConfig::INCLUDE_NESTED_FUNCTIONS,
+        &mut |_| {},
+        &mut |expr| collect_shared_nominals(expr.ty(), declarations, builtin_types),
+    );
 }
 
 fn collect_module_nominals(

--- a/crates/sifr_codegen/src/project_stdlib_nominals/module_bindings.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals/module_bindings.rs
@@ -1,0 +1,27 @@
+use sifr_ir::HirModule;
+use sifr_type_system::source_class_rust_name;
+use std::collections::HashSet;
+
+pub(crate) fn project_module_binding_names(module: &HirModule) -> HashSet<String> {
+    let mut names = module
+        .classes
+        .iter()
+        .map(|class| source_class_rust_name(&class.name))
+        .collect::<HashSet<_>>();
+    // An imported nominal shadows a builtin just as a local declaration does.
+    // Its basename is not a demand for the builtin's crate-root re-export.
+    for import in &module.imports {
+        if import.module.starts_with("sifr.") || import.module.starts_with("_sifr.") {
+            continue;
+        }
+        for name in &import.names {
+            let binding = import
+                .aliases
+                .iter()
+                .find(|(original, _)| original == name)
+                .map_or(name, |(_, alias)| alias);
+            names.insert(source_class_rust_name(binding));
+        }
+    }
+    names
+}

--- a/crates/sifr_codegen/src/python_interop_common.rs
+++ b/crates/sifr_codegen/src/python_interop_common.rs
@@ -28,12 +28,6 @@ pub(crate) fn rust_source_uses_python_runtime(source: &str) -> bool {
     source.contains("::sifr_stdlib::python::") || source.contains("::sifr_runtime::python::")
 }
 
-pub(crate) fn python_error_contract_rust_types(
-    module: &HirModule,
-) -> std::collections::BTreeSet<String> {
-    python_error_contract_types(module).into_keys().collect()
-}
-
 pub(crate) fn python_error_contract_types(
     module: &HirModule,
 ) -> std::collections::BTreeMap<String, Type> {

--- a/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
@@ -229,6 +229,18 @@ impl RustEmitter {
         else {
             return lowered;
         };
+        // Root Error has a direct consuming conversion from each concrete error.
+        // A data ancestor need not itself be an error (an explicit Error marker
+        // may be introduced by the child), so never discard the child's message
+        // by first converting it to that data ancestor.
+        if target_ty.is_builtin_error_base() {
+            return crate::RustExpr::FnCall {
+                func: Box::new(crate::RustExpr::Path(vec![
+                    "::std::convert::Into::<Error>::into".to_string(),
+                ])),
+                args: vec![lowered],
+            };
+        }
         for (index, ancestor) in ancestors.iter().take(target_index + 1).enumerate() {
             let rendered_target = if index == target_index {
                 self.render_rust_type_with_generics(target_ty)

--- a/crates/sifr_codegen/src/support_plan.rs
+++ b/crates/sifr_codegen/src/support_plan.rs
@@ -41,14 +41,19 @@ pub(crate) struct ModuleSupportDemand {
     suppressed_union_definitions: HashSet<String>,
     locally_shadowed_error_classes: HashSet<String>,
     referenced_error_classes: HashSet<String>,
-    python_error_rust_types: BTreeSet<String>,
+    error_conversions: crate::error_refs::ErrorConversionDemand,
+    error_conversion_paths: HashMap<String, String>,
     required_features: HashSet<StdlibFeature>,
     needs_file_handle_struct: bool,
     structural_interop_enabled: bool,
 }
 
 impl ModuleSupportDemand {
-    pub(crate) fn from_emitter(module: &HirModule, emitter: &RustEmitter) -> Self {
+    pub(crate) fn from_emitter(
+        module: &HirModule,
+        emitter: &RustEmitter,
+        module_name: Option<&str>,
+    ) -> Self {
         let runtime = RuntimeSupportDemand::for_module(module);
         let needs_file_handles = emitter.runtime_needs.file_handles();
         let user_defined_error_classes = module
@@ -79,9 +84,11 @@ impl ModuleSupportDemand {
                 .map(str::to_string)
                 .collect(),
             referenced_error_classes,
-            python_error_rust_types: crate::python_interop_common::python_error_contract_rust_types(
+            error_conversions: crate::error_refs::collect_error_conversion_demand(
                 module,
+                module_name,
             ),
+            error_conversion_paths: HashMap::new(),
             required_features: emitter.intrinsic_registry_features.clone(),
             needs_file_handle_struct: needs_file_handles
                 && !module
@@ -118,12 +125,15 @@ impl ModuleSupportDemand {
             .extend(other.suppressed_union_definitions.iter().cloned());
         self.referenced_error_classes
             .extend(other.referenced_error_classes.iter().cloned());
-        self.python_error_rust_types
-            .extend(other.python_error_rust_types.iter().cloned());
+        self.error_conversions.merge(&other.error_conversions);
         self.required_features
             .extend(other.required_features.iter().copied());
         self.needs_file_handle_struct |= other.needs_file_handle_struct;
         self.structural_interop_enabled |= other.structural_interop_enabled;
+    }
+
+    pub(crate) fn set_error_conversion_paths(&mut self, paths: &HashMap<String, String>) {
+        self.error_conversion_paths.clone_from(paths);
     }
 
     pub(crate) fn needs_support(&self) -> bool {
@@ -131,7 +141,7 @@ impl ModuleSupportDemand {
             || self.runtime_needs.file_handles()
             || !self.directly_used_stdlib_modules.is_empty()
             || !self.referenced_error_classes.is_empty()
-            || !self.python_error_rust_types.is_empty()
+            || !self.error_conversions.is_empty()
     }
 
     pub(crate) fn directly_used_stdlib_modules(&self) -> HashSet<String> {
@@ -191,12 +201,11 @@ pub(crate) fn render_support(
             }
         }
     }
-    if demand.runtime.async_python && referenced_error_classes.contains("Error") {
+    if referenced_error_classes.contains("Error") {
         items.extend(
             demand
-                .python_error_rust_types
-                .iter()
-                .map(|rust_type| build_error_into_error_impl(rust_type)),
+                .error_conversions
+                .render(&demand.error_conversion_paths),
         );
     }
 

--- a/crates/sifr_codegen/src/union_type_helpers.rs
+++ b/crates/sifr_codegen/src/union_type_helpers.rs
@@ -191,7 +191,7 @@ impl RustEmitter {
                             name: class.name.clone(),
                             fields: class.fields.clone(),
                             methods: Vec::new(),
-                            parent_class: class.parent_class.clone(),
+                            parent_class: class.semantic_parent_chain(),
                         },
                     ),
                 );

--- a/crates/sifr_driver/src/stdlib/bootstrap.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap.rs
@@ -300,7 +300,7 @@ fn compile_stdlib_sources_with_sysroot(
                         name: class.name.clone(),
                         fields: class.fields.clone(),
                         methods,
-                        parent_class: class.parent_class.clone(),
+                        parent_class: class.semantic_parent_chain(),
                     },
                     &local_classes,
                 );
@@ -419,7 +419,7 @@ fn compile_stdlib_sources_with_sysroot(
                                 name: class.name.clone(),
                                 fields: class.fields.clone(),
                                 methods: Vec::new(),
-                                parent_class: class.parent_class.clone(),
+                                parent_class: class.semantic_parent_chain(),
                             },
                         ),
                     );

--- a/crates/sifr_driver/src/tests/async_python_error_channel.rs
+++ b/crates/sifr_driver/src/tests/async_python_error_channel.rs
@@ -1,0 +1,129 @@
+use super::support::parse_suite;
+use crate::{collect_project_hir_modules, compile_stdlib, type_check_source};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_lowering::{LoweringOptions, PythonBridgeTargetAuthority};
+use sifr_type_system::Type;
+use std::collections::{BTreeMap, HashMap};
+
+const HTTP: &str = include_str!(
+    "../../../../verification/areas/python_interop/fixtures/async_declaration/httpx2_client.sifr"
+);
+const CONTEXT: &str = include_str!(
+    "../../../../verification/areas/python_interop/fixtures/async_context/aiosqlite_session.sifr"
+);
+
+fn check_example(source: &str, bridge_module: &str) -> Vec<sifr_ir::HirDiagnostic> {
+    let stdlib = compile_stdlib().expect("stdlib must compile");
+    sifr_lowering::lower_module_with_externals_name_and_options(
+        "main",
+        &parse_suite(source),
+        &stdlib.defs,
+        LoweringOptions {
+            python_bridge_authorities: BTreeMap::from([(
+                "main".to_string(),
+                PythonBridgeTargetAuthority {
+                    runtime_package: "__sifr_bridge__.p_error_channel_test".to_string(),
+                    modules: [bridge_module.to_string()].into_iter().collect(),
+                },
+            )]),
+            ..LoweringOptions::default()
+        },
+    )
+    .err()
+    .unwrap_or_default()
+}
+
+#[test]
+fn async_python_error_channel_preserves_both_original_examples() {
+    for (source, bridge) in [(HTTP, "client"), (CONTEXT, "session")] {
+        let errors = check_example(source, bridge);
+        assert!(errors.is_empty(), "original async contract: {errors:?}");
+    }
+}
+
+#[test]
+fn async_python_error_channel_rejects_unrelated_return_errors() {
+    for (source, bridge, count) in [(HTTP, "client", 1), (CONTEXT, "session", 3)] {
+        let source = source.replace(
+            "async def main() -> Result[None, Error]:",
+            "async def main() -> Result[None, ValueError]:",
+        );
+        let errors = check_example(&source, bridge);
+        assert_eq!(errors.len(), count, "{errors:?}");
+        assert!(
+            errors.iter().all(|error| {
+                error.code == Some(DiagnosticCode::RESULT_INVALID_RAISE)
+                    && error.message.contains("PythonError")
+            }),
+            "{errors:?}"
+        );
+    }
+}
+
+#[test]
+fn async_python_error_channel_retains_stdlib_ancestry_without_data_parent() {
+    let stdlib = compile_stdlib().expect("stdlib must compile");
+    let error = &stdlib.defs.classes["sifr.python"]["PythonError"];
+    let Type::Class {
+        identity,
+        parent_class,
+        fields,
+        ..
+    } = error
+    else {
+        panic!("PythonError must be a nominal class");
+    };
+    assert_eq!(identity.as_deref(), Some("_sifr.python.PythonError"));
+    assert_eq!(parent_class.as_deref(), Some("Error"));
+    assert_eq!(fields.len(), 5);
+    assert!(fields.iter().all(|(_, ty)| *ty == Type::Str));
+}
+
+#[test]
+fn async_python_error_channel_preserves_local_and_imported_error_ancestry() {
+    let modules = HashMap::from([
+        (
+            "errors".to_string(),
+            parse_suite(
+                "class DomainError(Error):\n    message: str\n\nclass DetailedError(DomainError):\n    detail: str\n\n    def __init__(self, message: str, detail: str):\n        super().__init__(message)\n        self.detail = detail\n",
+            ),
+        ),
+        (
+            "main".to_string(),
+            parse_suite(
+                "from errors import DomainError, DetailedError\n\ndef direct(own error: DomainError) -> Result[None, Error]:\n    raise error\n\ndef inherited(own error: DetailedError) -> Result[None, Error]:\n    raise error\n\ndef main():\n    pass\n",
+            ),
+        ),
+    ]);
+    let stdlib = compile_stdlib().expect("stdlib must compile");
+    let lowered = collect_project_hir_modules(&modules, stdlib.defs)
+        .expect("exported errors must retain their declared ancestry");
+    let root = &lowered.hir_modules["errors"].classes[0];
+    assert!(root.parent_class.is_none());
+    assert!(root.parent_type.is_none());
+    assert_eq!(root.semantic_parent_chain().as_deref(), Some("Error"));
+    assert_eq!(root.fields.len(), 1);
+}
+
+#[test]
+fn async_python_error_channel_rejects_same_named_nominal_target() {
+    let source = "from sifr.python import PythonError\n\nclass Error(ValueError):\n    message: str\n\ndef fail(own error: PythonError) -> Result[None, Error]:\n    raise error\n\ndef main():\n    pass\n";
+    let errors = type_check_source(source);
+    assert!(
+        errors
+            .iter()
+            .any(|error| { error.code == DiagnosticCode::RESULT_INVALID_RAISE.code() }),
+        "same-name target must remain nominal: {errors:?}"
+    );
+}
+
+#[test]
+fn async_python_error_channel_preserves_same_named_stdlib_root_ancestry() {
+    for module in ["sifr.csv", "sifr.configparser"] {
+        let source = format!(
+            "from {module} import Error as ImportedError\n\ndef propagate(own error: ImportedError) -> Result[None, Error]:\n    raise error\n\ndef main():\n    pass\n"
+        );
+        let errors = type_check_source(&source);
+        assert!(errors.is_empty(), "{module}: {errors:?}");
+    }
+}

--- a/crates/sifr_driver/src/tests/async_python_error_channel_native.rs
+++ b/crates/sifr_driver/src/tests/async_python_error_channel_native.rs
@@ -1,0 +1,190 @@
+use super::project_build_check::mktemp_dir;
+use crate::{CompileResult, build, build_project, compile, emit_project};
+use std::path::Path;
+
+fn emitted(result: CompileResult) -> String {
+    match result {
+        CompileResult::Success { rust_source } => rust_source,
+        CompileResult::Errors { errors } => panic!("error conversion must emit: {errors:?}"),
+    }
+}
+
+fn run(binary: &Path) {
+    let output = std::process::Command::new(binary)
+        .output()
+        .expect("run native regression");
+    assert!(output.status.success(), "native regression: {output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "error-conversions-ok"
+    );
+}
+
+#[test]
+fn async_python_error_channel_native_local_and_transitive_conversions() {
+    let source = r#"
+class DomainError(Error):
+    message: str
+
+class DetailedError(DomainError):
+    detail: str
+
+    def __init__(self, message: str, detail: str):
+        super().__init__(message)
+        self.detail = detail
+
+def direct(own error: DomainError) -> Result[None, Error]:
+    raise error
+
+def inherited() -> Result[None, DetailedError]:
+    raise DetailedError("inherited", "detail")
+
+def propagate() -> Result[None, Error]:
+    return inherited()
+
+def main():
+    try:
+        _direct: None = direct(DomainError("direct"))
+        assert False
+    except Error as error:
+        assert error.message == "direct"
+    try:
+        _propagated: None = propagate()
+        assert False
+    except Error as error:
+        assert error.message == "inherited"
+    print("error-conversions-ok")
+"#;
+    let rust = emitted(compile(source));
+    assert!(rust.contains("From<DomainError> for Error"), "{rust}");
+    assert!(rust.contains("From<DetailedError> for Error"), "{rust}");
+    let dir = mktemp_dir("error_channel_local_native");
+    let binary = build(source, &dir).expect("local/transitive errors must compile natively");
+    run(&binary);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn async_python_error_channel_native_stdlib_nominal_collisions() {
+    let source = r#"
+from sifr.csv import Error as CsvError
+from sifr.configparser import Error as ConfigError
+
+def csv(own error: CsvError) -> Result[None, Error]:
+    raise error
+
+def config(own error: ConfigError) -> Result[None, Error]:
+    raise error
+
+def main():
+    try:
+        _csv: None = csv(CsvError("csv"))
+        assert False
+    except Error as error:
+        assert error.message == "csv"
+    try:
+        _config: None = config(ConfigError("config"))
+        assert False
+    except Error as error:
+        assert error.message == "config"
+    print("error-conversions-ok")
+"#;
+    let rust = emitted(compile(source));
+    for identity in ["sifr.csv.Error", "sifr.configparser.Error"] {
+        let name = sifr_type_system::class_rust_name(Some(identity), "Error");
+        assert_eq!(
+            rust.matches(&format!("From<{name}> for Error")).count(),
+            1,
+            "{rust}"
+        );
+    }
+    let dir = mktemp_dir("error_channel_stdlib_native");
+    let binary = build(source, &dir).expect("distinct stdlib errors must compile natively");
+    run(&binary);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn async_python_error_channel_native_project_aliases_and_collisions() {
+    let dir = mktemp_dir("error_channel_project_native");
+    for (name, source) in [
+        (
+            "left",
+            "class DomainError(Error):\n    message: str\n\nclass DetailedError(DomainError):\n    detail: str\n\n    def __init__(self, message: str, detail: str):\n        super().__init__(message)\n        self.detail = detail\n",
+        ),
+        ("right", "class DomainError(Error):\n    message: str\n"),
+        ("api", "from left import DomainError as PublicError\n"),
+        ("shadow", "class ValueError(Error):\n    message: str\n"),
+        (
+            "main",
+            r#"
+from api import PublicError as LeftError
+from left import DetailedError as LeftDetailedError
+from right import DomainError as RightError
+from shadow import ValueError as ShadowError
+
+def left(own error: LeftError) -> Result[None, Error]:
+    raise error
+
+def right(own error: RightError) -> Result[None, Error]:
+    raise error
+
+def detailed(own error: LeftDetailedError) -> Result[None, Error]:
+    raise error
+
+def shadow(own error: ShadowError) -> Result[None, Error]:
+    raise error
+
+def main():
+    try:
+        _left: None = left(LeftError("left"))
+        assert False
+    except Error as error:
+        assert error.message == "left"
+    try:
+        _right: None = right(RightError("right"))
+        assert False
+    except Error as error:
+        assert error.message == "right"
+    try:
+        _detailed: None = detailed(LeftDetailedError("detailed", "detail"))
+        assert False
+    except Error as error:
+        assert error.message == "detailed"
+    try:
+        _shadow: None = shadow(ShadowError("shadow"))
+        assert False
+    except Error as error:
+        assert error.message == "shadow"
+    print("error-conversions-ok")
+"#,
+        ),
+    ] {
+        std::fs::write(dir.join(format!("{name}.sifr")), source).expect("write source");
+    }
+    let main = dir.join("main.sifr");
+    let rust = emitted(emit_project(
+        &main,
+        &mut sifr_frontend::DiskSourceProvider::new(),
+    ));
+    for name in [
+        "crate::left::DomainError",
+        "crate::left::DetailedError",
+        "crate::right::DomainError",
+        "crate::shadow::ValueError",
+    ] {
+        assert_eq!(
+            rust.matches(&format!("From<{name}> for Error")).count(),
+            1,
+            "{rust}"
+        );
+    }
+    let binary = build_project(
+        &main,
+        &dir.join("out"),
+        &mut sifr_frontend::DiskSourceProvider::new(),
+    )
+    .expect("project error identities must compile natively");
+    run(&binary);
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod adapter_defaults;
 mod async_python_error_channel;
+mod async_python_error_channel_native;
 mod attached_api_aliases;
 mod attached_api_audit;
 mod attached_api_codegen;

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -18,6 +18,7 @@ mod project_error_exports;
 mod project_generic_identity;
 mod project_graph;
 mod project_python_class_metadata;
+mod required_error_message;
 mod single_file_frontend;
 mod stdlib_exports;
 mod support;

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod adapter_defaults;
+mod async_python_error_channel;
 mod attached_api_aliases;
 mod attached_api_audit;
 mod attached_api_codegen;

--- a/crates/sifr_driver/src/tests/package_project_build_check.rs
+++ b/crates/sifr_driver/src/tests/package_project_build_check.rs
@@ -4,6 +4,9 @@ use sifr_diagnostics::DiagnosticCode;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
+#[path = "required_error_message_python.rs"]
+mod required_error_message_python;
+
 #[derive(Clone)]
 struct TestPackage {
     root: PathBuf,

--- a/crates/sifr_driver/src/tests/required_error_message.rs
+++ b/crates/sifr_driver/src/tests/required_error_message.rs
@@ -1,0 +1,278 @@
+use super::project_build_check::mktemp_dir;
+use crate::{CompileResult, build, build_project, check, compile, emit_project, run_tests};
+use sifr_frontend::DiskSourceProvider;
+use std::path::Path;
+
+fn emitted(result: CompileResult) -> String {
+    match result {
+        CompileResult::Success { rust_source } => rust_source,
+        CompileResult::Errors { errors } => panic!("required error message must emit: {errors:?}"),
+    }
+}
+
+fn run(binary: &Path) {
+    let output = std::process::Command::new(binary)
+        .output()
+        .expect("execute native assertions");
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "required-error-message-ok"
+    );
+}
+
+#[test]
+fn required_error_message_rejects_invalid_source_before_emission() {
+    for source in [
+        "class EmptyError(Error):\n    pass\ndef main():\n    _error = EmptyError()\n",
+        "class CodeError(Error):\n    code: int\ndef main():\n    _error = CodeError(3)\n",
+        "class CodeError(Error):\n    message: int\ndef main():\n    _error = CodeError(3)\n",
+        "class CodeError(Error):\n    def __init__(self, code: int):\n        self.code = code\ndef main():\n    _error = CodeError(3)\n",
+    ] {
+        let errors = check(source);
+        assert!(!errors.is_empty(), "source check must reject: {source}");
+        assert!(
+            matches!(compile(source), CompileResult::Errors { .. }),
+            "emission must reject: {source}"
+        );
+    }
+}
+
+#[test]
+fn required_error_message_native_default_custom_and_inherited() {
+    let source = r#"
+class EmptyError(Error):
+    pass
+
+class CodeError(Error):
+    code: int
+
+class OwnError(Error):
+    code: int
+    message: str
+
+class CustomError(Error):
+    code: int
+
+    def __init__(self, text: str, code: int):
+        self.message = text + "!"
+        self.code = code
+
+class ChildError(CustomError):
+    pass
+
+class LeafError(ChildError):
+    pass
+
+class SuperError(Error):
+    code: int
+
+    def __init__(self, message: str, code: int):
+        super().__init__(message)
+        self.code = code
+
+class ImplicitError(Error):
+    def __init__(self, message: str):
+        pass
+
+class Payload:
+    code: int
+
+class MixedError(Payload, Error):
+    def __init__(self, message: str, code: int):
+        super().__init__(code)
+        self.message = message
+
+class MessageData:
+    message: str
+
+class MessageMid(MessageData):
+    def __init__(self, message: str):
+        super().__init__(message)
+
+class TaggedError(MessageMid, Error):
+    pass
+
+def specific() -> Result[None, CodeError]:
+    raise CodeError("specific", 3)
+
+def unrelated() -> Result[None, Error]:
+    raise ValueError("unrelated")
+
+def root(own error: CodeError) -> Result[None, Error]:
+    raise error
+
+def inherited() -> Result[None, LeafError]:
+    raise LeafError("inherited", 7)
+
+def propagate() -> Result[None, Error]:
+    return inherited()
+
+def take(own error: Error) -> str:
+    return error.message
+
+def main():
+    assert EmptyError("empty").message == "empty"
+    assert OwnError(4, "own").message == "own"
+    assert SuperError("super", 5).message == "super"
+    assert ImplicitError("implicit").message == "implicit"
+    assert str(LeafError("display", 7)) == "display!"
+    assert take(MixedError("mixed", 8)) == "mixed"
+    assert take(TaggedError("nested-data")) == "nested-data"
+    assert take(SuperError("super-root", 5)) == "super-root"
+    try:
+        _specific: None = specific()
+        assert False
+    except CodeError as error:
+        assert error.code == 3
+        assert error.message == "specific"
+    try:
+        _root: None = root(CodeError("root", 9))
+        assert False
+    except Error as error:
+        assert error.message == "root"
+    try:
+        _propagated: None = propagate()
+        assert False
+    except Error as error:
+        assert error.message == "inherited!"
+    print("required-error-message-ok")
+"#;
+    let rust = emitted(compile(source));
+    for name in [
+        "CodeError",
+        "EmptyError",
+        "OwnError",
+        "CustomError",
+        "ChildError",
+        "LeafError",
+        "SuperError",
+        "MixedError",
+    ] {
+        assert_eq!(
+            rust.matches(&format!("From<{name}> for Error")).count(),
+            1,
+            "{rust}"
+        );
+    }
+    assert!(
+        !rust.contains("new(err.to_string())"),
+        "conversion must consume string storage"
+    );
+    let dir = mktemp_dir("required_error_message_local");
+    let binary = build(source, &dir).expect("native local message contract");
+    run(&binary);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn required_error_message_native_project_and_test_project_identities() {
+    let dir = mktemp_dir("required_error_message_project");
+    let files = [
+        (
+            "left",
+            "class CodeError(Error):\n    code: int\nclass Inherited(CodeError):\n    pass\n",
+        ),
+        ("right", "class CodeError(Error):\n    code: int\n"),
+        ("facade", "from left import Inherited as PublicError\n"),
+        ("shadow", "class ValueError(Error):\n    pass\n"),
+        (
+            "csv_child",
+            "from sifr.csv import Error\nclass CsvChild(Error):\n    pass\n",
+        ),
+        ("ordinary", "class Error:\n    code: int\n"),
+        (
+            "ordinary_child",
+            "from ordinary import Error\nclass OrdinaryChild(Error):\n    def __init__(self, code: int):\n        super().__init__(code)\n",
+        ),
+        (
+            "checks",
+            r#"
+from facade import PublicError as LeftError
+from right import CodeError as RightError
+from shadow import ValueError as ShadowError
+from csv_child import CsvChild
+from sifr.configparser import NoSectionError
+from ordinary_child import OrdinaryChild
+
+def take(own error: Error) -> str:
+    return error.message
+
+def fail() -> Result[None, LeftError]:
+    raise LeftError("project", 3)
+
+def propagate() -> Result[None, Error]:
+    return fail()
+
+def verify():
+    assert OrdinaryChild(17).code == 17
+    assert LeftError("left", 1).code == 1
+    assert take(LeftError("left", 1)) == "left"
+    assert take(RightError("right", 2)) == "right"
+    assert take(ShadowError("shadow")) == "shadow"
+    assert take(CsvChild("csv")) == "csv"
+    assert take(NoSectionError("section")) == "no section: section"
+    try:
+        _result: None = propagate()
+        assert False
+    except Error as error:
+        assert error.message == "project"
+"#,
+        ),
+        (
+            "main",
+            "from checks import verify\ndef main():\n    verify()\n    print(\"required-error-message-ok\")\n",
+        ),
+        (
+            "test_messages",
+            "from checks import verify\ndef test_required_message():\n    verify()\n",
+        ),
+    ];
+    for (name, source) in files {
+        std::fs::write(dir.join(format!("{name}.sifr")), source).expect("write owned test fixture");
+    }
+    let main = dir.join("main.sifr");
+    let rust = emitted(emit_project(&main, &mut DiskSourceProvider::new()));
+    for name in [
+        "crate::left::CodeError",
+        "crate::left::Inherited",
+        "crate::right::CodeError",
+        "crate::shadow::ValueError",
+        "crate::csv_child::CsvChild",
+    ] {
+        assert_eq!(
+            rust.matches(&format!("From<{name}> for Error")).count(),
+            1,
+            "{rust}"
+        );
+    }
+    let binary = build_project(&main, &dir.join("out"), &mut DiskSourceProvider::new())
+        .expect("native imported message contract");
+    run(&binary);
+    assert!(
+        run_tests(&dir, &mut DiskSourceProvider::new())
+            .expect("native test-project message contract")
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn required_error_message_imported_constructor_rejects_missing_message() {
+    let dir = mktemp_dir("required_error_message_negative_project");
+    std::fs::write(
+        dir.join("errors.sifr"),
+        "class CodeError(Error):\n    code: int\nclass LeafError(CodeError):\n    pass\n",
+    )
+    .expect("write declarations");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from errors import LeafError\ndef main():\n    _error = LeafError(3)\n",
+    )
+    .expect("write invalid call");
+    let result = emit_project(&dir.join("main.sifr"), &mut DiskSourceProvider::new());
+    assert!(
+        matches!(result, CompileResult::Errors { .. }),
+        "invalid imported call must fail before Rust"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/crates/sifr_driver/src/tests/required_error_message_python.rs
+++ b/crates/sifr_driver/src/tests/required_error_message_python.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+#[test]
+fn required_error_message_python_native_five_field_contract() {
+    let dir = mktemp_dir("required_error_message_python");
+    let app = production_package(&dir, "app", "sifr-demo-app", "demo_app");
+    write_package_source(
+        &app,
+        "main.sifr",
+        r#"
+from sifr.python import PythonError
+
+def take(own error: Error) -> str:
+    return error.message
+
+def main():
+    error = PythonError("python", "kind", "Exception", "traceback", "context")
+    assert error.message == "python"
+    assert error.kind == "kind"
+    assert error.exception_type == "Exception"
+    assert error.traceback == "traceback"
+    assert error.context == "context"
+    assert take(error) == "python"
+    print("required-error-message-ok")
+"#,
+    );
+    let graph = package_graph(&dir, &[&app], &[]);
+    let source_map = sifr_package::PackageSourceMap::build(
+        &graph,
+        &mut sifr_frontend::DiskSourceProvider::new(),
+    )
+    .expect("source map");
+    let mut entrypoint =
+        package_entrypoint(&graph, &source_map, &app, app.root.join("src/main.sifr"));
+    // Canonical PythonError links the Python runtime even without invoking
+    // Python. Use the existing probed package fixture, including native trust.
+    entrypoint.python_runtime = Some(local_python_runtime(&dir));
+    let artifact =
+        build_cached_package_project(&entrypoint, &mut sifr_frontend::DiskSourceProvider::new())
+            .expect("canonical PythonError must build with the selected runtime");
+    let output = std::process::Command::new(artifact.binary_path())
+        .output()
+        .expect("execute native PythonError assertions");
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "required-error-message-ok"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/crates/sifr_frontend/src/callable_identities.rs
+++ b/crates/sifr_frontend/src/callable_identities.rs
@@ -533,7 +533,7 @@ fn class_type(module_name: &str, class: &HirClass) -> Type {
         name: class.name.clone(),
         fields: class.fields.clone(),
         methods: Vec::new(),
-        parent_class: class.parent_class.clone(),
+        parent_class: class.semantic_parent_chain(),
     }
 }
 

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -321,11 +321,15 @@ pub fn collect_module_exports(
                         name: class.name.clone(),
                         fields: exported_class_fields(class),
                         methods,
-                        parent_class: exported_parent_chain(
-                            class.parent_class.as_deref(),
-                            module,
-                            &imported_ancestry,
-                        ),
+                        parent_class: if class.is_error_type {
+                            class.semantic_parent_chain()
+                        } else {
+                            exported_parent_chain(
+                                class.parent_class.as_deref(),
+                                module,
+                                &imported_ancestry,
+                            )
+                        },
                     },
                 }
             };

--- a/crates/sifr_frontend/src/slot_table.rs
+++ b/crates/sifr_frontend/src/slot_table.rs
@@ -408,7 +408,7 @@ fn owner_type_for_identity(
                 name: class.name.clone(),
                 fields: class.fields.clone(),
                 methods: Vec::new(),
-                parent_class: class.parent_class.clone(),
+                parent_class: class.semantic_parent_chain(),
             });
         }
     }

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -50,7 +50,7 @@ pub(crate) fn run_specializations(
             name: class.name.clone(),
             fields: class.fields.clone(),
             methods: Vec::new(),
-            parent_class: class.parent_class.clone(),
+            parent_class: class.semantic_parent_chain(),
         };
         if !class.type_params.is_empty() {
             errors.push(malformed(

--- a/crates/sifr_ir/src/class_ancestry.rs
+++ b/crates/sifr_ir/src/class_ancestry.rs
@@ -1,0 +1,31 @@
+use crate::HirClass;
+use sifr_type_system::Type;
+
+impl HirClass {
+    /// Nominal ancestry for type checking, separate from the stored data parent.
+    /// The builtin Error marker has no embedded parent field.
+    #[must_use]
+    pub fn semantic_parent_chain(&self) -> Option<String> {
+        if !self.is_error_type {
+            return self.parent_class.clone();
+        }
+        if let Some(Type::Class {
+            identity,
+            name,
+            parent_class,
+            ..
+        }) = self.parent_type.as_ref().map(Type::resolve_alias)
+        {
+            let parent = identity.as_ref().unwrap_or(name);
+            return Some(match parent_class {
+                Some(chain) => format!("{parent}|{chain}"),
+                None => parent.clone(),
+            });
+        }
+        Some(
+            self.parent_class
+                .clone()
+                .unwrap_or_else(|| "Error".to_string()),
+        )
+    }
+}

--- a/crates/sifr_ir/src/class_ancestry.rs
+++ b/crates/sifr_ir/src/class_ancestry.rs
@@ -17,10 +17,17 @@ impl HirClass {
         }) = self.parent_type.as_ref().map(Type::resolve_alias)
         {
             let parent = identity.as_ref().unwrap_or(name);
-            return Some(match parent_class {
+            let mut chain = match parent_class {
                 Some(chain) => format!("{parent}|{chain}"),
                 None => parent.clone(),
-            });
+            };
+            if !chain
+                .split('|')
+                .any(|ancestor| matches!(ancestor, "Error" | "sifr.builtin.Error"))
+            {
+                chain.push_str("|Error");
+            }
+            return Some(chain);
         }
         Some(
             self.parent_class

--- a/crates/sifr_ir/src/lib.rs
+++ b/crates/sifr_ir/src/lib.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 pub mod cfg;
+mod class_ancestry;
 pub mod diagnostic_types;
 pub mod flow_graph;
 mod hir_expr;

--- a/crates/sifr_lowering/Cargo.toml
+++ b/crates/sifr_lowering/Cargo.toml
@@ -20,5 +20,8 @@ bigdecimal = "0.4.10"
 num-bigint = { workspace = true }
 serde_json = { workspace = true }
 
+[dev-dependencies]
+insta = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/sifr_lowering/src/lower/classes.rs
+++ b/crates/sifr_lowering/src/lower/classes.rs
@@ -17,8 +17,14 @@ use ruff_text_size::Ranged;
 use sifr_python_ast::{Expr, Stmt, StmtClassDef};
 use sifr_type_system::{FunctionType, ParamConvention, Type};
 
+mod class_declaration_diagnostics;
 mod class_type_collection;
+use class_declaration_diagnostics::{
+    missing_method_param_annotation, unsupported_class_declaration,
+};
+mod error_message_contract;
 pub(in crate::lower) use class_type_collection::*;
+pub(in crate::lower) use error_message_contract::root_error_type;
 mod class_iteration_protocol;
 use class_iteration_protocol::validate_iteration_protocol_methods;
 mod class_semantics;

--- a/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
@@ -614,12 +614,26 @@ pub(in crate::lower) fn lower_class(
             let previous_must_use_bindings = std::mem::take(&mut ctx.live_must_use_bindings);
             let previous_borrowed_params = std::mem::take(&mut ctx.borrowed_params);
             prepare_method_param_ownership(&params, &method_name, skips_normal_body_lowering, ctx);
-            let body = if skips_normal_body_lowering {
+            let mut body = if skips_normal_body_lowering {
                 Vec::new()
             } else {
                 lower_function_stmts(&func.body, &method_ft, ctx)
             };
             if method_name == "__init__" {
+                if ctx.error_types.contains(&class_name) && !skips_normal_body_lowering {
+                    super::error_message_contract::lower_root_initialization(&mut body);
+                    super::error_message_contract::validate_constructor(
+                        class_def,
+                        func,
+                        &body,
+                        &own_fields,
+                        &params,
+                        parent_class_name
+                            .as_deref()
+                            .is_some_and(|parent| parent != "NonSend"),
+                        ctx,
+                    );
+                }
                 if let Some(gap) = constructor_uninitialized_storage_at_first_self_use(
                     &body,
                     &own_fields,
@@ -738,6 +752,15 @@ pub(in crate::lower) fn lower_class(
     super::python_cleanup_validation::validate(class_def, &hir_methods, ctx);
 
     let is_error = ctx.error_types.contains(&class_name);
+    if is_error && own_fields.is_empty() && !hir_methods.iter().any(|method| method.name == "new") {
+        if let (Some(parent), Some(parent_ty)) = (&parent_class_name, &parent_type) {
+            if let Some(constructor) = super::error_message_contract::inherited_constructor(
+                class_def, parent, parent_ty, ctx,
+            ) {
+                hir_methods.push(constructor);
+            }
+        }
+    }
     if is_error
         && !all_fields
             .iter()

--- a/crates/sifr_lowering/src/lower/classes/class_declaration_diagnostics.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_declaration_diagnostics.rs
@@ -1,0 +1,56 @@
+use super::{Expr, LowerCtx, StmtClassDef};
+use ruff_text_size::{Ranged, TextRange};
+use sifr_diagnostics::DiagnosticCode;
+
+pub(super) fn missing_method_param_annotation(
+    ctx: &mut LowerCtx,
+    class_name: &str,
+    method_name: &str,
+    param_name: &str,
+    range: ruff_text_size::TextRange,
+) {
+    ctx.error_with_code_at(
+        DiagnosticCode::TYPE_MISSING_ANNOTATION,
+        format!(
+            "parameter '{param_name}' in {class_name}.{method_name} is missing a type annotation"
+        ),
+        range,
+    );
+}
+
+pub(super) fn invalid_class_base(
+    ctx: &mut LowerCtx,
+    class_name: &str,
+    reason: &str,
+    range: TextRange,
+) {
+    ctx.error_with_code_at(
+        DiagnosticCode::CLASS_INVALID_BASE,
+        format!("invalid base class for '{class_name}': {reason}"),
+        range,
+    );
+}
+
+pub(super) fn unsupported_class_declaration(
+    ctx: &mut LowerCtx,
+    class_name: &str,
+    detail: &str,
+    range: TextRange,
+) {
+    ctx.error_with_code_at(
+        DiagnosticCode::CLASS_UNSUPPORTED_DECLARATION,
+        format!("unsupported class declaration in '{class_name}': {detail}"),
+        range,
+    );
+}
+
+pub(super) fn parent_class_range(class_def: &StmtClassDef, parent_name: &str) -> TextRange {
+    class_def
+        .bases()
+        .iter()
+        .find_map(|base| match base {
+            Expr::Name(name) if name.id.as_str() == parent_name => Some(name.range()),
+            _ => None,
+        })
+        .unwrap_or_else(|| class_def.name.range())
+}

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -306,7 +306,7 @@ pub(in crate::lower) fn collect_class_type(
     // Inherit parent fields and methods for single inheritance
     let parent_class_name =
         crate::lower::descriptor_declarations::data_parent_name(&class_name, ctx);
-    let mut parent_class_chain: Option<String> = None;
+    let mut parent_class_chain = is_error.then(|| "Error".to_string());
     let mut inherited_field_defaults = Vec::new();
     if let Some(ref parent_name) = parent_class_name {
         if let Some(parent_ty) =

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -1,6 +1,6 @@
 use super::str;
 use crate::hir_nodes::HirExpr;
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::Ranged;
 use sifr_diagnostics::DiagnosticCode;
 use sifr_python_ast::{Expr, Stmt, StmtClassDef};
 use sifr_type_system::{FunctionType, ParamConvention, Type};
@@ -46,58 +46,10 @@ pub(super) fn method_signature_return_type(
     }
 }
 
-pub(super) fn missing_method_param_annotation(
-    ctx: &mut LowerCtx,
-    class_name: &str,
-    method_name: &str,
-    param_name: &str,
-    range: ruff_text_size::TextRange,
-) {
-    ctx.error_with_code_at(
-        DiagnosticCode::TYPE_MISSING_ANNOTATION,
-        format!(
-            "parameter '{param_name}' in {class_name}.{method_name} is missing a type annotation"
-        ),
-        range,
-    );
-}
-
-pub(super) fn invalid_class_base(
-    ctx: &mut LowerCtx,
-    class_name: &str,
-    reason: &str,
-    range: TextRange,
-) {
-    ctx.error_with_code_at(
-        DiagnosticCode::CLASS_INVALID_BASE,
-        format!("invalid base class for '{class_name}': {reason}"),
-        range,
-    );
-}
-
-pub(super) fn unsupported_class_declaration(
-    ctx: &mut LowerCtx,
-    class_name: &str,
-    detail: &str,
-    range: TextRange,
-) {
-    ctx.error_with_code_at(
-        DiagnosticCode::CLASS_UNSUPPORTED_DECLARATION,
-        format!("unsupported class declaration in '{class_name}': {detail}"),
-        range,
-    );
-}
-
-pub(super) fn parent_class_range(class_def: &StmtClassDef, parent_name: &str) -> TextRange {
-    class_def
-        .bases()
-        .iter()
-        .find_map(|base| match base {
-            Expr::Name(name) if name.id.as_str() == parent_name => Some(name.range()),
-            _ => None,
-        })
-        .unwrap_or_else(|| class_def.name.range())
-}
+use super::class_declaration_diagnostics::{
+    invalid_class_base, missing_method_param_annotation, parent_class_range,
+    unsupported_class_declaration,
+};
 
 pub(in crate::lower) fn collect_class_type(
     class_def: &StmtClassDef,
@@ -108,7 +60,7 @@ pub(in crate::lower) fn collect_class_type(
     let mut fields: Vec<(String, Type)> = Vec::new();
     let mut methods: Vec<(String, FunctionType)> = Vec::new();
     let mut method_ranges: HashMap<String, ruff_text_size::TextRange> = HashMap::new();
-    let is_error = is_error_class_with_ctx(class_def, &ctx.error_types);
+    let is_error = is_error_class_with_ctx(class_def, ctx);
     let is_protocol = is_protocol_class(class_def);
     let newtype_inner = get_newtype_inner(class_def);
 
@@ -301,8 +253,6 @@ pub(in crate::lower) fn collect_class_type(
         return;
     }
 
-    // For error types, ensure a 'message' field exists (add if not explicitly declared)
-    // This will be checked after collecting all fields
     // Inherit parent fields and methods for single inheritance
     let parent_class_name =
         crate::lower::descriptor_declarations::data_parent_name(&class_name, ctx);
@@ -373,6 +323,9 @@ pub(in crate::lower) fn collect_class_type(
         }
     }
     let inherited_field_count = fields.len();
+    if is_error {
+        super::error_message_contract::seed(class_def, &mut fields);
+    }
 
     // Register a preliminary class type so self-referential annotations work
     // (e.g., `def distance(self, other: Point)` inside class Point)
@@ -771,6 +724,15 @@ pub(in crate::lower) fn collect_class_type(
     }
 
     let is_python_opaque = ctx.python_opaque_classes.contains_key(&class_name);
+    if is_error {
+        super::error_message_contract::collect(
+            class_def,
+            &mut fields,
+            &mut field_defaults,
+            &mut parent_class_chain,
+            ctx,
+        );
+    }
     let generic_type_args = ctx
         .class_declared_type_params
         .get(&class_name)
@@ -792,6 +754,7 @@ pub(in crate::lower) fn collect_class_type(
         },
     };
 
+    super::error_message_contract::inherit_constructor(class_def, &fields, is_error, ctx);
     // Update the constructor function to return the class type
     if is_python_opaque {
         ctx.functions.remove(&class_name);
@@ -885,6 +848,9 @@ pub(in crate::lower) fn collect_class_type(
 
     if is_error {
         ctx.error_types.insert(class_name.clone());
+    } else {
+        // A declaration can shadow a builtin error name without inheriting it.
+        ctx.error_types.remove(&class_name);
     }
 
     if !field_defaults.is_empty() {

--- a/crates/sifr_lowering/src/lower/classes/error_message_contract.rs
+++ b/crates/sifr_lowering/src/lower/classes/error_message_contract.rs
@@ -1,0 +1,285 @@
+//! The required string representation shared by error declarations and constructors.
+use super::{HirExpr, HirFunction, HirParam, HirStmt, LowerCtx, MethodKind, Stmt, Type};
+use ruff_text_size::Ranged;
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_ast::StmtClassDef;
+
+pub(in crate::lower) fn root_error_type() -> Type {
+    Type::Class {
+        identity: None,
+        type_args: Vec::new(),
+        name: "Error".to_string(),
+        fields: vec![("message".to_string(), Type::Str)],
+        methods: Vec::new(),
+        parent_class: None,
+    }
+}
+
+pub(super) fn seed(class: &StmtClassDef, fields: &mut Vec<(String, Type)>) {
+    let explicitly_declared = class.body.iter().any(|stmt| matches!(stmt,
+        Stmt::AnnAssign(ann) if matches!(ann.target.as_ref(), sifr_python_ast::Expr::Name(name) if name.id.as_str() == "message")));
+    if !explicitly_declared && !fields.iter().any(|(name, _)| name == "message") {
+        fields.push(("message".to_string(), Type::Str));
+    }
+}
+
+pub(super) fn collect(
+    class: &StmtClassDef,
+    fields: &mut Vec<(String, Type)>,
+    defaults: &mut Vec<(usize, HirExpr)>,
+    ancestry: &mut Option<String>,
+    ctx: &mut LowerCtx,
+) {
+    // An explicit Error marker also applies when the data parent is not an error.
+    if let Some(chain) = ancestry {
+        if !chain
+            .split('|')
+            .any(|parent| matches!(parent, "Error" | "sifr.builtin.Error"))
+        {
+            chain.push_str("|Error");
+        }
+    }
+    if let Some(index) = fields.iter().position(|(name, _)| name == "message") {
+        if !matches!(fields[index].1.resolve_alias(), Type::Str) {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                format!(
+                    "error class '{}': message must have type 'str', got '{}'",
+                    class.name,
+                    fields[index].1.display_name()
+                ),
+                class.name.range(),
+            );
+        }
+        if defaults.iter().any(|(field, _)| *field == index) {
+            ctx.error_with_code_at(
+                DiagnosticCode::CLASS_UNSUPPORTED_DECLARATION,
+                format!("error class '{}': message must be supplied by the constructor, not a field default", class.name),
+                class.name.range(),
+            );
+            defaults.retain(|(field, _)| *field != index);
+        }
+    } else {
+        // Preserve explicit layouts (especially PythonError); only absent storage
+        // gains the inherited root field, before the additional payload fields.
+        fields.insert(0, ("message".to_string(), Type::Str));
+        for (index, _) in defaults {
+            *index += 1;
+        }
+    }
+}
+
+pub(super) fn inherit_constructor(
+    class: &StmtClassDef,
+    fields: &[(String, Type)],
+    is_error: bool,
+    ctx: &mut LowerCtx,
+) {
+    let explicit_constructor = class
+        .body
+        .iter()
+        .any(|stmt| matches!(stmt, Stmt::FunctionDef(f) if f.name.as_str() == "__init__"));
+    if !explicit_constructor
+        && ctx
+            .functions
+            .get(class.name.as_str())
+            .is_some_and(|function| function.return_type.is_builtin_error_base())
+    {
+        ctx.functions.remove(class.name.as_str());
+        ctx.function_defaults.remove(class.name.as_str());
+    }
+    if !is_error || explicit_constructor {
+        return;
+    }
+    // Collection repeats after annotations resolve. Do not retain the provisional
+    // field-derived signature, or a colliding builtin constructor signature.
+    ctx.functions.remove(class.name.as_str());
+    ctx.function_defaults.remove(class.name.as_str());
+    let Some(parent) =
+        super::super::descriptor_declarations::data_parent_name(class.name.as_str(), ctx)
+    else {
+        return;
+    };
+    let Some(Type::Class {
+        fields: parent_fields,
+        ..
+    }) = ctx.class_types.get(&parent)
+    else {
+        return;
+    };
+    if fields != parent_fields {
+        return; // ordinary missing-initializer diagnostic owns additional fields
+    }
+    if let Some(constructor) = ctx.functions.get(&parent).cloned() {
+        let defaults = ctx
+            .function_defaults
+            .get(&parent)
+            .cloned()
+            .unwrap_or_default();
+        if !constructor
+            .params
+            .iter()
+            .enumerate()
+            .any(|(index, (_, ty, _))| {
+                matches!(ty.resolve_alias(), Type::Str)
+                    && !defaults.iter().any(|(default, _)| *default == index)
+            })
+        {
+            ctx.error_with_code_at(
+                DiagnosticCode::CLASS_MISSING_INITIALIZER,
+                format!("error class '{}': inherited constructor requires a caller-supplied 'str' parameter for its message", class.name),
+                class.name.range(),
+            );
+        }
+        ctx.functions.insert(class.name.to_string(), constructor);
+        if !defaults.is_empty() {
+            ctx.function_defaults
+                .insert(class.name.to_string(), defaults);
+        }
+    }
+}
+
+pub(super) fn lower_root_initialization(body: &mut [HirStmt]) {
+    for stmt in body {
+        if let HirStmt::Expr {
+            expr:
+                HirExpr::SuperCall {
+                    parent_type,
+                    method,
+                    args,
+                    ..
+                },
+        } = stmt
+        {
+            if parent_type.is_builtin_error_base() && method == "new" && args.len() == 1 {
+                *stmt = HirStmt::FieldAssign {
+                    object: "self".to_string(),
+                    field: "message".to_string(),
+                    field_ty: Type::Str,
+                    value: args[0].clone(),
+                };
+            }
+        }
+    }
+}
+
+pub(super) fn validate_constructor(
+    class: &StmtClassDef,
+    function: &sifr_python_ast::StmtFunctionDef,
+    body: &[HirStmt],
+    own_fields: &[(String, Type)],
+    params: &[HirParam],
+    requires_parent: bool,
+    ctx: &mut LowerCtx,
+) {
+    if !params
+        .iter()
+        .any(|param| matches!(param.ty.resolve_alias(), Type::Str) && param.default.is_none())
+    {
+        ctx.error_with_code_at(
+            DiagnosticCode::CLASS_MISSING_INITIALIZER,
+            format!("error class '{}': constructor requires a caller-supplied 'str' parameter for its message", class.name),
+            function.name.range(),
+        );
+    }
+    // A final materialization uses self even if the source body does not. The
+    // same storage proof used for early self access must hold at that boundary.
+    let mut materialization = body.to_vec();
+    materialization.push(HirStmt::Expr {
+        expr: HirExpr::Name {
+            name: "self".to_string(),
+            binding_id: None,
+            ty: Type::None,
+        },
+    });
+    if let Some(gap) = super::constructor_uninitialized_storage_at_first_self_use(
+        &materialization,
+        own_fields,
+        params,
+        requires_parent,
+    ) {
+        if gap.statement_index == body.len() {
+            ctx.error_with_code_at(
+                DiagnosticCode::CLASS_MISSING_INITIALIZER,
+                format!(
+                    "error class '{}': constructor must initialize required storage: {}{}",
+                    class.name,
+                    if gap.missing_parent {
+                        "super().__init__(...), "
+                    } else {
+                        ""
+                    },
+                    gap.missing_fields.join(", ")
+                ),
+                function.name.range(),
+            );
+        }
+    }
+    if own_fields.iter().any(|(field, _)| field == "message") {
+        if let Some(param) = params.iter().find(|param| param.name == "message") {
+            if !matches!(param.ty.resolve_alias(), Type::Str) || param.default.is_some() {
+                ctx.error_with_code_at(
+                    DiagnosticCode::TYPE_MISMATCH,
+                    format!(
+                        "error class '{}': constructor message parameter must be a required 'str'",
+                        class.name
+                    ),
+                    function.name.range(),
+                );
+            }
+        }
+    }
+}
+
+pub(super) fn inherited_constructor(
+    class: &StmtClassDef,
+    parent_name: &str,
+    parent_type: &Type,
+    ctx: &LowerCtx,
+) -> Option<HirFunction> {
+    let constructor = ctx.functions.get(class.name.as_str())?;
+    let defaults = ctx.function_defaults.get(class.name.as_str());
+    let params: Vec<_> = constructor
+        .params
+        .iter()
+        .enumerate()
+        .map(|(index, (name, ty, convention))| HirParam {
+            name: name.clone(),
+            ty: ty.clone(),
+            convention: *convention,
+            keyword_only: false,
+            default: defaults
+                .and_then(|defaults| defaults.iter().find(|(i, _)| *i == index))
+                .map(|(_, value)| value.clone()),
+        })
+        .collect();
+    Some(HirFunction {
+        name: "new".to_string(),
+        body: vec![HirStmt::Expr {
+            expr: HirExpr::SuperCall {
+                parent_class: parent_name.to_string(),
+                parent_type: parent_type.clone(),
+                method: "new".to_string(),
+                args: params
+                    .iter()
+                    .map(|param| HirExpr::Name {
+                        name: param.name.clone(),
+                        binding_id: None,
+                        ty: param.ty.clone(),
+                    })
+                    .collect(),
+                ty: parent_type.clone(),
+            },
+        }],
+        params,
+        return_type: Type::None,
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        receiver: None,
+        decorators: Vec::new(),
+        rust_interop: Vec::new(),
+        python_interop: Vec::new(),
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    })
+}

--- a/crates/sifr_lowering/src/lower/descriptor_declarations.rs
+++ b/crates/sifr_lowering/src/lower/descriptor_declarations.rs
@@ -338,7 +338,17 @@ fn collect_class_bases(stmts: &[Stmt], ctx: &mut LowerCtx) {
                     continue;
                 }
             }
-            if special_base(name) {
+            let imported_error_parent = name == "Error"
+                && ctx.class_types.get(name).is_some_and(|ty| {
+                    matches!(
+                        ty.resolve_alias(),
+                        Type::Class {
+                            identity: Some(_),
+                            ..
+                        }
+                    ) && !ty.is_builtin_error_base()
+                });
+            if special_base(name) && !imported_error_parent {
                 continue;
             }
             data_parents.push((range, name.to_string()));

--- a/crates/sifr_lowering/src/lower/diagnostics.rs
+++ b/crates/sifr_lowering/src/lower/diagnostics.rs
@@ -6,14 +6,27 @@ use sifr_type_system::Type;
 
 use super::LowerCtx;
 
-pub(in crate::lower) fn is_error_class_with_ctx(
-    class_def: &StmtClassDef,
-    error_types: &std::collections::HashSet<String>,
-) -> bool {
+pub(in crate::lower) fn is_error_class_with_ctx(class_def: &StmtClassDef, ctx: &LowerCtx) -> bool {
     for base in class_def.bases() {
         if let Expr::Name(n) = base {
             let base_name = n.id.as_str();
-            if base_name == "Error" || error_types.contains(base_name) {
+            // The declaration-base pass distinguishes the builtin Error marker
+            // from an imported data parent whose local spelling is Error. Local
+            // declarations are provisional here, including class Error(Error).
+            if base_name == "Error"
+                && super::descriptor_declarations::data_parent_name(class_def.name.as_str(), ctx)
+                    .as_deref()
+                    != Some("Error")
+            {
+                return true;
+            }
+            let is_error = ctx.class_types.get(base_name).map_or_else(
+                || ctx.error_types.contains(base_name),
+                |ty| ty.is_builtin_error_base() || matches!(ty.resolve_alias(), Type::Class {
+                    parent_class: Some(chain), ..
+                } if chain.split('|').any(|parent| matches!(parent, "Error" | "sifr.builtin.Error"))),
+            );
+            if is_error {
                 return true;
             }
         }

--- a/crates/sifr_lowering/src/lower/expressions/method_argument_ownership.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_argument_ownership.rs
@@ -74,6 +74,43 @@ pub(super) fn try_lower_super_method_call(
         return None;
     }
     let method_name = attr.attr.to_string();
+    if method_name == "__init__"
+        && ctx.current_parent_class.is_none()
+        && ctx
+            .current_class
+            .as_ref()
+            .is_some_and(|class| ctx.error_types.contains(class))
+    {
+        let parent_type = super::super::classes::root_error_type();
+        let signature = FunctionType::new(
+            vec![("message".to_string(), Type::Str)],
+            parent_type.clone(),
+        );
+        let Some(args) = lower_signature_call_args(call, "Error", &signature, None, ctx) else {
+            return Some(None);
+        };
+        if !matches!(
+            args[0].ty().resolve_alias(),
+            Type::Str | Type::LiteralStr(_)
+        ) {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                format!(
+                    "Error.__init__(): expected 'str' message, got '{}'",
+                    args[0].ty().display_name()
+                ),
+                call.range(),
+            );
+            return Some(None);
+        }
+        return Some(Some(HirExpr::SuperCall {
+            parent_class: "Error".to_string(),
+            parent_type: parent_type.clone(),
+            method: "new".to_string(),
+            args,
+            ty: parent_type,
+        }));
+    }
     let (Some(parent_name), Some(parent_type)) = (
         ctx.current_parent_class.clone(),
         ctx.current_parent_type.clone(),
@@ -130,6 +167,27 @@ pub(super) fn try_lower_super_method_call(
         return Some(None);
     };
     consume_owned_method_arguments(&args, call, &function_type, ctx);
+    if method_name == "__init__"
+        && ctx
+            .current_class
+            .as_ref()
+            .is_some_and(|class| ctx.error_types.contains(class))
+    {
+        for (arg, (name, expected, _)) in args.iter().zip(&function_type.params) {
+            if !arg.ty().is_assignable_to(expected) {
+                ctx.error_with_code_at(
+                    DiagnosticCode::TYPE_MISMATCH,
+                    format!(
+                        "{parent_name}.__init__(): argument '{name}' expected '{}', got '{}'",
+                        expected.display_name(),
+                        arg.ty().display_name()
+                    ),
+                    call.range(),
+                );
+                return Some(None);
+            }
+        }
+    }
     super::super::sequence_guards::invalidate_mutable_call_sequence_guards(
         ctx,
         &args,

--- a/crates/sifr_lowering/src/lower/imported_class_identity.rs
+++ b/crates/sifr_lowering/src/lower/imported_class_identity.rs
@@ -483,7 +483,7 @@ fn set_canonical_identities(ty: &mut Type, local_classes: &HashMap<String, Strin
                                 // A same-named base refers to the prior declaration
                                 // (notably builtin Error), never the class itself.
                                 .filter(|parent_identity| {
-                                    Some(*parent_identity) != identity.as_ref()
+                                    parent != "Error" && Some(*parent_identity) != identity.as_ref()
                                 })
                                 .map_or_else(|| parent.to_string(), Clone::clone)
                         })

--- a/crates/sifr_lowering/src/lower/imported_class_identity.rs
+++ b/crates/sifr_lowering/src/lower/imported_class_identity.rs
@@ -480,6 +480,11 @@ fn set_canonical_identities(ty: &mut Type, local_classes: &HashMap<String, Strin
                         .map(|parent| {
                             local_classes
                                 .get(parent)
+                                // A same-named base refers to the prior declaration
+                                // (notably builtin Error), never the class itself.
+                                .filter(|parent_identity| {
+                                    Some(*parent_identity) != identity.as_ref()
+                                })
                                 .map_or_else(|| parent.to_string(), Clone::clone)
                         })
                         .collect::<Vec<_>>()

--- a/crates/sifr_lowering/src/lower/imports.rs
+++ b/crates/sifr_lowering/src/lower/imports.rs
@@ -336,7 +336,13 @@ pub(in crate::lower) fn resolve_imports_early(
                 for name in &names {
                     let local = local_name_for(name);
                     if let Some(class_ty) = module_classes.get(name) {
-                        if !ctx.class_types.contains_key(&local) {
+                        if !ctx.class_types.contains_key(&local)
+                            || (local == "Error"
+                                && ctx
+                                    .class_types
+                                    .get(&local)
+                                    .is_some_and(sifr_type_system::Type::is_builtin_error_base))
+                        {
                             let imported_class_ty = super::imported_class_identity::type_for_import(
                                 class_ty,
                                 &module_key,
@@ -404,6 +410,8 @@ pub(in crate::lower) fn resolve_imports_early(
                             // Register as error type if flagged
                             if externals.is_error_type(&module_key, name) {
                                 ctx.error_types.insert(local.clone());
+                            } else if local == "Error" {
+                                ctx.error_types.remove(&local);
                             }
                             if let Some(module_workloads) =
                                 externals.function_workloads.get(&module_key)

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -162,6 +162,8 @@ mod python_interop_tests;
 mod python_interop_validation_tests;
 #[cfg(test)]
 mod python_trust_tests;
+#[cfg(test)]
+mod required_error_message_tests;
 mod result_diagnostics;
 #[cfg(test)]
 mod result_diagnostics_tests;

--- a/crates/sifr_lowering/src/lower/required_error_message_tests.rs
+++ b/crates/sifr_lowering/src/lower/required_error_message_tests.rs
@@ -1,0 +1,202 @@
+use crate::lower_module;
+use sifr_python_parser::parse_module;
+use sifr_type_system::Type;
+
+#[test]
+fn required_error_message_rejects_invalid_storage_and_constructors() {
+    for (source, diagnostic) in [
+        (
+            "class Data:\n    message: str = \"default\"\nclass Bad(Data, Error):\n    pass\n",
+            "inherited constructor requires a caller-supplied 'str' parameter",
+        ),
+        (
+            "class Data:\n    message: str\n    def __init__(self):\n        self.message = \"fixed\"\nclass Bad(Data, Error):\n    pass\n",
+            "inherited constructor requires a caller-supplied 'str' parameter",
+        ),
+        (
+            "class Bad(Error):\n    def __init__(self):\n        self.message = \"fixed\"\n",
+            "caller-supplied 'str' parameter",
+        ),
+        (
+            "class Bad(Error):\n    def __init__(self, text: str = \"default\"):\n        self.message = text\n",
+            "caller-supplied 'str' parameter",
+        ),
+        (
+            "class Bad(Error):\n    message: int\n",
+            "message must have type 'str'",
+        ),
+        (
+            "class Bad(Error):\n    def __init__(self, code: int):\n        self.message = code\n",
+            "message must have type 'str'",
+        ),
+        (
+            "class Bad(Error):\n    def __init__(self, code: int):\n        self.code = code\n",
+            "constructor must initialize required storage: message",
+        ),
+        (
+            "class Bad(Error):\n    def __init__(self, message: int):\n        pass\n",
+            "constructor message parameter must be a required 'str'",
+        ),
+        (
+            "class Bad(Error):\n    message: str = \"default\"\n",
+            "not a field default",
+        ),
+        (
+            "class Bad(Error):\n    def __init__(self, message: str = \"default\"):\n        pass\n",
+            "constructor message parameter must be a required 'str'",
+        ),
+        (
+            "class Base(Error):\n    pass\nclass Bad(Base):\n    message: int\n",
+            "cannot be re-annotated",
+        ),
+        (
+            "class Base(Error):\n    pass\nclass Bad(Base):\n    def __init__(self, message: str):\n        pass\n",
+            "super().__init__",
+        ),
+        (
+            "class Bad(Error):\n    def __init__(self, flag: bool):\n        if flag:\n            self.message = \"conditional\"\n",
+            "before field storage is initialized",
+        ),
+        (
+            "class Bad(Error):\n    def __init__(self, message: str):\n        super().__init__(3)\n",
+            "expected 'str'",
+        ),
+    ] {
+        let parsed = parse_module(source).expect("valid syntax");
+        let errors = match lower_module(parsed.suite()) {
+            Ok(_) => panic!("invalid error contract must fail checking: {source}"),
+            Err(errors) => errors,
+        };
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.message.contains(diagnostic)),
+            "{source}\n{errors:?}"
+        );
+        assert!(
+            errors.iter().all(|error| error.primary_range.is_some()),
+            "source diagnostics: {errors:?}"
+        );
+    }
+}
+
+#[test]
+fn required_error_message_default_calls_require_a_string() {
+    for call in ["Empty()", "Code(3)", "Code(3, 4)", "Empty(3)", "Leaf()"] {
+        let source = format!(
+            "class Empty(Error):\n    pass\nclass Code(Error):\n    code: int\nclass Leaf(Empty):\n    pass\ndef main():\n    value = {call}\n"
+        );
+        let parsed = parse_module(&source).expect("valid syntax");
+        assert!(
+            lower_module(parsed.suite()).is_err(),
+            "{call} must fail before Rust"
+        );
+    }
+}
+
+#[test]
+fn required_error_message_layout_is_single_typed_storage() {
+    let parsed = parse_module("class Empty(Error):\n    pass\nclass Code(Error):\n    code: int\nclass Own(Error):\n    code: int\n    message: str\nclass Leaf(Code):\n    pass\nclass PythonError(Error):\n    message: str\n    kind: str\n    exception_type: str\n    traceback: str\n    context: str\n").expect("parse");
+    let module = lower_module(parsed.suite())
+        .expect("required message classes")
+        .module;
+    let layout: Vec<_> = module
+        .classes
+        .iter()
+        .map(|class| {
+            (
+                class.name.as_str(),
+                class
+                    .fields
+                    .iter()
+                    .map(|(name, ty)| (name.as_str(), ty.display_name()))
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect();
+    insta::assert_debug_snapshot!(layout, @r###"
+    [
+        (
+            "Empty",
+            [
+                (
+                    "message",
+                    "str",
+                ),
+            ],
+        ),
+        (
+            "Code",
+            [
+                (
+                    "message",
+                    "str",
+                ),
+                (
+                    "code",
+                    "int",
+                ),
+            ],
+        ),
+        (
+            "Own",
+            [
+                (
+                    "code",
+                    "int",
+                ),
+                (
+                    "message",
+                    "str",
+                ),
+            ],
+        ),
+        (
+            "Leaf",
+            [],
+        ),
+        (
+            "PythonError",
+            [
+                (
+                    "message",
+                    "str",
+                ),
+                (
+                    "kind",
+                    "str",
+                ),
+                (
+                    "exception_type",
+                    "str",
+                ),
+                (
+                    "traceback",
+                    "str",
+                ),
+                (
+                    "context",
+                    "str",
+                ),
+            ],
+        ),
+    ]
+    "###);
+    let leaf = module
+        .classes
+        .iter()
+        .find(|class| class.name == "Leaf")
+        .expect("leaf");
+    assert!(
+        matches!(&leaf.parent_type, Some(Type::Class {fields, ..}) if fields[0] == ("message".to_string(), Type::Str))
+    );
+    assert_eq!(
+        leaf.methods
+            .iter()
+            .find(|method| method.name == "new")
+            .expect("inherited constructor")
+            .params
+            .len(),
+        2
+    );
+}

--- a/crates/sifr_lowering/src/lower/rust_interop_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_tests.rs
@@ -571,7 +571,7 @@ fn rust_opaque_self_target_requires_representable_state_error() {
     let errors = lower_errors(
         r"
 class ResourceError(Error):
-    detail: str
+    detail: int
 
 @rust.opaque(type=bridge.resources.Resource)
 class Resource:

--- a/demos/config_json_csv/emitted.rs
+++ b/demos/config_json_csv/emitted.rs
@@ -1817,6 +1817,15 @@ mod sifr_generated_project_nominals {
             Self::new(err.message)
         }
     }
+    impl From<
+        crate::sifr_generated_project_nominals::SifrGeneratedStdlibSifrX2econfigparserX2eParsingError,
+    > for Error {
+        fn from(
+            err: crate::sifr_generated_project_nominals::SifrGeneratedStdlibSifrX2econfigparserX2eParsingError,
+        ) -> Self {
+            Self::new(err.message)
+        }
+    }
 }
 pub use sifr_generated_project_nominals::Error;
 pub use sifr_generated_project_nominals::JSONDecodeError;

--- a/demos/error_safety/emitted.rs
+++ b/demos/error_safety/emitted.rs
@@ -73,6 +73,11 @@ mod sifr_generated_project_nominals {
             Self::new(err.message)
         }
     }
+    impl From<crate::AppError> for Error {
+        fn from(err: crate::AppError) -> Self {
+            Self::new(err.message)
+        }
+    }
 }
 pub use sifr_generated_project_nominals::DivisionError;
 pub use sifr_generated_project_nominals::Error;

--- a/demos/parallel_map_demo/main.sifr
+++ b/demos/parallel_map_demo/main.sifr
@@ -11,7 +11,7 @@ def double(value: int) -> int:
 
 def stringify(value: int) -> Result[str, MapError]:
     if value < 0:
-        raise MapError()
+        raise MapError("negative item")
     return str(value)
 
 

--- a/demos/stdlib/emitted.rs
+++ b/demos/stdlib/emitted.rs
@@ -2574,6 +2574,11 @@ mod sifr_generated_project_nominals {
             Self::new(err.message)
         }
     }
+    impl From<SifrGeneratedStdlibSifrX2egraphlibX2eCycleError> for Error {
+        fn from(err: SifrGeneratedStdlibSifrX2egraphlibX2eCycleError) -> Self {
+            Self::new(err.message)
+        }
+    }
 }
 pub use sifr_generated_project_nominals::Error;
 pub use sifr_generated_project_nominals::FloatOverflowError;

--- a/demos/stdlib/emitted.rs
+++ b/demos/stdlib/emitted.rs
@@ -2574,8 +2574,14 @@ mod sifr_generated_project_nominals {
             Self::new(err.message)
         }
     }
-    impl From<SifrGeneratedStdlibSifrX2egraphlibX2eCycleError> for Error {
-        fn from(err: SifrGeneratedStdlibSifrX2egraphlibX2eCycleError) -> Self {
+    impl
+        From<
+            crate::sifr_generated_project_nominals::SifrGeneratedStdlibSifrX2egraphlibX2eCycleError,
+        > for Error
+    {
+        fn from(
+            err: crate::sifr_generated_project_nominals::SifrGeneratedStdlibSifrX2egraphlibX2eCycleError,
+        ) -> Self {
             Self::new(err.message)
         }
     }

--- a/demos/structured_parsing_serialization/emitted.rs
+++ b/demos/structured_parsing_serialization/emitted.rs
@@ -2922,6 +2922,15 @@ mod sifr_generated_project_nominals {
             Self::new(err.message)
         }
     }
+    impl From<
+        crate::sifr_generated_project_nominals::SifrGeneratedStdlibSifrX2econfigparserX2eParsingError,
+    > for Error {
+        fn from(
+            err: crate::sifr_generated_project_nominals::SifrGeneratedStdlibSifrX2econfigparserX2eParsingError,
+        ) -> Self {
+            Self::new(err.message)
+        }
+    }
 }
 pub use sifr_generated_project_nominals::Error;
 pub use sifr_generated_project_nominals::IOError;

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -828,6 +828,20 @@ except IOError as e:
 
 **User-defined error classes:** User-defined error classes inherit `message: str` from `Error`. The constructor accepts a message string, and `print(e)` formats it via `Display`. Users can add additional fields as needed.
 
+The inherited message is required constructor storage. An auto-generated
+constructor takes `message: str` before additional fields when the class does
+not declare its own message. Explicit string declarations retain their field
+order, including the five-field PythonError contract. A message field cannot
+have an incompatible type or a field default. Custom constructors must
+initialize the string (directly, from a matching required parameter, or through
+`super().__init__`); construction cannot finish with missing storage. A
+custom constructor requires a caller-supplied string parameter; a zero-argument
+constructor or a defaulted-only message input cannot satisfy this contract. A child
+without new fields or an explicit constructor forwards the parent's constructor
+signature and initialization. An inherited message is stored only in its data
+parent. Consuming root conversions move that parent or the owned message;
+they never derive a message from formatting or substitute missing text.
+
 ```python
 # Simple user-defined error — inherits message from Error
 class AppError(Error):

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -193,9 +193,9 @@ It does not broaden the active item.
 | 12C | incorporated into 12B | Builtin-registration Clippy blocker | No independent item, review, or gate remains. |
 | 12D | recorded, not started | Native corpus emission dependencies | Adjudicate checked-read control flow and the complete native diagnostic inventory before Item 12B closure. |
 | 12G | merged | Dependency-checker demo path identity | Authoritative DLPack project path and computed-reference regressions merged in PR #3695; exact-SHA validation and Opus review passed. |
-| 12H | authorized: after 12G handoff | Project-wide generated-field identity | Repair declaration/consumer naming consistency across generated files. |
-| 12I | authorized: after 12H handoff | Macro-defined project support visibility | Repair cancellation task-local visibility without blanket exports. |
-| 12J | authorized: after 12I handoff | Async Python error-channel contract | Resolve the authoritative error contracts and preserve async semantics. |
+| 12H | blocked: reviewed candidate preserved | Project-wide generated-field identity | Draft #3697, reviewed `9b52ac20094608c8a31f252db99e49ef7c963384`; sole gate failed SQL coverage. Retained record `b6e6210a97598fb631b929b2d4daf4012b41bb16` owns details and follow-ups. |
+| 12I | blocked: reviewed candidate preserved | Macro-defined project support visibility | Draft #3698, reviewed `f6e8afd964bb214a44c50271dcb2014ee8e828b4`; sole gate failed SQL coverage. Retained record `19ad69969a672d7b741122ded4dd879f2bdaf9ab` owns details and follow-ups. |
+| 12J | implementing | Async Python error-channel contract | Preserve declared error ancestry separately from descriptor data parents; retain original async fixtures and error contracts. |
 | 12K | authorized: integration after dependency qualification | Item 12B and Python dependency integration | Qualify the integrated candidate and merge the preserved work; do not reset Item 12B review history. |
 | 12A | pending | Phase closure and whole-phase review | Review the fully merged phase once, reconcile architecture/roadmap/evidence, and archive only when no actionable row remains. |
 

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -1678,3 +1678,120 @@ companion freshness checks and reached guardrails, then reproduced the
 existing SQL coverage-classification blocker. Logs are under
 `target/demo-name-followup/`. Existing Clippy baseline debt and its unresolved
 migration were not refreshed.
+
+### 2026-09-06 Item12J-M1 orchestration scope
+
+The 12J-R1 worker is closed. Draft PR #3699 preserves implementation
+`4bc432f3474134b1a1d43202d39fd147893bb014` and record
+`c430ed3331169f06eb148122f681e7d2a457d2ee` in
+`/private/tmp/sifr-item12j-r1.9j9Uhf/sifr`. Its terminal evidence and the
+separate Item12J-M1 mechanism are recorded in that commit's Python dependency
+issue. Nine focused and 587 driver tests pass, but the second review is
+NOT SATISFIED. Neither 12J nor R1 is qualified; no gate or merge occurred.
+
+Assign one fresh worker to 12J-M1, before integration. Its dependencies are the
+preserved candidate, both review findings, and the existing nominal error
+language/representation contract. First establish that contract from repository
+authorities. Then repair the distinct message-storage and conversion-demand
+mechanism: an unrelated root Error reference must not generate invalid unused
+conversions for specific errors; legitimate root upcasts must have sound native
+representations. Cover absent, integer, own-string and inherited message storage,
+with specific and root channels, local/imported identities and project modes.
+Preserve previously valid specific-error programs. Do not invent a message
+fallback, silently narrow accepted language, or weaken fixtures. If the existing
+contract cannot decide a necessary language behavior, return needs-new-scope
+with the precise user choice before implementing that policy.
+
+This is a separately bounded mechanism item under the user's instruction to
+record second-review defects as later work. It does not reopen 12J/R1 for a
+third review or waive the repeated, unresolved conversion obligation. M1 has
+one initial exact-SHA review and at most one remediation review, limited to
+this contract/mechanism and its interactions, and one final-candidate merge
+gate if approval and prerequisite qualification permit. Preserve every prior
+failed review/gate and do not present a changed scope as approval of old code.
+
+Named validation: `cargo test -p sifr_driver async_python_error_channel`,
+`cargo test -p sifr_codegen`, `cargo test -p sifr_driver`,
+`cargo build --locked -p sifr`, demo freshness update/check with that compiler,
+the original `async-declaration-examples` and `async-context-examples` Python
+interop command, `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`,
+HIR and file-size guards, and the single `scripts/run_all_tests.sh --profile merge`.
+Register focused named regressions before testing; reuse unchanged evidence.
+If a frontend/lowering/IR change is necessary to this representation contract,
+register its affected original Item12J crate test command before implementation.
+Implement the complete bounded correction before testing. Keep 12I native
+qualification, 12B/12C, SQL coverage, TypeVar #3667, and other follow-ups outside
+this worker. Preserve an approved candidate for 12K if an external dependency
+prevents standalone merge; never integrate an unapproved candidate as-is.
+
+### Item12J-M1 contract adjudication handoff (2026-09-06)
+
+State: **needs-new-scope; not implemented, not reviewed, not merged**.
+The section above was copied verbatim from the parent's new orchestration
+scope, preserving all historical records in retained record `c430ed3331169f06eb148122f681e7d2a457d2ee`.
+This session owns the independent checkout `/private/tmp/sifr-item12j-m1.VO82Kk/sifr`
+and branch `codex/emitted-rust-excellence-item-12j-m1`. It retains all original
+12J/R1 commits. The parent and the two closed worker worktrees, indexes, targets,
+and evidence were read only. Fetched latest main remains
+`4ce05473f58716a611ac190581bf0737ba15331e`; there are no intervening base changes.
+Draft [PR #3699](https://github.com/sifr-lang/sifr/pull/3699) remains unapproved.
+
+Repository contract evidence at the retained candidate:
+
+- `internal_docs/architecture.md:762-769,829-864` says every error inherits
+  `message: str`, supplied by a user error's constructor. `AppError(Error): pass`
+  is documented as accepting a message. No absent-message initialization or
+  integer-message root projection is specified.
+- `docs/language/error-handling.mdx:31-46` describes custom errors as plain
+  structs with typed fields; examples declare their own string message. It
+  does not decide message-less upcasts.
+- `crates/sifr_type_system/src/types/error_contracts.rs:9-24` recognizes root
+  Error only with exactly one string `message`; codegen's
+  `preamble/types_and_errors.rs:367-410` stores that string and requires it in
+  `new`. Root storage cannot represent an absent message today.
+- `crates/sifr_lowering/src/lower/descriptor_declarations.rs:341-350,460-465` treats
+  Error as a special base, bypassing ordinary embedded-parent storage.
+  `classes/class_type_collection.rs:304-309` retains an unimplemented comment
+  promising message insertion; `:863-875` actually derives the default
+  constructor from collected fields. This explains accepted `CodeError(3)`,
+  `EmptyError()`, and integer `message` declarations without supplying a
+  hidden root string.
+- `crates/sifr_codegen/src/class_emitter.rs:460-475` can format a specific
+  error's own message (including integers), or use Debug when absent. That
+  existing Display rule does not say a root upcast must store this formatting
+  as its message. Treating it as conversion policy would be a new decision,
+  including for inherited/custom formatting.
+- `error_refs/conversions.rs:99-130` and `preamble/error_conversion.rs:17-23`
+  assume a field and string type that ancestry does not establish. Suppressing
+  invalid unused impls alone leaves the accepted explicit root upcast broken.
+
+The [R1 review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5556273003)
+already supplies exact-binary evidence: the own-channel code-only example built
+before R1 and now fails E0609 when unrelated code mentions Error; explicit
+root upcasts check successfully but fail native E0277 before R1 / E0609 after.
+Absent and integer message cases fail too. No additional compiler probe was run.
+
+Required owner/user decision (none selected by this worker):
+
+| Contract direction | Concrete behavior and tradeoff |
+| --- | --- |
+| Enforce inherited required string storage | Require a message in every error constructor and reject incompatible field overrides. This follows the documented architecture, but changes accepted `CodeError(3)`, `EmptyError()`, and `message: int` programs; explicit authorization must relax M1's preservation requirement. |
+| Define root conversion from existing Display | Preserve specific constructors and define the root string for message-less/integer errors from their existing Display output, while retaining real string storage where present. Requires an explicit new conversion policy for own/inherited/custom formatting, allocation, and observable root messages; it is not authorized as a fallback. |
+| Allow root errors without a string message | Preserve message-less structured payloads through a new root representation and define absent-message access/formatting and field collisions. This changes the root language/API contract and has substantially wider compiler/runtime/interop scope. |
+
+Do not choose rejection, default text, blanket formatting, or a new root
+representation implicitly. Resume only after the contract direction and its
+scope adjustment are explicit. The complete correction, reaching regression
+registration, named compiler/native validation, review, and gate are **unreached**.
+M1 used zero Opus reviews and zero gates; old 12J's two NOT SATISFIED reviews
+remain exhausted. No approved implementation SHA exists for M1.
+
+Only the phase and Python dependency Markdown records change. Documentation
+diff checking and the named file-size guard are recorded in external evidence
+`/private/tmp/sifr-item12j-m1.VO82Kk/evidence.md`, which will identify the final
+record SHA. Prior unchanged-input evidence remains historical evidence for
+unapproved `4bc432f3474134b1a1d43202d39fd147893bb014`, not an M1 pass:
+focused 9 / driver 587 pass; codegen two 12B failures; strict Clippy 12B/12C
+failure; native async suites blocked by 12I E0425 with runtime assertions
+unreached; lowering two #3667 failures. SQL and other integration dependencies
+remain separately owned. No next item or integration work was started.

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -196,6 +196,7 @@ It does not broaden the active item.
 | 12H | blocked: reviewed candidate preserved | Project-wide generated-field identity | Draft #3697, reviewed `9b52ac20094608c8a31f252db99e49ef7c963384`; sole gate failed SQL coverage. Retained record `b6e6210a97598fb631b929b2d4daf4012b41bb16` owns details and follow-ups. |
 | 12I | blocked: reviewed candidate preserved | Macro-defined project support visibility | Draft #3698, reviewed `f6e8afd964bb214a44c50271dcb2014ee8e828b4`; sole gate failed SQL coverage. Retained record `19ad69969a672d7b741122ded4dd879f2bdaf9ab` owns details and follow-ups. |
 | 12J | blocked: unapproved candidate preserved | Async Python error-channel contract | Draft #3699, reviewed `f720a342edd87004975355b478948f7eb5c8b406` NOT SATISFIED (12J-R1); native suites blocked by 12I. Terminal handoff at user checkpoint, zero remediation reviews and zero gates used. |
+| 12J-R1 | in progress: remaining remediation | Complete Item 12J non-builtin error conversions | Connect semantic error ancestry to conversion demand without resetting Item 12J's review or gate budget. |
 | 12K | authorized: integration after dependency qualification | Item 12B and Python dependency integration | Qualify the integrated candidate and merge the preserved work; do not reset Item 12B review history. |
 | 12A | pending | Phase closure and whole-phase review | Review the fully merged phase once, reconcile architecture/roadmap/evidence, and archive only when no actionable row remains. |
 
@@ -678,6 +679,35 @@ integration.** Owned branch `codex/emitted-rust-excellence-item-12j`, worktree
   owns12J-R1 and separate12J-F1–F3 follow-ups. A separately assigned continuation
   must resolve12J-R1 and preserve the remaining one-remediation/one-gate caps.
   12K integration and all next-item implementation remain unstarted by this worker.
+
+### 2026-09-06 dependency handoff and bounded remediation
+
+12G is merged (PRs #3695/#3696). 12H and 12I are approved but unmerged
+candidates in draft PRs #3697/#3698; their sole gates failed externally owned
+SQL coverage classifications. Their complete handoffs and deferred findings
+remain in record commits `b6e6210a97598fb631b929b2d4daf4012b41bb16` and
+`19ad69969a672d7b741122ded4dd879f2bdaf9ab`.
+
+12J is unapproved, not merged: draft PR #3699, implementation
+`f720a342edd87004975355b478948f7eb5c8b406`, record
+`60219b080eadb519a813d9a84568552824be0754`. Its initial review found missing
+non-builtin error conversions (12J-R1); native async validation also depends
+on 12I. The original worker is closed. Assign a fresh worker to 12J-R1 before
+12K. This is the remaining remediation of 12J, not a new initial-review cycle.
+
+12J-R1 scope: connect semantic error ancestry to conversion demand for local,
+project-imported and stdlib errors, preserving nominal identity and the original
+runtime/error contract. Dependencies are the preserved 12J candidate and its
+initial review; 12I remains a separate native qualification dependency.
+Use the exact named validation in the Python owner issue at record `60219b0`,
+including `cargo test -p sifr_driver async_python_error_channel` and the
+`async-declaration-examples`/`async-context-examples` suites. Register focused
+emission/compilation regressions before testing. Finish this in-scope correction
+without absorbing known external failures. At most one remediation review and
+one final-candidate merge gate remain for 12J; no third review or budget reset.
+If external qualification still blocks merge, preserve the corrected reviewed
+candidate for 12K. New second-review mechanism defects become later bounded
+items. Do not integrate the unapproved 12J candidate as-is.
 
 ### Item 12B: Bounded algorithmic dependency repair
 

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -195,8 +195,9 @@ It does not broaden the active item.
 | 12G | merged | Dependency-checker demo path identity | Authoritative DLPack project path and computed-reference regressions merged in PR #3695; exact-SHA validation and Opus review passed. |
 | 12H | blocked: reviewed candidate preserved | Project-wide generated-field identity | Draft #3697, reviewed `9b52ac20094608c8a31f252db99e49ef7c963384`; sole gate failed SQL coverage. Retained record `b6e6210a97598fb631b929b2d4daf4012b41bb16` owns details and follow-ups. |
 | 12I | blocked: reviewed candidate preserved | Macro-defined project support visibility | Draft #3698, reviewed `f6e8afd964bb214a44c50271dcb2014ee8e828b4`; sole gate failed SQL coverage. Retained record `19ad69969a672d7b741122ded4dd879f2bdaf9ab` owns details and follow-ups. |
-| 12J | blocked: unapproved candidate preserved | Async Python error-channel contract | Draft #3699, reviewed `f720a342edd87004975355b478948f7eb5c8b406` NOT SATISFIED (12J-R1); native suites blocked by 12I. Terminal handoff at user checkpoint, zero remediation reviews and zero gates used. |
-| 12J-R1 | in progress: remaining remediation | Complete Item 12J non-builtin error conversions | Connect semantic error ancestry to conversion demand without resetting Item 12J's review or gate budget. |
+| 12J | blocked: both reviews exhausted, unapproved | Async Python error-channel contract | Draft #3699 preserves final reviewed candidate `4bc432f3474134b1a1d43202d39fd147893bb014`; initial and remediation reviews are NOT SATISFIED. No gate or merge. Message-storage follow-up 12J-M1 requires adjudication; 12I remains external. |
+| 12J-R1 | blocked: second-review mechanism defect | Complete Item 12J non-builtin error conversions | Named local/project/stdlib native regressions pass, but the sole remediation review found invalid demand for errors without a string message and a remaining accepted-upcast omission. Stop; no third review or gate. |
+| 12J-M1 | recorded: requires adjudication, not started | Error message storage and root-upcast admissibility | Resolve the second-review storage/demand defect and remaining conversion contract without breaking valid specific-error channels or resetting 12J's exhausted review budget. |
 | 12K | authorized: integration after dependency qualification | Item 12B and Python dependency integration | Qualify the integrated candidate and merge the preserved work; do not reset Item 12B review history. |
 | 12A | pending | Phase closure and whole-phase review | Review the fully merged phase once, reconcile architecture/roadmap/evidence, and archive only when no actionable row remains. |
 
@@ -708,6 +709,61 @@ one final-candidate merge gate remain for 12J; no third review or budget reset.
 If external qualification still blocks merge, preserve the corrected reviewed
 candidate for 12K. New second-review mechanism defects become later bounded
 items. Do not integrate the unapproved 12J candidate as-is.
+
+### Item12J-R1 terminal handoff (2026-09-06)
+
+State: **blocked, NOT APPROVED, NOT MERGED**. Draft
+[PR #3699](https://github.com/sifr-lang/sifr/pull/3699) retains reviewed
+implementation `4bc432f3474134b1a1d43202d39fd147893bb014`, following preserved
+`f720a342` / record `60219b0` and remediation implementation `3ba19e49a`.
+Owned worktree `/private/tmp/sifr-item12j-r1.9j9Uhf/sifr`, branch
+`codex/emitted-rust-excellence-item-12j-r1`. The PR was updated by normal
+fast-forward push; the original worker's rollback worktree and parent index/
+intentional dirty documents remain unchanged. Base is still main
+`4ce05473f58716a611ac190581bf0737ba15331e`.
+
+- Final-candidate focused regressions: **9 pass**, including emission, native
+  build and execution for local/transitive errors, project aliases/transitive
+  errors/same-basename identities/builtin-name shadows, and distinct CSV and
+  configparser Error classes. Full driver: **587 pass, 77 existing ignored**.
+- All **264 companions are fresh**; only `demos/error_safety/emitted.rs` and
+  `demos/stdlib/emitted.rs` were regenerated. Formatting, HIR and file-size
+  checks pass (3758 files, 900-line cap). No original Sifr fixture, lockfile,
+  workflow, runtime assertion, architecture or roadmap change was made.
+- Codegen remains **1407 pass / 2 pre-existing 12B list-repeat failures**.
+  Strict Clippy fails only at the unchanged 12B/12C-owned
+  `project_stdlib_nominals.rs:45` expect. Unchanged original IR/frontend passes
+  and #3667-owned lowering failures are reused with explicit input provenance.
+- Both original named async suites fail native build at the **12I-owned
+  cancellation task-local E0425** (HTTP one Rust error; context 58, with retained
+  E0425 stderr tail). Neither runtime marker was observed; cleanup/cancellation
+  runtime preservation remains unqualified. No external repair was absorbed.
+- The [sole remediation Opus review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5556273003)
+  returned **NOT SATISFIED**. New mechanism: broad nominal demand emits
+  `Self::new(err.message)` even for errors without a string message, including
+  errors never converted to the root Error. The reviewer verified a previously
+  compiling `CodeError(Error)` with only `code: int` now fails E0609 merely when
+  an unrelated function mentions Error. Empty errors and `message: int` also
+  fail. Accepted message-less root upcasts remain uncompilable (E0277 before R1,
+  E0609 now), so the original conversion obligation also remains unresolved.
+- This is later bounded **Item12J-M1**, owned by nominal error representation
+  and conversion-demand/ancestry admissibility. The
+  [Python owner record](ad-hoc-python-interop-qualification-dependencies.md#later-item12j-m1-error-message-storage-and-root-upcast-admissibility)
+  records its scope and the required adjudication. No later-item code was
+  written. The review's mapping-cleanup suggestion is separate 12J-F5.
+- Cumulative Item12J budget: **one initial review + one remediation review used;
+  both NOT SATISFIED. Zero create-PR gates, zero merge-profile gates, no merge.**
+  The user's second-review stop rule prevents another fix/review cycle. The
+  unused gate was not run without an approved candidate. Do not integrate this
+  candidate as-is or reset any original review/gate history.
+
+Exact evidence is preserved outside the reviewed Git tree at
+`/private/tmp/sifr-item12j-r1.9j9Uhf/evidence-4bc432f3474134b1a1d43202d39fd147893bb014.md`,
+with SHA-keyed review and native JSON reports. The compiler hash is
+`12adc00c7d5111550f893a20b1b3c3936ece888a13e3bf14b22e67f2d4e7fe09`.
+The final handoff is documentation-only and receives no extra review or gate.
+Next action: adjudicate 12J-M1 and the unresolved conversion obligation before
+any 12J qualification/integration; this worker stops after publishing records.
 
 ### Item 12B: Bounded algorithmic dependency repair
 

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -195,7 +195,7 @@ It does not broaden the active item.
 | 12G | merged | Dependency-checker demo path identity | Authoritative DLPack project path and computed-reference regressions merged in PR #3695; exact-SHA validation and Opus review passed. |
 | 12H | blocked: reviewed candidate preserved | Project-wide generated-field identity | Draft #3697, reviewed `9b52ac20094608c8a31f252db99e49ef7c963384`; sole gate failed SQL coverage. Retained record `b6e6210a97598fb631b929b2d4daf4012b41bb16` owns details and follow-ups. |
 | 12I | blocked: reviewed candidate preserved | Macro-defined project support visibility | Draft #3698, reviewed `f6e8afd964bb214a44c50271dcb2014ee8e828b4`; sole gate failed SQL coverage. Retained record `19ad69969a672d7b741122ded4dd879f2bdaf9ab` owns details and follow-ups. |
-| 12J | implementing | Async Python error-channel contract | Preserve declared error ancestry separately from descriptor data parents; retain original async fixtures and error contracts. |
+| 12J | blocked: unapproved candidate preserved | Async Python error-channel contract | Draft #3699, reviewed `f720a342edd87004975355b478948f7eb5c8b406` NOT SATISFIED (12J-R1); native suites blocked by 12I. Terminal handoff at user checkpoint, zero remediation reviews and zero gates used. |
 | 12K | authorized: integration after dependency qualification | Item 12B and Python dependency integration | Qualify the integrated candidate and merge the preserved work; do not reset Item 12B review history. |
 | 12A | pending | Phase closure and whole-phase review | Review the fully merged phase once, reconcile architecture/roadmap/evidence, and archive only when no actionable row remains. |
 
@@ -643,6 +643,41 @@ artifact hashes, package ownership, and missing-input errors remain enforced.
   Helmholtz's retained candidate/index were not modified.
 - Blocker: none. Item12G is complete. Stop this worker after the record update;
   the orchestrator may assign Item12H to a fresh worker. No next-item code was written.
+
+### Item12J terminal handoff (2026-09-06)
+
+Draft [PR #3699](https://github.com/sifr-lang/sifr/pull/3699) preserves candidate
+`f720a342edd87004975355b478948f7eb5c8b406`, based on freshly fetched main
+`4ce05473f58716a611ac190581bf0737ba15331e`. **Not merged; not approved for
+integration.** Owned branch `codex/emitted-rust-excellence-item-12j`, worktree
+`/private/tmp/sifr-item12j.pT6Xkk/sifr`; parent records/index and retained
+12B/12H/12I worktrees were not mutated.
+
+- The ancestry repair preserves the original async fixtures and removes their
+  source-check failures. Six focused regressions, IR (4), frontend (132 unit +
+  7 integration), and driver (584 passed, 77 existing ignored) pass. All 264
+  generated companions remain byte-identical; fmt, HIR and file-size guards pass.
+- Both named native suites fail at 12I-owned cancellation task-local visibility
+  E0425 after source checking; runtime assertions did not execute. Lowering
+  retains two TypeVar assertion failures owned by #3667; codegen retains two
+  12B-owned list-repeat failures; strict Clippy fails on the preserved12B/12C
+  builtin-registration expect. None is a passing command or full certification.
+- The [initial exact-SHA Opus review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5555927728)
+  is **NOT SATISFIED**: 12J-R1, the newly accepted non-builtin error ancestry lacks
+  generated `From<T> for Error` conversions. Opus reproduced E0277 for a local
+  DomainError and imported CSV Error. This is an unresolved in-scope omission,
+  not an external blocker to be waived. No remediation code was written.
+- [Validation/terminal receipt and changed paths](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5555929816)
+  are keyed to the candidate outside the Git tree. Raw logs, JSON reports and
+  review are retained in `/private/tmp/sifr-item12j.pT6Xkk/`.
+- The user's orchestration checkpoint required terminal handoff once an external
+  blocker was established. Stop after these records; remediation reviews used
+  **0**, merge-profile gates **0**, create-PR gates **0**. There is no final
+  reviewer-approved candidate to gate. No review/gate history is reset.
+- The [Python owner record](ad-hoc-python-interop-qualification-dependencies.md#item12j-terminal-evidence-and-unresolved-review)
+  owns12J-R1 and separate12J-F1–F3 follow-ups. A separately assigned continuation
+  must resolve12J-R1 and preserve the remaining one-remediation/one-gate caps.
+  12K integration and all next-item implementation remain unstarted by this worker.
 
 ### Item 12B: Bounded algorithmic dependency repair
 

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -1869,6 +1869,8 @@ are retained. Custom constructors that already compute an initialized string
 Fetched main remains `4ce05473f58716a611ac190581bf0737ba15331e`, with no base delta.
 Disk before initial Cargo validation: 209 GiB free, no private target yet.
 
+#### Historical 054a823b9 documentation-only receipt
+
 Only the phase and Python dependency Markdown records change. Documentation
 diff checking and the named file-size guard are recorded in external evidence
 `/private/tmp/sifr-item12j-m1.VO82Kk/evidence.md`, which will identify the final
@@ -1878,3 +1880,90 @@ focused 9 / driver 587 pass; codegen two 12B failures; strict Clippy 12B/12C
 failure; native async suites blocked by 12I E0425 with runtime assertions
 unreached; lowering two #3667 failures. SQL and other integration dependencies
 remain separately owned. No next item or integration work was started.
+
+### Item12J-M1 terminal handoff (2026-09-06): approved, externally blocked
+
+Status: **SATISFIED source review; not merged, not closed**. The user's required
+constructor-supplied string decision is implemented; the old decision blocker is
+resolved, not renewed. This terminal record supersedes the earlier needs-choice
+status without changing any historical12J/R1 verdict or review/gate count.
+
+- Implementation: `d726ffc11258c49f0185fd2d49697988cf90972c`.
+- M1 delta base: `054a823b9aaafd388ddf1d944f1b7e50fcb95c29`, retaining all original12J/R1 lineage.
+- Main remains `4ce05473f58716a611ac190581bf0737ba15331e`; no base integration occurred.
+- Linked bounded draft [PR #3700](https://github.com/sifr-lang/sifr/pull/3700),
+  branch `codex/item12j-m1-required-string`. Predecessor #3699 remains preserved.
+- Sole initial exact-SHA [Opus review](https://github.com/sifr-lang/sifr/pull/3700#issuecomment-5558127599):
+  **SATISFIED**, no blocking findings. One initial review used; zero remediation
+  reviews, provider retries, create-PR gates, or merge gates used. No merge SHA.
+- Owned independent checkout `/private/tmp/sifr-item12j-m1-required.vL5lSI/sifr`;
+  parent and every retained worker checkout/index/target remained unchanged.
+- SHA-keyed receipt and complete36-path inventory:
+  `/private/tmp/sifr-item12j-m1-required.vL5lSI/evidence-d726ffc11258c49f0185fd2d49697988cf90972c.md`
+  and sibling `changed-paths.txt`. The receipt identifies the final record SHA;
+  this record-only commit does not change reviewed implementation inputs.
+
+#### Exact-candidate evidence and external owner receipt
+
+Final full driver passes **592 active /77 existing ignored**, including all five
+M1 regressions. Focused lowering passes3, original async-error-channel tests pass9,
+frontend passes132unit+7integration, IR passes4 and type-system147 with documented
+unchanged complete-input reuse. The locked CLI build passes; compiler SHA256 is
+`166c1d23662db3c0da97b9c921e6f7fee22755b68c49e576906e07a569eec16e` before and after
+native verification. All264 demo companions are fresh after the named update
+regenerated exactly `config_json_csv`, `stdlib`, and
+`structured_parsing_serialization`. Formatting, HIR maintainability, and the
+canonical900-line file guard pass (3764files). No test assertion or ignore policy
+was weakened. All raw logs remain beside the SHA-keyed receipt.
+
+Standalone merge is blocked by these externally owned named checks:
+
+- **12B:** codegen1407pass/2known list-repeat assertion failures;
+  `codegen-complete.log`, retained dependency PR #3694. No12B input was integrated.
+- **12B/12C:** strict Clippy stops at the unchanged `expect_used` body in
+  `project_stdlib_nominals.rs:47` (formerly45); `clippy-candidate.log`.
+- **TypeVar [#3667](https://github.com/sifr-lang/sifr/issues/3667):**
+  lowering1117pass/2known stale diagnostic assertions/1existing ignored;
+  `lowering-candidate.log`. The prior owner notification remains valid and was
+  not duplicated or claimed resolved.
+- **12I / Python qualification owner:** both original async native suites fail
+  inaccessible cancellation-task-local E0425. Source policies pass; runtime
+  assertions are **UNREACHED**, not passes or skips. HTTP reports1Rust error;
+  context reports58 with the same retained diagnostic tail. `async-native.log`,
+  `async-declaration.json`, `async-context.json`, and `python-results.json`
+  preserve the reports. Retained12I PR #3698 was not integrated.
+- SQL coverage remains an external historical dependency, not a newly run gate
+  failure. No merge-profile gate was run over these failed prerequisites; its
+  allowance is unused, not reset. No create-PR gate was run.
+
+The new native local/project/test-project and canonical PythonError assertions
+pass. They do not replace the externally blocked original async cleanup/runtime
+qualification. Initial209GiBfree/no target and later187GiBfree/~20GiB private
+target checks were recorded; the latter target was in use by owned validation.
+No shared/former-worker target was cleaned or cold-cache performance claimed.
+
+#### Separately owned Opus follow-ups (not started)
+
+- **12J-M1-F1 — compiler invariant hardening:** replace the conversion storage
+  walk's programmer-invariant panic with a compiler diagnostic if desired.
+  Review found no source program violating lowering's invariant. This is a
+  hardening suggestion, not a blocker or runtime fallback authorization.
+- **12J-M1-F2 — reference-only inherited stdlib storage qualification:** determine
+  whether an inherited error such as `sifr.sql.EncodeError` can reach codegen
+  only as a type reference without its declaring HirClass. The pre-existing
+  reference-only path still uses `err.message`; the reviewer did not establish
+  reachability. Qualify in the SQL owner's scope; do not claim it fixed here.
+- **12J-M1-F3 — integration validation coverage:** execute the migrated E2E and
+  broader stdlib suites in the integration owner's authorized gate. M1 ran only
+  the named commands; Opus's read-only first-party source audit found no remaining
+  constructor migration, arity, required-string, or expected-output violation.
+  Source audit is not executable-suite qualification.
+- **12J-M1-F4 — architecture shadow clarification:** document explicitly that a
+  same-module `class Error(Error)` shadow can be the data parent for subsequent
+  classes. Native M1 coverage already exercises the necessary physical layout;
+  the extra prose is a later documentation suggestion, not implemented here.
+
+No remediation review, whole-phase review, second gate, third review, external
+fix, or next-item code was started. Preserve this approved implementation for
+the separately owned12K integration once dependency qualification clears. The
+worker stops after publishing this record and its evidence; it does not start12K.

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -1786,6 +1786,89 @@ registration, named compiler/native validation, review, and gate are **unreached
 M1 used zero Opus reviews and zero gates; old 12J's two NOT SATISFIED reviews
 remain exhausted. No approved implementation SHA exists for M1.
 
+### Item12J-M1 user adjudication and implementation registration (2026-09-06)
+
+The user answered **"Do your recommendation through workers"** and explicitly
+authorized enforcing the required constructor-supplied string message for every
+error. The prior decision blocker is resolved: this supersedes preservation of
+message-less constructor calls and integer message overrides, which must now be
+rejected. History above remains evidence of the earlier unresolved decision.
+No Display-derived fallback, absent-message root representation, test weakening,
+or next-item implementation is authorized.
+
+Implementation notes for this authorization: error storage is seeded and checked
+in lowering, and both explicit and inherited constructors must have a required
+string input and complete their storage initialization. Pure error children
+forward the actual parent constructor; mixed non-error data parents retain their
+physical layout. Canonical nominal identity drives consuming root conversions,
+including projections through owned embedded parents, without Display fallback.
+Imported `Error` shadows and constructor-only stdlib nominals are handled in
+both project and test-project import ownership. These are directly necessary
+collision/export paths, not general 12K integration.
+
+The runtime's channel errors and the sync/parallel-map first-party callers now
+supply explicit messages. The opaque-state negative fixture changes its payload
+from representable `str` to unrepresentable `int`, preserving its original
+diagnostic assertion and purpose under the new inherited message contract.
+PythonError's native five-field assertion uses the existing package fixture's
+probed interpreter/native-link trust; it is not skipped or weakened. File-size
+splits isolate declaration diagnostics and project import binding ownership.
+
+This sole implementer owns independent checkout
+`/private/tmp/sifr-item12j-m1-required.vL5lSI/sifr`, branch
+`codex/item12j-m1-required-string`, retaining record `054a823b9aaafd388ddf1d944f1b7e50fcb95c29`
+and all original12J/R1 lineage. Parent and former workers' checkouts, indexes,
+targets, and evidence are read-only. Parent orchestrates only.
+
+Scope: consistent typed string storage; default/custom/inherited constructors;
+declaration and call diagnostics; nominal identity and exports; consuming root
+conversions. Preserve explicit string layouts including PythonError's exact
+five fields with no duplicate message storage or extra parameter. Migrate
+necessary first-party fixtures/demos/docs while preserving their purpose and
+assertions. Mixed-marker ancestry or other deferred findings are included only
+if directly necessary to this required-string contract, with explicit provenance.
+
+Before testing, register focused `required_error_message` regressions in lowering
+and driver for absent/integer/missing constructor diagnostics and positive
+own/inherited/default/custom/local/imported/stdlib/collision/project/test-project
+emission and native execution, including unused root-conversion demand and
+explicit consuming upcasts. Commands: `cargo test -p sifr_lowering required_error_message`,
+`cargo test -p sifr_driver required_error_message`, plus all named M1 commands:
+`cargo test -p sifr_driver async_python_error_channel`, `cargo test -p sifr_codegen`,
+`cargo test -p sifr_driver`, `cargo test -p sifr_ir`, `cargo test -p sifr_lowering`,
+`cargo test -p sifr_frontend`, `cargo test -p sifr_type_system`,
+`cargo build --locked -p sifr`,
+`python3 scripts/check_demo_emitted_freshness.py --sifr target/debug/sifr --update`
+then without `--update`,
+`uv run --project verification --locked python -m sifr_verify areas run --area python_interop --suite async-declaration-examples --suite async-context-examples`,
+`cargo clippy --workspace -- -D warnings`, `cargo fmt --check`,
+`python3 scripts/check_hir_maintainability_guardrails.py`, and
+`python3 scripts/check_file_size_guardrails.py`.
+Finish bounded implementation before running tests, then iterate on in-scope
+failures. Inspect disk/private target before long Cargo runs. One initial
+exact-SHA Opus review and at most one remediation review remain unused, as does
+one `scripts/run_all_tests.sh --profile merge` on the approved final candidate;
+skip create-pr. A new second-review mechanism defect is later work and stops M1.
+Prior12J/R1 reviews remain NOT SATISFIED and exhausted; no budget is reset.
+
+12I cancellation-task-local native qualification, 12B codegen failures, 12C
+Clippy, TypeVar #3667, and SQL coverage remain externally owned. Finish M1
+before evaluating those blockers; preserve the corrected approved candidate
+for12K if they prevent merge. No gate without approval and no second gate.
+After merge/record, or an evidenced external block after correction/review,
+return item, PR, reviewed SHA, record SHA, merge SHA or none, evidence/paths,
+blocker or none and stop.
+
+Directly necessary provenance: the earlier12J-F1 mixed data-parent/Error-marker
+ancestry and12J-F4 imported parent named Error are included only where needed
+to ensure an accepted error retains its required string storage and root
+ancestry. Native regressions exercise both. Runtime channel producers and two
+parallel-map callers now supply explicit messages; their behavior/assertions
+are retained. Custom constructors that already compute an initialized string
+(such as configparser's section errors) retain that source contract.
+Fetched main remains `4ce05473f58716a611ac190581bf0737ba15331e`, with no base delta.
+Disk before initial Cargo validation: 209 GiB free, no private target yet.
+
 Only the phase and Python dependency Markdown records change. Documentation
 diff checking and the named file-size guard are recorded in external evidence
 `/private/tmp/sifr-item12j-m1.VO82Kk/evidence.md`, which will identify the final

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -287,16 +287,99 @@ under the R1 evidence root contain the diagnostics. The final native collision
 case uses `ValueError(Error)` and retains the original negative Error-target
 test. This source ancestry issue is not repaired by the conversion item.
 
+## Item12J-R1 terminal evidence (2026-09-06)
+
+State: **blocked, unapproved, not merged**. Draft
+[PR #3699](https://github.com/sifr-lang/sifr/pull/3699) preserves reviewed
+implementation `4bc432f3474134b1a1d43202d39fd147893bb014` on the original base
+`4ce05473f58716a611ac190581bf0737ba15331e`. History retains original `f720a342`,
+record `60219b0`, R1 implementation `3ba19e49a`, then its one-line Clippy fix.
+The final record is a separate documentation-only commit. Original/parent
+worktrees and indexes remain untouched; only the existing PR branch was
+fast-forwarded from this isolated worker's branch.
+
+Final candidate evidence, outside the reviewed tree:
+`/private/tmp/sifr-item12j-r1.9j9Uhf/evidence-4bc432f3474134b1a1d43202d39fd147893bb014.md`.
+Compiler SHA256:
+`12adc00c7d5111550f893a20b1b3c3936ece888a13e3bf14b22e67f2d4e7fe09`.
+
+- Focused command: 9 pass, including all three emission/native build/run groups
+  and the transitive imported case. Full driver: 587 pass, 77 existing ignored.
+- Build, formatting, HIR, canonical file-size guard (3758 files) and freshness
+  of all 264 companions pass. Two companions were producer-regenerated; no
+  original fixture, lockfile, workflow, assertion or runtime contract was edited.
+- Codegen: 1407 pass / 2 existing 12B list-repeat failures. Strict Clippy retains
+  only the 12B/12C `project_stdlib_nominals.rs:45` expect failure. Original
+  unchanged-input IR4 and frontend132+7 passes, and lowering1114 pass /2 stale
+  TypeVar assertions /1 ignored (#3667), are explicitly reused, not rerun passes.
+- Both exact named async suites exit 1 at 12I-owned native task-local E0425.
+  HTTP reports one Rust error; context 58, with a retained E0425 tail. Runtime
+  output markers are false for both. No native async runtime pass or complete
+  area certification is claimed. SHA-keyed JSON archives and logs are retained.
+- The [only remaining remediation review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5556273003)
+  returned **NOT SATISFIED**. Its full response is
+  `review-4bc432f3474134b1a1d43202d39fd147893bb014.md` under the evidence root,
+  SHA256 `ab616b0a0917bac3c269ece9f24ea9d82f0bb7124f685241ac860af6a34e8b42`.
+  It verified the new message-storage mechanism defect and remaining conversion
+  omission described in Item12J-M1 below. No third review or post-review code
+  repair was attempted.
+- Cumulative 12J allowance consumed: one initial review and one remediation
+  review, both NOT SATISFIED; zero create-PR gates and zero merge-profile gates.
+  There is no approved final candidate to gate or merge. The unused gate is not
+  a new review allowance. All 12B/12H/12I histories remain unchanged.
+
+## Later Item12J-M1: error message storage and root-upcast admissibility
+
+Status: recorded only; requires adjudication, not started by R1.
+Owners: nominal error representation, error conversion demand, ancestry
+admissibility. This is a new second-review mechanism, not a third R1 review.
+
+The sole remediation review found two related blocking consequences at
+`crates/sifr_codegen/src/error_refs/conversions.rs:99-130`, using
+`preamble/error_conversion.rs:17-23` and the broadened render guard in
+`support_plan.rs:204`:
+
+1. **New regression:** `class CodeError(Error): code: int`, raised only into its
+   own `Result[None, CodeError]` channel, compiled before R1. Adding an unrelated
+   function returning `Result[None, Error]` now demands an invalid
+   `From<CodeError> for Error` whose body reads absent `err.message`, producing
+   E0609. The reviewer verified native success with preserved compiler
+   `36640bf...9b61940` and failure with the exact candidate compiler above.
+   `class EmptyError(Error): pass` and `message: int` similarly expose absent or
+   non-string storage (E0609/E0308). These classes need not be upcast themselves
+   for the regression to occur.
+2. **Remaining in-scope omission:** explicitly raising that CodeError into
+   `Result[None, Error]` source-checks on both original 12J and R1. Native build
+   changes from E0277 to E0609, not to success. The original obligation remains
+   unresolved for this representation, so repeated-finding adjudication is
+   required in addition to recording the new mechanism.
+
+Later bounded work must establish a shared, typed message-storage/conversion
+contract: own string message versus consuming a valid ancestor conversion,
+without assuming a `message` field from ancestry alone. Preserve previously
+compiling specific-error channels; do not emit invalid unused conversions when
+an unrelated Error reference appears. Reconcile root-Error source admissibility
+with actual conversion ability instead of accepting backend-invalid programs.
+Register emission and native compilation regressions for absent, non-string,
+and inherited message storage, inside and outside root-Error channels. No
+invented message fallback, fixture weakening or unrelated dependency repair is
+authorized by this record. Resolve the contract/adjudication before defining
+any later item's review/gate allowance; do not reset 12J's two consumed reviews.
+
+Separate non-blocking **12J-F5**, owner codegen nominal-path mapping: the review
+suggests consolidating `render()`'s ancestor-name derivation with the project
+nominal-path authority to remove duplicate mapping logic. This is not another
+R1 implementation step. Prior 12J-F1–F4 and retained H/I findings remain owned.
+
 ## Required next action
 
-Item12G is merged. Items12H/12I have terminal blocked, approved-candidate handoffs;
-Item12J now has the terminal blocked, **unapproved** candidate below. Stop12J's
-worker after publishing records. The orchestrator must assign the unresolved
-12J-R1 correction explicitly and preserve its remaining at-most-one remediation
-review and one final-candidate gate, with no reset of12B/H/I history. Item12K's
-separate integration allowance follows dependency qualification; this12J
-candidate must not be treated as approved or integrated as-is. No next-item
-code, integration, external repair, or gate bypass was written by12J.
+Stop the R1 worker after publishing this terminal record. Adjudicate Item12J-M1
+and the unresolved conversion obligation before treating Item12J as qualified.
+Candidate `4bc432f3474134b1a1d43202d39fd147893bb014` is unapproved and must not be
+integrated as-is. No third review, gate, merge, 12K integration, external repair,
+or next-item code is performed by this worker. 12K's separately approved
+integration allowance follows dependency qualification and does not reset any
+12B/H/I/J history.
 
 ### Item12J terminal evidence and unresolved review
 

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -161,6 +161,71 @@ Do not add blanket exports, suppressions, or substitute cancellation behavior.
 
 ## Later Item12J: async Python error-channel contract
 
+### Item12J implementation (2026-09-06)
+
+Owned worktree `/private/tmp/sifr-item12j.pT6Xkk/sifr`, branch
+`codex/emitted-rust-excellence-item-12j`, freshly fetched base
+`4ce05473f58716a611ac190581bf0737ba15331e`. Parent's two intentional dirty
+records and retained 12B/12H/12I worktrees are read-only to this worker.
+
+12H and 12I have terminal blocked handoffs, satisfying the execution order.
+They are not merged: 12H draft [#3697](https://github.com/sifr-lang/sifr/pull/3697)
+retains reviewed `9b52ac20094608c8a31f252db99e49ef7c963384`, record
+`b6e6210a97598fb631b929b2d4daf4012b41bb16`; 12I draft
+[#3698](https://github.com/sifr-lang/sifr/pull/3698) retains reviewed
+`f6e8afd964bb214a44c50271dcb2014ee8e828b4`, record
+`19ad69969a672d7b741122ded4dd879f2bdaf9ab`. Both sole gates failed SQL
+coverage. Their detailed evidence and deferred 12H-F1–F5 / 12I-F1–F3 remain in
+those commits and PRs; integration belongs to 12K, with no budget reset.
+
+Authoritative contracts: `stdlib/_sifr/python.sifr` declares
+`PythonError(Error)` with five string fields; architecture error semantics
+retain ordinary error inheritance and Result covariance. Python protocol
+architecture preserves same-loop async execution, original error replay, and
+ordered cleanup/cancellation. The existing examples' `Result[None, Error]`
+channels are valid under that inheritance contract and remain unchanged.
+
+Root cause: descriptor data-parent selection intentionally excludes the builtin
+Error marker, but class type collection and HIR-to-Type exports reused the
+data-parent metadata as complete nominal ancestry. The implementation preserves
+semantic error ancestry separately from data storage and uses that ancestry
+at each HIR-to-Type reconstruction. It does not add an embedded Error field,
+change the five-field Python boundary, or make unrelated nominal errors assignable.
+
+Exact commands registered before test execution:
+
+```bash
+cargo test -p sifr_driver async_python_error_channel
+cargo build --locked -p sifr
+python3 scripts/check_demo_emitted_freshness.py --sifr target/debug/sifr --update
+python3 scripts/check_demo_emitted_freshness.py --sifr target/debug/sifr
+uv run --project verification --locked python -m sifr_verify areas run --area python_interop --suite async-declaration-examples --suite async-context-examples
+cargo test -p sifr_ir
+cargo test -p sifr_lowering
+cargo test -p sifr_frontend
+cargo test -p sifr_codegen
+cargo test -p sifr_driver
+cargo clippy --workspace -- -D warnings
+cargo fmt --check
+python3 scripts/check_hir_maintainability_guardrails.py
+python3 scripts/check_file_size_guardrails.py
+scripts/run_all_tests.sh --profile merge
+```
+
+Focused regressions cover both unchanged original examples, rejection of
+unrelated return channels (one/three diagnostics), imported PythonError's exact
+identity/shape/ancestry, local and imported transitive error ancestry without
+data-parent storage, and rejection of a same-named nominal Error target.
+The sixth regression covers imported CSV/configparser classes named Error:
+canonical export must not rewrite their builtin ancestor to their own identity.
+All six focused regressions pass before the candidate is frozen. The first
+attempt lacked fresh-worktree submodules; early regression failures identified
+test bridge/constructor setup and the repaired project-export ancestry path.
+Those attempts are historical failures, not final candidate evidence.
+The merge-profile gate is reserved for the final reviewed SHA, once only;
+create-PR is omitted. Outer filtered-suite certification failures are not passes.
+No 12K implementation, runner bypass, external repair, or history rewrite is allowed.
+
 Both fixtures fail SIFR-RESULT-0003 during checking:
 `verification/areas/python_interop/fixtures/async_declaration/httpx2_client.sifr`
 and `verification/areas/python_interop/fixtures/async_context/aiosqlite_session.sifr`.

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -489,3 +489,58 @@ was integrated. Only the two Markdown records change, with documentation diff
 and file-size results retained at `/private/tmp/sifr-item12j-m1.VO82Kk/evidence.md`.
 Draft PR #3699 remains the linked unapproved predecessor. Next action: explicit
 owner/user contract adjudication before resuming M1; this worker stops here.
+
+## Item12J-M1 required-string terminal receipt (2026-09-06)
+
+The user explicitly authorized the required constructor-supplied `message: str`
+contract, including breaking message-less calls and integer overrides. The prior
+decision blocker above is **resolved**, and the implementation is now source-review
+**SATISFIED**, but **not merged / not closed** because external qualification is
+still blocked. Historical12J/R1 NOT SATISFIED verdicts and exhausted reviews remain
+unchanged; no old allowance was reset.
+
+- Approved implementation: `d726ffc11258c49f0185fd2d49697988cf90972c`, retaining
+  record `054a823b9aaafd388ddf1d944f1b7e50fcb95c29` and all original12J/R1 lineage.
+- Draft bounded [PR #3700](https://github.com/sifr-lang/sifr/pull/3700), linked to
+  preserved predecessor #3699; branch `codex/item12j-m1-required-string`.
+- Initial exact-SHA [Opus review](https://github.com/sifr-lang/sifr/pull/3700#issuecomment-5558127599)
+  SATISFIED with no blockers. M1 used1initial review,0remediation reviews,0provider
+  retries,0create-PR gates,0merge gates; merge SHA none.
+- Owned checkout `/private/tmp/sifr-item12j-m1-required.vL5lSI/sifr`; parent and
+  previous worker checkouts/indexes/targets stayed read-only. Main remains
+  `4ce05473f58716a611ac190581bf0737ba15331e`.
+- Receipt, final record SHA,36changed paths, raw logs, and native JSON archives:
+  `/private/tmp/sifr-item12j-m1-required.vL5lSI/evidence-d726ffc11258c49f0185fd2d49697988cf90972c.md`.
+
+Typed string storage, required default/custom/inherited construction, declaration
+and call rejection, nominal exports, and consuming root projections now agree.
+PythonError keeps exactly five fields and five constructor inputs: its native
+package regression asserts all fields and root conversion using the existing
+probed interpreter/native-link trust, with no ignore or fallback. Local,
+inherited, mixed data-parent, imported/aliased, stdlib, collision, project and
+test-project native regressions pass. Full driver592active/77existing ignored,
+M1focused lowering3, original async-error-channel9, frontend132+7, IR4,
+type-system147, locked build,264fresh companions and all named static guards pass.
+
+**12I remains the Python qualification blocker:** both named original async
+declaration/context suites pass their source policy but fail native build with
+inaccessible `SIFR_GENERATED_SIFR_TASK_CANCELLATION` E0425. HTTP reports1Rust error;
+context reports58 with the same retained tail. Both runtime stdout markers and
+cleanup/cancellation assertions are **UNREACHED**, not native passes or skips.
+Fresh archives are `async-declaration.json`, `async-context.json`, and
+`python-results.json` beside `async-native.log`. Compiler SHA256 remained
+`166c1d23662db3c0da97b9c921e6f7fee22755b68c49e576906e07a569eec16e` across the run.
+
+Other known owners also block standalone merge:12B's2list-repeat codegen
+assertions,12B/12C's unchanged strict-Clippy `expect_used` (now line47), and
+TypeVar #3667's2stale lowering assertions. SQL coverage is retained external
+history, not newly rerun. None was absorbed or claimed fixed; no merge gate was
+spent over failed prerequisites.
+
+The phase terminal handoff records separate follow-ups12J-M1-F1 (compiler
+invariant hardening), F2 (unproven reference-only inherited SQL error reachability),
+F3 (integration E2E/stdlib executable coverage), and F4 (local Error-shadow
+storage documentation). They are not blocking source-review findings and no
+follow-up implementation started. Preserve the approved M1 candidate for the
+separately owned12K integration after dependency qualification. This worker
+stops after the record; it does not integrate12I or begin12K.

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -240,6 +240,53 @@ contract before repairing all affected fixtures or the appropriate compiler
 mechanism. Preserve original assertions, async cleanup/cancellation, and
 error propagation. Do not broaden accepted errors or suppress diagnostics.
 
+## Item12J-R1 bounded remediation plan (2026-09-06)
+
+Owned worktree `/private/tmp/sifr-item12j-r1.9j9Uhf/sifr`, branch
+`codex/emitted-rust-excellence-item-12j-r1`, retaining implementation `f720a342`
+and record `60219b0` unchanged in history. Fetched `origin/main` is still
+`4ce05473f58716a611ac190581bf0737ba15331e`, the original reviewed base.
+The parent's intentional dirty records and every retained worker are read-only.
+The 2026-09-06 parent amendment is carried into this worktree's phase record.
+
+Implement only the initial review's 12J-R1 conversion omission. Conversion
+demand follows semantic ancestry and canonical nominal identities; project
+and test-project support use the project nominal path registry. Existing
+consuming inheritance conversions preserve inherited messages without cloning.
+No 12I integration or next-item implementation is authorized here.
+
+Register these focused native regressions before running tests, all selected by
+the original named `cargo test -p sifr_driver async_python_error_channel` command:
+
+- `async_python_error_channel_native_local_and_transitive_conversions`: emit,
+  build and run local root/transitive errors using direct raise and propagation.
+- `async_python_error_channel_native_stdlib_nominal_collisions`: emit, build and
+  run distinct CSV/configparser Error declarations with original message assertions.
+- `async_python_error_channel_native_project_aliases_and_collisions`: emit,
+  build and run re-exported aliases, a transitive imported error, two same-named
+  project errors, and a local
+  nominal named ValueError distinct from the builtin. The existing negative
+  regression retains rejection of a same-named nominal Error target.
+
+Run only the exact Item12J command list above, reusing original IR, lowering,
+and frontend evidence where their complete crate inputs remain unchanged.
+Run affected codegen/driver tests, compiler build, freshness, named async suites,
+strict Clippy and formatting/HIR/file-size checks after the complete correction.
+Freeze the corrected SHA before the sole remaining remediation Opus review.
+One exact-final-candidate merge-profile gate remains; create-PR is omitted.
+Known external failures remain owned and honestly failed. If they prevent
+independent merge, preserve the corrected reviewed candidate for 12K and stop.
+
+Deferred **12J-F4**, owner nominal error export ancestry: the native test setup
+also tried project-imported `class Error(ValueError)` and `class Error(Error)`
+as positive source cases. Both remain rejected with SIFR-RESULT-0003 when raised
+into builtin Error. R1 changes no lowering/frontend/export inputs relative to
+`60219b0`, so this is unchanged-input source-check evidence, not an independent
+base runtime run. The retained `focused-corrected.log` and `focused-native.log`
+under the R1 evidence root contain the diagnostics. The final native collision
+case uses `ValueError(Error)` and retains the original negative Error-target
+test. This source ancestry issue is not repaired by the conversion item.
+
 ## Required next action
 
 Item12G is merged. Items12H/12I have terminal blocked, approved-candidate handoffs;

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -226,24 +226,100 @@ The merge-profile gate is reserved for the final reviewed SHA, once only;
 create-PR is omitted. Outer filtered-suite certification failures are not passes.
 No 12K implementation, runner bypass, external repair, or history rewrite is allowed.
 
-Both fixtures fail SIFR-RESULT-0003 during checking:
+Historical pre-12J observation: both fixtures failed SIFR-RESULT-0003 during checking:
 `verification/areas/python_interop/fixtures/async_declaration/httpx2_client.sifr`
 and `verification/areas/python_interop/fixtures/async_context/aiosqlite_session.sifr`.
 Their raised PythonError is incompatible with the declared Result[None, Error]
 channel; the latter fixture produces three diagnostics.
 
-Frontend/lowering/type-system, stdlib, and all Python-interop fixtures/runners
-are unchanged from exact base. This is input-identity evidence, not a repeated
-base qualification run. Determine the authoritative source/error-identity
+At that historical observation, frontend/lowering/type-system, stdlib, and all
+Python-interop fixtures/runners were unchanged from the observing candidate's
+base. This is input-identity evidence, not a repeated base qualification run.
+It does not describe the present12J compiler diff. Determine the authoritative source/error-identity
 contract before repairing all affected fixtures or the appropriate compiler
 mechanism. Preserve original assertions, async cleanup/cancellation, and
 error propagation. Do not broaden accepted errors or suppress diagnostics.
 
 ## Required next action
 
-Item12G is merged and complete. Stop its worker after publishing the closure
-record. The orchestrator may next assign bounded Item12H to a fresh isolated
-worker, then Item12I and Item12J in order. Use the named validation mapping
-above and preserve each item's review/gate limits. Item12K's expressly approved
-integration allowance follows dependency qualification; it does not reset
-Item12B's exhausted history. No Item12H–12K code was written by Item12G.
+Item12G is merged. Items12H/12I have terminal blocked, approved-candidate handoffs;
+Item12J now has the terminal blocked, **unapproved** candidate below. Stop12J's
+worker after publishing records. The orchestrator must assign the unresolved
+12J-R1 correction explicitly and preserve its remaining at-most-one remediation
+review and one final-candidate gate, with no reset of12B/H/I history. Item12K's
+separate integration allowance follows dependency qualification; this12J
+candidate must not be treated as approved or integrated as-is. No next-item
+code, integration, external repair, or gate bypass was written by12J.
+
+### Item12J terminal evidence and unresolved review
+
+State: **blocked**, draft [PR #3699](https://github.com/sifr-lang/sifr/pull/3699).
+Reviewed implementation `f720a342edd87004975355b478948f7eb5c8b406`; merge SHA:
+none. The final record is a separate documentation-only commit after that SHA.
+The initial [Opus review](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5555927728)
+returned **NOT SATISFIED**. The user's orchestration checkpoint then requested
+terminal handoff because external failure was already established. No remediation
+code or review was started; no final-approved candidate exists to gate.
+Allowances consumed: one initial review, zero remediation reviews, zero merge
+gates, zero create-PR gates. Do not relabel this as a qualified candidate.
+
+[Exact-candidate evidence and changed paths](https://github.com/sifr-lang/sifr/pull/3699#issuecomment-5555929816)
+are published outside the reviewed Git tree. Evidence root:
+`/private/tmp/sifr-item12j.pT6Xkk/`, receipt
+`evidence-f720a342edd87004975355b478948f7eb5c8b406.md`, review
+`review-f720a342edd87004975355b478948f7eb5c8b406.md`. Compiler SHA256:
+`36640bfbb7c29f7d0019d86ed9539c20311db434c326bf31bada4319b9d61940`.
+
+- Six focused lowering/export regressions pass; IR4, frontend132 unit +7
+  integration, driver584 active (77 existing ignored) pass. These focused tests
+  do not prove generated conversions for local/imported error classes.
+- Lowering1114 pass /2 fail /1 ignored, existing TypeVar message assertions
+  [owner #3667 notified](https://github.com/sifr-lang/sifr/issues/3667#issuecomment-5555882691).
+  Codegen1407 pass /2 existing12B-owned list-repeat failures. Strict Clippy
+  fails at unchanged `project_stdlib_nominals.rs:45` (`expect_used`), owner12B/12C.
+- All264 generated companions remain byte-identical. Formatting, HIR and
+  canonical file-size guard (3756 files) pass. No fixture/assertion changes.
+- The exact two-suite command exits1: both examples pass source checking and
+  fail native build at12I-owned inaccessible cancellation task-local E0425.
+  HTTP has one reported Rust error; context reports58 errors with retained tail
+  naming that task-local and E0425. No runtime output markers were observed;
+  original cleanup/cancellation/assertions did not execute. This is neither
+  a native pass nor complete-area certification; no bypass flag was used.
+- Native report files are `async-declaration-<candidate>.json`,
+  `async-context-<candidate>.json`, and `python-results-<candidate>.json` under
+  the evidence root; receipt records their SHA256s and log names. Final native
+  TMPDIR is private; driver used `RUST_TEST_THREADS=1` without changing selection
+  or internal concurrency. Interrupted earlier cache/scheduling attempts are
+  explicitly incomplete in the receipt, never passing evidence.
+
+**Unresolved in-scope finding12J-R1 (not implemented):** `support_plan.rs:184–200`
+generates conversions only for builtin errors and async PythonError, while the
+new ancestry also accepts non-builtin local/imported errors into builtinError.
+Opus emitted local DomainError and imported `sifr.csv.Error` examples and
+verified E0277, missing `From<T> for Error`. The bounded correction must connect
+semantic ancestry to conversion demand and add emission/compilation regressions
+for local, project-imported and stdlib errors, preserving nominal identity and
+the original runtime contract. The first review remains NOT SATISFIED until
+the sole permitted remediation review approves a corrected exact SHA. A new
+mechanism defect on that second review must be deferred and stopped, not trigger
+a third review. This terminal worker does not implement that continuation.
+
+Separate review follow-ups, not implementation or new blockers:
+
+- **12J-F1**, owner nominal error inheritance: pre-existing mixed data-base plus
+  Error-marker ancestry (`MixedError(Payload, Error)`) overwrites the marker and
+  still rejects propagation. Review classifies this as unchanged from base;
+  no independent base-runtime result is claimed here.
+- **12J-F2**, owner nominal export diagnostics: already-diagnosed unresolved
+  parent paths can fall back to a noncanonical/nontransitive parent string.
+  Evaluate separately; do not add a compatibility fallback in12J.
+- **12J-F3**, owner codegen maintainability: the class-field PythonError-contract
+  reconstruction does not currently consult ancestry, making that converted
+  field a harmless consistency-only change. Cleanup is optional later work.
+
+The review's infrastructure observation remains owned by12I: runtime async
+cleanup/cancellation cannot be certified before its visibility repair is
+integrated and qualified. Detailed12H-F1–F5 and12I-F1–F3 remain in their retained
+record commits/PRs above; none was copied over with stale statuses or discarded.
+The known SQL coverage failure remains an external owner and was not rerun
+or newly claimed as a12J gate result. This item stops without merging or starting12K.

--- a/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
+++ b/plans/issues/active/ad-hoc-python-interop-qualification-dependencies.md
@@ -453,3 +453,39 @@ integrated and qualified. Detailed12H-F1–F5 and12I-F1–F3 remain in their ret
 record commits/PRs above; none was copied over with stale statuses or discarded.
 The known SQL coverage failure remains an external owner and was not rerun
 or newly claimed as a12J gate result. This item stops without merging or starting12K.
+
+## Item12J-M1 contract adjudication (2026-09-06)
+
+Status: **needs-new-scope; no implementation, approval, or merge**. The new
+bounded M1 scope and full authority audit are preserved in the
+[phase handoff](ad-hoc-emitted-rust-excellence.md#item12j-m1-contract-adjudication-handoff-2026-09-06).
+Owned checkout `/private/tmp/sifr-item12j-m1.VO82Kk/sifr`, branch
+`codex/emitted-rust-excellence-item-12j-m1`, retains `c430ed3331169f06eb148122f681e7d2a457d2ee`
+and all reviewed 12J/R1 lineage. Fetched main remains `4ce05473f58716a611ac190581bf0737ba15331e`.
+The parent and all prior worker workspaces/evidence remain unchanged.
+
+Architecture requires inherited `message: str` supplied at construction, while
+the implementation treats root Error as a special base without embedded
+storage and constructs custom errors from only their declared fields. Root
+Error itself requires a string. The source/representation authorities do not
+define a root message for accepted `CodeError(3)`, `EmptyError()`, or
+`message: int` values. Existing specific-error Display behavior is not an
+authorized root-conversion policy. The prior native regression and unresolved
+root-upcast failures are reused from the sole R1 remediation review; no new
+compiler probe or test was run before resolving this contract conflict.
+
+The required explicit choice is between enforcing inherited required string
+storage (breaking existing constructors/overrides), defining how existing
+Display output supplies a root string (new observable conversion semantics),
+or allowing absent-message payloads in a wider root representation (larger
+language/runtime scope). No option was implemented. Suppressing only invalid
+unused conversions would leave the repeated root-upcast obligation unresolved.
+
+M1 used **zero reviews, zero gates**. Complete implementation, registered
+regressions, compiler/native tests, and merge are unreached. Old 12J/R1 remains
+NOT SATISFIED, not qualified, with both reviews consumed and no gate. Named
+historical external failures retain their owners and statuses; no 12K input
+was integrated. Only the two Markdown records change, with documentation diff
+and file-size results retained at `/private/tmp/sifr-item12j-m1.VO82Kk/evidence.md`.
+Draft PR #3699 remains the linked unapproved predecessor. Next action: explicit
+owner/user contract adjudication before resuming M1; this worker stops here.

--- a/stdlib/sifr/sync.sifr
+++ b/stdlib/sifr/sync.sifr
@@ -45,13 +45,13 @@ class Channel[T]:
 
     def push(mut self, own value: T) -> Result[None, ClosedError]:
         if self._closed:
-            raise ClosedError()
+            raise ClosedError("channel is closed")
         self._buffer.append(value)
         return None
 
     def pop(mut self) -> Result[T, ClosedError]:
         if len(self._buffer) == 0:
-            raise ClosedError()
+            raise ClosedError("channel is closed")
         value: T = self._buffer[0]
         self._buffer.pop(0)
         return value
@@ -188,7 +188,7 @@ class Semaphore:
         if self._permits > 0:
             self._permits = self._permits - 1
             return SemaphorePermit()
-        raise WouldBlockError()
+        raise WouldBlockError("lock is held")
 
 
 class Notify:


### PR DESCRIPTION
## Item12J-M1 only: required constructor-supplied string messages

Linked bounded follow-up to draft #3699. Retains record054a823b9 and all original12J/R1 lineage without rewriting history. The user expressly adjudicated the former blocker: enforce inherited required `message: str`, including breaking message-less calls and integer overrides. No Display fallback or absent-message root design is authorized.

Approved implementation: `d726ffc11258c49f0185fd2d49697988cf90972c`.
Final documentation-only record: `a7e13eb45006eac925417491b89a932af5df2595`.
Merge SHA: none. Status: source-review SATISFIED, externally blocked, not closed.
M1 delta base: `054a823b9aaafd388ddf1d944f1b7e50fcb95c29`.
Main base: `4ce05473f58716a611ac190581bf0737ba15331e`.

### Changes

- Typed required storage and declaration/call/constructor diagnostics, including default/custom/inherited constructors and direct root initialization.
- Consuming conversions project through actual owned data-parent storage; nominal imports/exports cover collisions and project/test-project assembly.
- Preserve valid string-message layouts and PythonError's exact five-field constructor; native regression coverage includes real package interpreter/link trust.
- Migrate necessary channel/sync/parallel-map producers, retain opaque-state negative-test purpose, and regenerate three affected demo companions.
- Register all focused/named validation and the authoritative decision in the phase record. No next-item implementation or external owner integration.

### Final evidence

Pass: full driver592 active/77 existing ignored; M1 focused lowering3; original async-error-channel9; frontend132+7; IR4; type-system147; locked CLI build; formatting/HIR/file-size guards. The final full driver run includes all five M1 driver regressions. Freshness update passed, and all264 companions are fresh.

Known external failures remain: codegen1407pass/2list-repeat failures (12B), lowering1117pass/2TypeVar failures/1ignored (#3667), unchanged Clippy `expect_used` (12B/12C), and both original async native suites blocked at12I cancellation-task-local E0425 (source policies pass; runtime assertions unreached). SQL coverage is retained external history, not rerun.

M1's [initial exact-SHA Opus review](https://github.com/sifr-lang/sifr/pull/3700#issuecomment-5558127599) is **SATISFIED**, no blocking findings. One initial review used; zero remediation reviews/provider retries/gates. Original12J/R1 remain historically NOT SATISFIED with both reviews exhausted. No create-PR gate, merge gate, or merge has run for M1. This draft must not merge while named external qualification remains blocked. Follow-ups12J-M1-F1–F4 are recorded separately and not started. Preserve the approved implementation for the integration owner; this worker stops without starting12K.

Local evidence directory: `/private/tmp/sifr-item12j-m1-required.vL5lSI` (SHA-keyed receipt and review will be published as PR comments). Parent and previous worker checkouts remain unchanged.
