### PR TITLE
fix(diagnostics): synchronize schema with locked generator (12K-B3)

### DIFF
--- a/docs/schemas/diagnostics.schema.json
+++ b/docs/schemas/diagnostics.schema.json
@@ -3,16 +3,16 @@
   "title": "DiagnosticEnvelope",
   "type": "object",
   "properties": {
-    "version": {
-      "type": "integer",
-      "format": "uint32",
-      "minimum": 0
-    },
     "diagnostics": {
       "type": "array",
       "items": {
         "$ref": "#/$defs/RenderedDiagnostic"
       }
+    },
+    "version": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
     }
   },
   "additionalProperties": false,
@@ -21,72 +21,11 @@
     "diagnostics"
   ],
   "$defs": {
-    "RenderedDiagnostic": {
-      "type": "object",
-      "properties": {
-        "code": {
-          "type": "string"
-        },
-        "severity": {
-          "$ref": "#/$defs/Severity"
-        },
-        "message": {
-          "type": "string"
-        },
-        "message_template": {
-          "type": "string"
-        },
-        "args": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/DiagnosticArg"
-          }
-        },
-        "url": {
-          "type": "string"
-        },
-        "spans": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/DiagnosticSpan"
-          }
-        },
-        "children": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RenderedDiagnosticChild"
-          }
-        },
-        "help": {
-          "type": "string"
-        },
-        "suggestions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RenderedDiagnosticSuggestion"
-          }
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "code",
-        "severity",
-        "message",
-        "message_template",
-        "args",
-        "url",
-        "spans",
-        "children",
-        "help",
-        "suggestions"
-      ]
-    },
-    "Severity": {
+    "ChildSeverity": {
       "type": "string",
       "enum": [
-        "Error",
-        "Warning",
-        "Note"
+        "Note",
+        "Help"
       ]
     },
     "DiagnosticArg": {
@@ -180,20 +119,12 @@
     "DiagnosticSpan": {
       "type": "object",
       "properties": {
-        "file": {
-          "type": "string"
-        },
-        "byte_start": {
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0
-        },
         "byte_end": {
           "type": "integer",
           "format": "uint32",
           "minimum": 0
         },
-        "line": {
+        "byte_start": {
           "type": "integer",
           "format": "uint32",
           "minimum": 0
@@ -203,21 +134,29 @@
           "format": "uint32",
           "minimum": 0
         },
+        "end_column": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
         "end_line": {
           "type": "integer",
           "format": "uint32",
           "minimum": 0
         },
-        "end_column": {
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0
+        "file": {
+          "type": "string"
         },
         "is_primary": {
           "type": "boolean"
         },
         "label": {
           "type": "string"
+        },
+        "line": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
         },
         "lines": {
           "type": "array",
@@ -243,18 +182,18 @@
     "DiagnosticSpanLine": {
       "type": "object",
       "properties": {
-        "text": {
-          "type": "string"
+        "highlight_end": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
         },
         "highlight_start": {
           "type": "integer",
           "format": "uint32",
           "minimum": 0
         },
-        "highlight_end": {
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0
+        "text": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -264,14 +203,74 @@
         "highlight_end"
       ]
     },
-    "RenderedDiagnosticChild": {
+    "RenderedDiagnostic": {
       "type": "object",
       "properties": {
-        "severity": {
-          "$ref": "#/$defs/ChildSeverity"
+        "args": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/DiagnosticArg"
+          }
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/RenderedDiagnosticChild"
+          }
+        },
+        "code": {
+          "type": "string"
+        },
+        "help": {
+          "type": "string"
         },
         "message": {
           "type": "string"
+        },
+        "message_template": {
+          "type": "string"
+        },
+        "severity": {
+          "$ref": "#/$defs/Severity"
+        },
+        "spans": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DiagnosticSpan"
+          }
+        },
+        "suggestions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/RenderedDiagnosticSuggestion"
+          }
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "severity",
+        "message",
+        "message_template",
+        "args",
+        "url",
+        "spans",
+        "children",
+        "help",
+        "suggestions"
+      ]
+    },
+    "RenderedDiagnosticChild": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "severity": {
+          "$ref": "#/$defs/ChildSeverity"
         }
       },
       "additionalProperties": false,
@@ -280,19 +279,9 @@
         "message"
       ]
     },
