### PR TITLE
Fix canonical diagnostic reference identity (12K-B2)

### DIFF
--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -2,6 +2,60 @@
 
 Status: active
 
+## Item 12K-B2: canonical diagnostic reference identity (2026-09-06)
+
+Owner: [#3704](https://github.com/sifr-lang/sifr/issues/3704), OPEN at dispatch.
+This section carries the parent's "Item12K-B1 receipt and B2/B3 dispatch
+(2026-09-06)" authorization into this independently owned checkout before
+implementation. Scope is the complete canonical reference matcher and focused
+positive/negative regressions, preserving unknown/non-active rejection and
+required registry coverage. SQL enum renaming, suppression, weaker assertions,
+schema synchronization (#3705 / B3), TypeVar follow-ups (#3703), inherited 12K
+integration, residual Item 12, and whole-phase closure are outside this item.
+
+The sole live implementer owns `/private/tmp/sifr-item12kb2.Qb9aoe/sifr`, its
+index and branch `codex/item12k-b2-diagnostic-reference-identity`, and sibling
+temporary evidence paths. Parent checkout/index/targets and all old worker
+checkouts remain read-only. Fresh main base is
+`4ce05473f58716a611ac190581bf0737ba15331e`. Its checker, MySQL analyzer, and
+SQLite lib blobs independently match the B1 receipt:
+`adea5eb1e4f7779b41a00fdba797d8ae9c044d18`,
+`5bb486b4a5f5086bfc0e420de3713f322dad38ff`, and
+`5c608cd22f031675273428e13f8e2f250513d8b5`, respectively.
+No inherited integration commits are included.
+
+[B1 terminal evidence](https://github.com/sifr-lang/sifr/pull/3702#issuecomment-5558641648)
+and [B1 review](https://github.com/sifr-lang/sifr/pull/3702#issuecomment-5558355686)
+were read along with the full B2 issue and terminal comment. B1 approved
+`a42545f759fac4e5e0537b6f9d9cc2fb8c9ed233`, record
+`d7c41463ca88d5993e3bc3fa847806160799e147`, remains preserved in
+`/private/tmp/sifr-item12kb1.nnPBDD/sifr`: one satisfied review, zero remediation,
+one failed gate, no merge. Its inherited integration/corpus lineage remains
+unchanged. Original 12K has zero reviews/gates consumed; previous exhausted
+allowances are not reset or reused as B2 evidence.
+
+Registered named checks, to run after the complete bounded implementation:
+
+- `python3 verification/areas/diagnostics/checks/code_coverage.py`
+- `python3 verification/areas/diagnostics/checks/code_coverage_test.py`
+  (canonical names, provider/prefixed identifiers, whole member tokens,
+  unknown/non-active canonical rejection, and required registry use)
+- `python3 scripts/check_file_size_guardrails.py`
+- `python3 -m py_compile verification/areas/diagnostics/checks/code_coverage.py verification/areas/diagnostics/checks/code_coverage_test.py`
+- Review the phase-record diff and run `git diff --check` (also check the
+  committed base-to-candidate diff).
+
+Only checker/tests/docs changes are planned: skip create-PR and merge gates.
+Do not run the known-failing full diagnostics area; schema_sync is B3-owned.
+If a compiler/lockfile/fixture/workflow change proves necessary in scope,
+record why and run at most one merge-profile gate on the approved final SHA.
+One initial exact-base/exact-candidate Opus review and at most one remediation
+are authorized, using atomic completed-response evidence outside the approved
+tree, keyed by candidate SHA. No review polling or third review. A new mechanism
+defect on second review or external blocker must be recorded under its later
+owner, then stop. Normal edits, Claude execution, PR/push/merge and owner-issue
+updates are authorized. After the narrow merge and record update, stop.
+
 Baseline commit: `e9df29f7e4cada7b376b2d455790f9c80a5647a0`
 
 ## Objective

--- a/verification/areas/diagnostics/checks/code_coverage.py
+++ b/verification/areas/diagnostics/checks/code_coverage.py
@@ -12,11 +12,26 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parents[4]
 CODES_RS = ROOT / "crates" / "sifr_diagnostics" / "src" / "codes.rs"
 CODE_RE = r"SIFR-(?:[A-Z]+|RUST-[A-Z]+)-\d{4}"
+CONSTANT_REFERENCE_RE = re.compile(
+    r"(?<!\w)(?:r#)?DiagnosticCode\s*::\s*(?:r#)?([A-Z_]\w*)\b"
+)
 INCLUDE_RE = re.compile(r'^\s*include!\("([^"]+)"\);\s*$', re.MULTILINE)
 LOCAL_MOD_RE = re.compile(
     r"^\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z0-9_]+);\s*$",
     re.MULTILINE,
 )
+
+
+def diagnostic_constant_references(text: str) -> list[str]:
+    """Read complete constant names under the exact DiagnosticCode identifier.
+
+    Like the registry, this textual audit uses uppercase/underscore-leading
+    constant names, not lowercase associated functions. Consume the entire
+    member token, including mixed-case suffixes, so malformed/unknown names
+    cannot masquerade as a registered constant. The type boundary excludes
+    provider identifiers, including underscore and Unicode prefixes.
+    """
+    return CONSTANT_REFERENCE_RE.findall(text)
 
 
 def git_ls_files(*patterns: str) -> list[pathlib.Path]:
@@ -132,10 +147,7 @@ def parse_registry() -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
     )
     if active_block is None:
         raise ValueError("could not find ACTIVE_DIAGNOSTIC_CODES")
-    active_constants = {
-        name
-        for name in re.findall(r"DiagnosticCode::([A-Z0-9_]+)", active_block.group("body"))
-    }
+    active_constants = set(diagnostic_constant_references(active_block.group("body")))
 
     active_code_to_constant = {
         code: name for name, code in constants.items() if name in active_constants
@@ -181,7 +193,7 @@ def main() -> int:
             continue
         rel = path.relative_to(ROOT)
         text = strip_cfg_test_blocks(read_rust_with_local_sources(path))
-        for name in re.findall(r"DiagnosticCode::([A-Z0-9_]+)", text):
+        for name in diagnostic_constant_references(text):
             if name not in all_constants:
                 errors.append(f"{rel}: references unknown DiagnosticCode::{name}")
                 continue

--- a/verification/areas/diagnostics/checks/code_coverage_test.py
+++ b/verification/areas/diagnostics/checks/code_coverage_test.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Focused identity and rejection regressions for canonical code coverage."""
+
+from __future__ import annotations
+
+from contextlib import redirect_stderr
+from io import StringIO
+import unittest
+from unittest.mock import patch
+
+import code_coverage
+
+
+class ReferenceIdentityTests(unittest.TestCase):
+    def test_canonical_paths_and_spacing(self) -> None:
+        for reference in (
+            "DiagnosticCode::TYPE_MISMATCH",
+            "sifr_diagnostics::DiagnosticCode::TYPE_MISMATCH",
+            "::sifr_diagnostics::DiagnosticCode::TYPE_MISMATCH",
+            "DiagnosticCode \n :: \t TYPE_MISMATCH",
+            "r#DiagnosticCode::r#TYPE_MISMATCH",
+            "(DiagnosticCode::TYPE_MISMATCH).as_str()",
+        ):
+            with self.subTest(reference=reference):
+                self.assertEqual(
+                    code_coverage.diagnostic_constant_references(reference),
+                    ["TYPE_MISMATCH"],
+                )
+
+    def test_provider_and_other_type_identifiers_are_not_canonical(self) -> None:
+        for owner in (
+            "MysqlDiagnosticCode", "SqliteDiagnosticCode", "OtherDiagnosticCode",
+            "_DiagnosticCode", "my_DiagnosticCode", "éDiagnosticCode",
+            "DiagnosticCodes", "DiagnosticCodeExtra", "DiagnosticCode_",
+        ):
+            for member in ("UnsupportedMode", "TYPE_MISMATCH"):
+                with self.subTest(owner=owner, member=member):
+                    self.assertEqual(
+                        code_coverage.diagnostic_constant_references(f"{owner}::{member}"),
+                        [],
+                    )
+
+    def test_complete_member_tokens(self) -> None:
+        for member in (
+            "TYPE_MISMATCH", "TYPE_MISMATCHExtra", "TYPE_MISMATCH_extra",
+            "TYPE_MISMATCH2", "TYPE_MISMATCHé", "UnsupportedMode", "_UNKNOWN",
+        ):
+            with self.subTest(member=member):
+                self.assertEqual(
+                    code_coverage.diagnostic_constant_references(f"DiagnosticCode::{member}"),
+                    [member],
+                )
+
+    def test_associated_functions_are_not_constant_uses(self) -> None:
+        self.assertEqual(
+            code_coverage.diagnostic_constant_references(
+                'DiagnosticCode::new("SIFR-TYPE-0002", Severity::Error)'
+            ),
+            [],
+        )
+
+    def test_mixed_references_preserve_each_canonical_use(self) -> None:
+        self.assertEqual(
+            code_coverage.diagnostic_constant_references(
+                "MysqlDiagnosticCode::UnsupportedMode, DiagnosticCode::TYPE_MISMATCH, "
+                "SqliteDiagnosticCode::Parse, DiagnosticCode::UNKNOWN, "
+                "DiagnosticCode::TYPE_MISMATCH"
+            ),
+            ["TYPE_MISMATCH", "UNKNOWN", "TYPE_MISMATCH"],
+        )
+
+
+class CoverageRejectionTests(unittest.TestCase):
+    def run_coverage(
+        self, source: str, active_reference: str = "DiagnosticCode::TYPE_MISMATCH"
+    ) -> tuple[int, str]:
+        # Supply source text only: exercise the real registry parser and main
+        # rejection/coverage logic without changing a compiler file or fixture.
+        source_path = code_coverage.ROOT / "crates/sifr_sql_mysql/src/analyzer.rs"
+        registry = '''
+pub const TYPE_MISMATCH: Self = Self::new("SIFR-TYPE-0002", Severity::Error);
+pub const TYPE_LEGACY: Self = Self::new("SIFR-TYPE-0999", Severity::Error);
+ACTIVE_DIAGNOSTIC_CODES: &[DiagnosticCode] = &[ACTIVE_REFERENCE];
+active_entry!("SIFR-TYPE-0002", Severity::Error, "crates/sifr_sql_mysql/src/analyzer.rs");
+'''.replace("ACTIVE_REFERENCE", active_reference)
+
+        def read_source(path):
+            self.assertIn(path, (code_coverage.CODES_RS, source_path))
+            return registry if path == code_coverage.CODES_RS else source
+
+        stderr = StringIO()
+        with (
+            patch.object(code_coverage, "non_test_compiler_sources", return_value=[source_path]),
+            patch.object(code_coverage, "read_rust_with_local_sources", side_effect=read_source),
+            redirect_stderr(stderr),
+        ):
+            result = code_coverage.main()
+        return result, stderr.getvalue()
+
+    def test_active_use_passes_alongside_providers(self) -> None:
+        self.assertEqual(self.run_coverage(
+            "MysqlDiagnosticCode::UnsupportedMode; SqliteDiagnosticCode::Parse; "
+            "DiagnosticCode::TYPE_MISMATCH;"
+        ), (0, ""))
+
+    def test_unknown_canonical_names_are_rejected_in_full(self) -> None:
+        for name in ("UNKNOWN", "UnsupportedMode", "TYPE_MISMATCHExtra", "_UNKNOWN"):
+            with self.subTest(name=name):
+                result, errors = self.run_coverage(
+                    f"DiagnosticCode::TYPE_MISMATCH; DiagnosticCode::{name};"
+                )
+                self.assertEqual(result, 1)
+                self.assertEqual(errors.splitlines(), [
+                    "diagnostic code coverage: crates/sifr_sql_mysql/src/analyzer.rs: "
+                    f"references unknown DiagnosticCode::{name}"
+                ])
+
+    def test_non_active_canonical_name_is_rejected(self) -> None:
+        result, errors = self.run_coverage(
+            "DiagnosticCode::TYPE_MISMATCH; DiagnosticCode::TYPE_LEGACY;"
+        )
+        self.assertEqual(result, 1)
+        self.assertIn("references non-active DiagnosticCode::TYPE_LEGACY", errors)
+
+    def test_provider_and_partial_names_do_not_supply_required_use(self) -> None:
+        for source in (
+            "", "MysqlDiagnosticCode::TYPE_MISMATCH", "_DiagnosticCode::TYPE_MISMATCH",
+            "DiagnosticCode::TYPE_MISMATCHExtra",
+        ):
+            with self.subTest(source=source):
+                result, errors = self.run_coverage(source)
+                self.assertEqual(result, 1)
+                self.assertIn(
+                    "SIFR-TYPE-0002 (TYPE_MISMATCH) is active but has no non-test "
+                    "compiler-source DiagnosticCode::TYPE_MISMATCH use", errors
+                )
+
+    def test_registry_list_uses_same_complete_identity(self) -> None:
+        for reference in (
+            "MysqlDiagnosticCode::TYPE_MISMATCH", "DiagnosticCode::TYPE_MISMATCHExtra",
+        ):
+            with self.subTest(reference=reference):
+                result, errors = self.run_coverage("", active_reference=reference)
+                self.assertEqual(result, 1)
+                self.assertIn(
+                    "SIFR-TYPE-0002 is active in the registry but missing from "
+                    "ACTIVE_DIAGNOSTIC_CODES", errors
+                )
+
+    def test_cfg_test_use_does_not_supply_required_coverage(self) -> None:
+        result, errors = self.run_coverage(
+            "#[cfg(test)]\nmod tests {\nlet code = DiagnosticCode::TYPE_MISMATCH;\n}"
+        )
+        self.assertEqual(result, 1)
+        self.assertIn("is active but has no non-test compiler-source", errors)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The diagnostic coverage audit reads `MysqlDiagnosticCode::UnsupportedMode` as canonical `DiagnosticCode::U`, and can truncate a mixed-case member to a registered prefix. Item 12K-B2 gives compiler-source scanning and active-registry scanning the same exact type-name boundary and complete constant-token matcher. Provider names no longer contribute references or satisfy required canonical coverage; real unknown and inactive canonical constants still fail.

Adds 11 focused tests covering canonical/qualified/raw paths, whitespace, provider and other prefixed identifiers, complete tokens, unknown/inactive rejection, required active usage, registry identity, and test-only exclusion. This PR starts independently from main `4ce05473f58716a611ac190581bf0737ba15331e`; it does not contain the inherited 12K stack.

Validation on implementation `8be5b9ece92703fda44149bb79ec6ed077e23c10`:

- `python3 verification/areas/diagnostics/checks/code_coverage.py`: pass.
- `python3 verification/areas/diagnostics/checks/code_coverage_test.py`: 11 passed.
- `python3 scripts/check_file_size_guardrails.py`: pass, 3755 files.
- Python syntax compilation, phase-record review, working-tree and base-to-candidate `git diff --check`: pass.

Only checker/tests/docs changed. Create-PR and merge gates are explicitly skipped under the B2 dispatch; no full diagnostics-area pass is claimed. B3/schema_sync (#3705) and TypeVar follow-ups (#3703) remain separately owned. [One exact-SHA Opus review](https://github.com/sifr-lang/sifr/pull/3706#issuecomment-5558708053) returned SATISFIED with no blockers; no remediation. [Named validation evidence](https://github.com/sifr-lang/sifr/pull/3706#issuecomment-5558694390) is published. Nonblocking review follow-ups are recorded in #3707 and #3708; no follow-up implementation was started.

Closes #3704.