-    "ChildSeverity": {
-      "type": "string",
-      "enum": [
-        "Note",
-        "Help"
-      ]
-    },
     "RenderedDiagnosticSuggestion": {
       "type": "object",
       "properties": {
-        "message": {
-          "type": "string"
-        },
         "applicability": {
           "$ref": "#/$defs/SuggestionApplicability"
         },
@@ -301,6 +290,9 @@
           "items": {
             "$ref": "#/$defs/RenderedSuggestionEdit"
           }
+        },
+        "message": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -310,6 +302,30 @@
         "edits"
       ]
     },
+    "RenderedSuggestionEdit": {
+      "type": "object",
+      "properties": {
+        "replacement": {
+          "type": "string"
+        },
+        "span": {
+          "$ref": "#/$defs/DiagnosticSpan"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "span",
+        "replacement"
+      ]
+    },
+    "Severity": {
+      "type": "string",
+      "enum": [
+        "Error",
+        "Warning",
+        "Note"
+      ]
+    },
     "SuggestionApplicability": {
       "type": "string",
       "enum": [
@@ -317,22 +333,6 @@
         "MaybeIncorrect",
         "HasPlaceholders",
         "Unspecified"
-      ]
-    },
-    "RenderedSuggestionEdit": {
-      "type": "object",
-      "properties": {
-        "span": {
-          "$ref": "#/$defs/DiagnosticSpan"
-        },
-        "replacement": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "span",
-        "replacement"
       ]
     }
   }

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -1592,6 +1592,127 @@ Final qualification owns the workflow repair. The diagnostic-baseline
 identity migration and pre-existing quality failures described above remain
 unresolved; these passing CLI results do not qualify the Clippy baseline.
 
+## Item12K-B3 owned authorization and test registration (2026-09-06)
+
+This worker owns only diagnostics schema synchronization, issue
+[#3705](https://github.com/sifr-lang/sifr/issues/3705), OPEN at dispatch.
+The parent supplied the newer “Item12K-B2 receipt and B3 dispatch” and
+preceding B1/B2 receipt; this registration carries that authorization into
+this independent phase record before implementation. Owned checkout:
+`/private/tmp/sifr-item12kb3.bEfGLS/sifr`, branch
+`codex/item12k-b3-schema-sync`, fetched main/base
+`770f1ab86050bc95abf05573b39c8c6d5238902e` (merged B2 PR #3706).
+Parent's two intentional dirty Markdown files and all predecessor checkouts,
+Git indexes, targets, and histories remain read-only. No inherited 12K stack
+is imported or approved by B3.
+
+Predecessor receipts:
+
+- B1 reviewed two assertions only at
+  `a42545f759fac4e5e0537b6f9d9cc2fb8c9ed233`; record
+  `d7c41463ca88d5993e3bc3fa847806160799e147`, PR #3702 unmerged.
+  Its [exact gate receipt](https://github.com/sifr-lang/sifr/pull/3702#issuecomment-5558641648)
+  records one failed 3254.32-second gate, Python 30/30, diagnostic baselines
+  179/179, diagnostics overall 182/184. Matcher B2 and schema B3 failed;
+  subsequent stages were unreached. No B1 retry is authorized.
+- B2 PR #3706 reviewed `8be5b9ece92703fda44149bb79ec6ed077e23c10`,
+  merged at this base; record `a53b5d34f6a7a659e39d66c0c0d6d9397c8b2216`.
+  [Receipt](https://github.com/sifr-lang/sifr/issues/3704#issuecomment-5558722496):
+  11 focused passes, canonical coverage, syntax/file-size checks, one
+  SATISFIED review, zero remediation/gates. #3707/#3708 are separate owners.
+- Original 12K candidate `7e23785ab07cba6f925eed2f934c0304750f1d74`
+  and corpus `8bcbe7ab7939e5c8362c10f61a80e368022cc372` stay preserved;
+  original 12K has zero reviews/gates used, with dependency caps unchanged.
+
+First capture the locked generator stdout and establish the exact source,
+artifact, and dependency mechanism; this is diagnosis, not a test pass.
+Complete the bounded root-cause correction before testing, preserving the
+intended public schema and strict comparison. No blind blessing, ignored
+field-order/value differences, fallback, or unrelated dependency upgrades.
+Necessary focused regressions are in scope; register their exact command
+before running them. Use apply_patch for edits or the normal generator when
+supported by the diagnosis. Do not overwrite the artifact through a shell
+redirect. Normal scoped push/draft PR/merge, owner updates, and read-only
+Claude execution are authorized.
+
+Named validation, executed from the owned checkout after implementation:
+
+- `cargo run --locked -q -p sifr_diagnostics --bin gen-diagnostic-schema`
+  (stdout capture under `/private/tmp/sifr-item12kb3.bEfGLS/`, also authorized
+  before implementation solely for diagnosis).
+- `python3 verification/areas/diagnostics/checks/schema_sync.py`.
+- `cargo test -p sifr_diagnostics`.
+- `uv run --project verification --locked python -m sifr_verify areas run --area diagnostics --result-json /private/tmp/sifr-item12kb3.bEfGLS/diagnostics-results.json`.
+  Require the full 179 baseline variants and five rules; no partial
+  certification or coverage bypass. Report actual coverage.
+- `python3 scripts/check_file_size_guardrails.py`.
+- Relevant JSON parsing, Python syntax, Markdown/diff checks, and
+  `git diff --check`. If Rust source changes also `cargo fmt --check` and
+  `python3 scripts/check_hir_maintainability_guardrails.py`.
+
+One initial exact-SHA Opus review and at most one remediation; prompt includes
+base/candidate/paths/scope/evidence, read-only, no invented requirements or
+repeated broad validation. Atomic completed response outside reviewed tree;
+at most three failed transport attempts, never three review rounds. A second
+review's new mechanism defect gets a later owner and terminal stop. Compiler,
+lockfile, fixture, and workflow unchanged means zero Sifr gates even if the
+schema artifact changes. If governed inputs necessarily change, run exactly
+one merge-profile gate on the approved final SHA, skip create-pr, no second
+gate. Reuse exact-input evidence. Check free space before long Cargo work;
+only clean this worker's unused private target if over 20 GiB. External
+failures receive owner records and terminal stop, not unrelated repairs.
+
+After B3 merge and documentation-only phase receipt, stop without further
+review/gates. Do not resume 12K or start 12D/E/F, Item12, or phase closure.
+Return item ID, PR, reviewed implementation/record/merge SHAs, exact test,
+review and gate counts, evidence links, changed paths, and blocker or none.
+
+### B3 diagnosis and focused-test registration
+
+Read-only diagnosis established that commit
+`066300ff185f38b425a884a2225b72990a194e58` removed workspace
+`serde_json/preserve_order` without updating the schema last written in
+`5f6019eeb9`. Locked package generation uses schemars 1.2.2 and serde_json
+1.0.151 without preserve_order. Schemars orders schema keywords explicitly,
+while the eight properties/definitions maps follow serde_json map order.
+The old artifact uses insertion order, the current generator lexical order.
+Recursive comparison found identical keys, values, and array order everywhere;
+only eight object key orders differ. This comparison classifies the defect;
+it does not replace strict synchronization validation.
+
+Diagnostic captures under the owned root (not counted as test passes):
+
+- `schema-before.json`, current locked generator, SHA256
+  `ebc73fd29b44df16e14ac636437d9f93b67088925a8a381b90b2fde7e72b83a3`.
+- `schema-preserve-order.json`, the same command with
+  `--features serde_json/preserve_order`, SHA256
+  `0af2f7f3e6c438bff56767af14dde31b18f2d1fd2b9b6e833a1300463d4f976a`,
+  byte-identical to the old tracked artifact. This controlled feature change
+  establishes cause without upgrading dependencies or changing source.
+- The first capture attempt could not build before this fresh checkout's
+  Ruff submodule was initialized; no generator executed on that attempt.
+  Owned Ruff is pinned at `f19957111640fdee8055bfe5b6aa854259344473`.
+
+B3 base and historical main `4ce05473f58716a611ac190581bf0737ba15331e`
+have identical Cargo.toml/lock, diagnostics/source crates, Ruff pin and Cargo
+config. Diagnostics tree `47f22e0bd83633bd650a9826fdc3a69d3078ded7`,
+schema blob `6c2e5a625970d4f0e23c02317375ac09c3b3639e`, checker blob
+`cbf87fa8f7b3fa916504820b2a6622868054aae3` match B1. B1's Cargo.lock
+diff adds only the lowering insta edge; no inherited integration evidence is
+used to certify this independently built candidate.
+
+Correction: update only the artifact's proven stale ordering with the captured
+normal generator output through apply_patch; retain the current dependency
+policy and model. Add `--locked` to the strict checker's generator command.
+Register `python3 -m unittest discover -s verification/areas/diagnostics/checks -p 'test_schema_sync.py' -v`
+before adding/running focused regressions for exact agreement, changed object
+order, values, array order, formatting, missing artifact and generator failure.
+JSON/Python syntax check registration:
+`python3 -m json.tool docs/schemas/diagnostics.schema.json` and
+`python3 -m py_compile verification/areas/diagnostics/checks/schema_sync.py verification/areas/diagnostics/checks/test_schema_sync.py`.
+No Rust/compiler, lockfile, fixture or workflow changes are necessary, so
+Sifr gate count is zero under the explicit dispatch rule.
+
 ## Descriptive demo variables follow-up (2026-09-05)
 
 A second pass found no delivery-labelled `m12` path or content under `demos`,

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -1642,7 +1642,7 @@ Named validation, executed from the owned checkout after implementation:
   before implementation solely for diagnosis).
 - `python3 verification/areas/diagnostics/checks/schema_sync.py`.
 - `cargo test -p sifr_diagnostics`.
-- `uv run --project verification --locked python -m sifr_verify areas run --area diagnostics --result-json /private/tmp/sifr-item12kb3.bEfGLS/diagnostics-results.json`.
+- `uv run --project verification --locked python -m sifr_verify areas run --area diagnostics --result-json /private/tmp/sifr-item12kb3.bEfGLS/sifr/target/verification/areas/diagnostics-b3-results.json`.
   Require the full 179 baseline variants and five rules; no partial
   certification or coverage bypass. Report actual coverage.
 - `python3 scripts/check_file_size_guardrails.py`.
@@ -1712,6 +1712,26 @@ JSON/Python syntax check registration:
 `python3 -m py_compile verification/areas/diagnostics/checks/schema_sync.py verification/areas/diagnostics/checks/test_schema_sync.py`.
 No Rust/compiler, lockfile, fixture or workflow changes are necessary, so
 Sifr gate count is zero under the explicit dispatch rule.
+
+### B3 validation invocation correction
+
+Implementation commit `226b489981d1adeed1691c1f2354d67ed608dd21` passed
+locked generator comparison, direct schema synchronization, all seven focused
+regressions, all 32 diagnostics crate tests, file-size (3756 files), JSON/Python
+syntax and diff checks. The first full-area invocation emitted pass for all
+179 baseline variants and all five rules, then exited 1 because this worker
+had registered `/private/tmp/sifr-item12kb3.bEfGLS/diagnostics-results.json`,
+outside the runner's permitted repository root. No result JSON was written.
+This is an owned invocation mistake, not a compiler/schema failure or a
+successful full-area command. Preserve `diagnostics-area-226b48998.log` as
+the exact failed-invocation evidence; do not synthesize a passing report.
+
+Before the corrected invocation, the registered command above now places its
+result under this owned checkout's `target/verification/areas/`. No compiler,
+checker, schema, test, dependency, fixture or workflow inputs changed. Reuse
+the other passing targeted evidence across this documentation-only correction;
+repeat the named complete area once to obtain its canonical successful report.
+No Sifr gate has run and no gate retry is involved. B3 reviews remain zero.
 
 ## Descriptive demo variables follow-up (2026-09-05)
 

--- a/verification/areas/diagnostics/checks/schema_sync.py
+++ b/verification/areas/diagnostics/checks/schema_sync.py
@@ -10,11 +10,15 @@ import sys
 
 ROOT = pathlib.Path(__file__).resolve().parents[4]
 SCHEMA_PATH = ROOT / "docs" / "schemas" / "diagnostics.schema.json"
+GENERATOR_COMMAND = [
+    "cargo", "run", "--locked", "-q", "-p", "sifr_diagnostics",
+    "--bin", "gen-diagnostic-schema",
+]
 
 
 def main() -> int:
     generated = subprocess.run(
-        ["cargo", "run", "-q", "-p", "sifr_diagnostics", "--bin", "gen-diagnostic-schema"],
+        GENERATOR_COMMAND,
         cwd=ROOT,
         check=False,
         stdout=subprocess.PIPE,
@@ -24,7 +28,7 @@ def main() -> int:
     if generated.returncode != 0:
         sys.stderr.write(
             "schema sync: failed to invoke generator: "
-            "cargo run -q -p sifr_diagnostics --bin gen-diagnostic-schema\n"
+            "cargo run --locked -q -p sifr_diagnostics --bin gen-diagnostic-schema\n"
         )
         sys.stderr.write(generated.stderr)
         return generated.returncode
@@ -34,7 +38,7 @@ def main() -> int:
     if actual != expected:
         sys.stderr.write(
             "docs/schemas/diagnostics.schema.json is out of sync. "
-            "Run `cargo run -q -p sifr_diagnostics --bin gen-diagnostic-schema "
+            "Run `cargo run --locked -q -p sifr_diagnostics --bin gen-diagnostic-schema "
             "> docs/schemas/diagnostics.schema.json`.\n"
         )
         return 1

--- a/verification/areas/diagnostics/checks/test_schema_sync.py
+++ b/verification/areas/diagnostics/checks/test_schema_sync.py
@@ -1,0 +1,90 @@
+"""Lock strict schema synchronization, including order-only artifact drift."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import subprocess
+import unittest
+from unittest.mock import Mock, patch
+
+import schema_sync
+
+
+class SchemaSyncTests(unittest.TestCase):
+    def run_check(
+        self,
+        actual: str,
+        expected: str,
+        *,
+        exists: bool = True,
+        generator_status: int = 0,
+    ) -> tuple[int, str]:
+        artifact = Mock()
+        artifact.exists.return_value = exists
+        artifact.read_text.return_value = actual
+        generated = subprocess.CompletedProcess(
+            args=[], returncode=generator_status, stdout=expected,
+            stderr="generator failed\n" if generator_status else "",
+        )
+        stderr = io.StringIO()
+        with (
+            patch.object(schema_sync, "SCHEMA_PATH", artifact),
+            patch.object(schema_sync.subprocess, "run", return_value=generated) as run,
+            contextlib.redirect_stderr(stderr),
+        ):
+            result = schema_sync.main()
+        run.assert_called_once_with(
+            ["cargo", "run", "--locked", "-q", "-p", "sifr_diagnostics",
+             "--bin", "gen-diagnostic-schema"],
+            cwd=schema_sync.ROOT,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if not exists or generator_status:
+            artifact.read_text.assert_not_called()
+        return result, stderr.getvalue()
+
+    def assert_out_of_sync(self, actual: str, expected: str) -> None:
+        result, error = self.run_check(actual, expected)
+        self.assertEqual(result, 1)
+        self.assertIn("is out of sync", error)
+
+    def test_exact_generator_output_passes(self) -> None:
+        output = '{"properties":{"a":{},"b":{}}}\n'
+        self.assertEqual(self.run_check(output, output), (0, ""))
+
+    def test_object_key_order_drift_fails(self) -> None:
+        self.assert_out_of_sync(
+            '{"properties":{"b":{},"a":{}}}\n',
+            '{"properties":{"a":{},"b":{}}}\n',
+        )
+
+    def test_schema_value_drift_fails(self) -> None:
+        self.assert_out_of_sync('{"type":"string"}\n', '{"type":"integer"}\n')
+
+    def test_array_order_drift_fails(self) -> None:
+        self.assert_out_of_sync(
+            '{"required":["b","a"]}\n', '{"required":["a","b"]}\n',
+        )
+
+    def test_formatting_drift_fails(self) -> None:
+        self.assert_out_of_sync('{"type": "string"}\n', '{"type":"string"}\n')
+        self.assert_out_of_sync('{"type":"string"}', '{"type":"string"}\n')
+
+    def test_missing_artifact_fails(self) -> None:
+        result, error = self.run_check("", "{}\n", exists=False)
+        self.assertEqual(result, 1)
+        self.assertIn("is out of sync", error)
+
+    def test_generator_failure_propagates_even_with_matching_stdout(self) -> None:
+        result, error = self.run_check("{}\n", "{}\n", generator_status=101)
+        self.assertEqual(result, 101)
+        self.assertIn("failed to invoke generator", error)
+        self.assertIn("generator failed", error)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Removing `serde_json/preserve_order` changed the locked generator's ordering in eight schema objects, leaving the checked-in diagnostics schema stale. The controlled feature comparison reproduces the old artifact byte-for-byte; all schema keys, values and array order are unchanged.

Align the artifact with the current generator, invoke Cargo with `--locked` in the synchronization checker, and add seven regressions preserving strict rejection of ordering, value, array, formatting, missing-artifact and generator-failure differences.

This independently based PR closes only Item12K-B3. Base is merged B2 `770f1ab86050bc95abf05573b39c8c6d5238902e`; no inherited 12K integration stack is included.

Validation: 32 diagnostics crate tests, seven focused checker regressions, locked generator/artifact comparison, direct schema synchronization, file-size, JSON/Python syntax and diff checks pass. The complete diagnostics area exits 0: 184/184 variants, comprising 179 baselines and five rules; zero failures, filters, or skips.

The first full-area invocation passed all 184 variants but exited 1 because its result path was outside the runner's allowed repository root. A documentation-only correction registered the proper owned target path; the complete second run passed and wrote its canonical report. This invocation error and both runs are preserved in the evidence receipt.

Compiler, lockfile, fixtures and workflows are unchanged; zero Sifr create-pr/merge gates are required by the explicit B3 dispatch. [The one initial exact-SHA Opus review](https://github.com/sifr-lang/sifr/pull/3709#issuecomment-5558960888) returned SATISFIED with no blockers for `380f7d655e2e83c50f05f54512de13d0f4e47d6d`; zero remediation reviews. [Validation receipt](https://github.com/sifr-lang/sifr/pull/3709#issuecomment-5558941208). Nonblocking later-owner follow-ups are #3710 (automatic focused-test discovery) and #3711 (feature-independent schema ordering); no follow-up implementation is included.

Fixes #3705.
