### PR TITLE
docs: restore 12K-B7 filesystem inventory ownership

### DIFF
--- a/internal_docs/typescript_go_architecture_transfer_guardrails.md
+++ b/internal_docs/typescript_go_architecture_transfer_guardrails.md
@@ -35,12 +35,30 @@ The source-provider implementation locks the following terms before behavior mig
 
 ## Current Direct-Read, Probe, And Documented Effect Inventory
 
-These production filesystem reads and path probes are semantic inputs, tooling
+The production filesystem reads and path probes below are semantic inputs, tooling
 inputs, package identity inputs, or command-surface inputs. The source-provider implementation must route
 semantic entries through a typed source provider or explicitly reclassify a row
 as a non-semantic exception. Path probes are listed alongside content and
 directory reads so the source provider can track successful and failed lookup dependencies
 without treating probes as source content reads.
+
+Inventory coverage is deliberately broader than semantic source ownership. The
+checker scans complete Rust files under its six declared crate `src` roots,
+including inline `#[cfg(test)]` modules and platform-specific code on every host.
+Its existing path filter excludes `source_provider.rs`, `tests` and `bin`
+directories, `tests.rs`, and `*_tests.rs`; it does not parse conditional blocks.
+Inline-test reads and probes therefore remain listed as test effects, as with
+the self-update runner fixtures below. Their non-semantic classification is not
+an exclusion for production code in the same file. A future production read in
+such a file still needs its own ownership adjudication.
+
+The checker enforces path membership, not exact line numbers or ownership
+classifications. The row descriptions remain the ownership record; adding a
+path does not grant a blanket exception to every read in that file. Line
+references for the 12K-B7 additions below use main
+`f11e1cd7eef16a02063555bccc9fd8e19287833b`: 22 matching lines across six paths,
+17 production and five inline-test lines. The SQL manifest line contains two
+file probes, so these are scanner-line counts, not counts of individual calls.
 
 | Area | Current site | Current behavior | Source-provider expectation |
 | --- | --- | --- | --- |
@@ -74,6 +92,14 @@ without treating probes as source content reads.
 | CLI self-update dry-run metadata fixture | `crates/sifr/src/self_update_metadata_source.rs:37`, `crates/sifr/src/self_update_metadata_source.rs:42` | Installed-release qualification may read an explicitly selected, absolute, regular-file schema-v2 metadata fixture only for `self update --dry-run`; ordinary and mutating updates continue to fetch the protected public governance asset. | Non-semantic release-qualification command surface; not compiler source identity. Keep inventoried unless release certification gains a dedicated fixture provider boundary. |
 | CLI self-update receipt state | `crates/sifr/src/self_update_receipt.rs:71`, `crates/sifr/src/self_update_receipt.rs:90`, `crates/sifr/src/self_update_receipt.rs:103`, `crates/sifr/src/self_update_receipt.rs:114`, `crates/sifr/src/self_update_receipt.rs:177`, `crates/sifr/src/self_update_receipt.rs:206` | Self-update reads and probes the standalone installer receipt and installed sysroot marker to decide whether the current executable is managed by the official installer. | Non-semantic install-state command surface; not compiler source identity. Keep inventoried unless a later install-state provider boundary is introduced. |
 | CLI self-update runner fixture reads | `crates/sifr/src/self_update_runner.rs:532`, `crates/sifr/src/self_update_runner.rs:565`, `crates/sifr/src/self_update_runner.rs:662` | Self-update runner tests read fixture files written by fake installer scripts to assert delegated environment, manifest, sysroot, and lock behavior. | Non-semantic test-fixture reads; not compiler source identity. Keep inventoried unless runner tests move to a dedicated fixture helper boundary. |
+| CLI host-tool program resolution | `crates/sifr/src/host_tool_cli.rs:196` | `resolve_program` probes PATH candidates for Cargo and rustc before building a host tool. | Non-semantic host-tool execution environment probe, owned by the CLI command; not Sifr source discovery. Keep inventoried as a command-surface exception. |
+| CLI host-tool sandbox setup | `crates/sifr/src/host_tool_sandbox.rs:238`, `crates/sifr/src/host_tool_sandbox.rs:334`, `crates/sifr/src/host_tool_sandbox.rs:358`, `crates/sifr/src/host_tool_sandbox.rs:389`, `crates/sifr/src/host_tool_sandbox.rs:395`, `crates/sifr/src/host_tool_sandbox.rs:429` | Sandbox setup probes macOS sandbox-exec, Linux bubblewrap/prlimit, system and subprocess directories, and mount-parent path shape. | Non-semantic host confinement and mount-layout probes, owned by the CLI sandbox. Preserve fail-closed capability enforcement; these are not compiler source lookup dependencies. |
+| Driver materialization inline-test effects | `crates/sifr_driver/src/build/materialize.rs:625`, `crates/sifr_driver/src/build/materialize.rs:626`, `crates/sifr_driver/src/build/materialize.rs:664`, `crates/sifr_driver/src/build/materialize.rs:665` | Inline tests read generated `src/main.rs` and probe the generated manifest, retained target marker, and rematerialized source. | Non-semantic temporary test-output observations, owned by materialization tests. Keep inventoried; this classification does not exempt production materialization inputs. |
+| Driver portable generated-source publication | `crates/sifr_driver/src/build/portable_project.rs:64`, `crates/sifr_driver/src/build/portable_project.rs:79` | `copy_tree` enumerates the generated Rust source directory and checks entry directory types while publishing the portable project. | Non-semantic generated-output materialization, owned by the driver build layer; not semantic Sifr source access. |
+| Driver portable project build identity | `crates/sifr_driver/src/build/portable_project.rs:130`, `crates/sifr_driver/src/build/portable_project.rs:177`, `crates/sifr_driver/src/build/portable_project.rs:342` | Portable metadata preparation reads `sysroot.toml`, the resolved generated Cargo lockfile, and authoritative Cargo locks to pin revisions and rewrite portable dependency sources. | Sysroot and package/build identity inputs, owned by driver build planning. Keep inventoried until a package-aware build snapshot owns these authorities; not a blanket generated-output exception. |
+| Driver portable lock inline-test effect | `crates/sifr_driver/src/build/portable_project.rs:443` | The inline lock-rewrite test reads its generated Cargo lockfile to check portable dependency sources and removal of private host paths. | Non-semantic temporary test-output read; does not reclassify the production identity reads in the same file. |
+| Driver SQL editor package readiness | `crates/sifr_driver/src/build/sql_profiles.rs:248`, `crates/sifr_driver/src/build/sql_profiles.rs:253` | `load_sql_editor_profiles` probes `sifr.toml`, `Cargo.toml`, and `Cargo.lock` before loading frozen package state; absent files defer SQL editor profiles. | Package/config availability inputs that affect editor analysis, owned by driver SQL profile loading and package snapshots. Successful and failed probes require provider/snapshot tracking; retain as an unresolved inventory obligation, not a non-semantic exception or a claim of completed migration. |
+| Package host-tool path identity | `crates/sifr_package/src/host_tools.rs:719`, `crates/sifr_package/src/host_tools.rs:745`, `crates/sifr_package/src/host_tools.rs:747` | `hash_path_package` enumerates package directories and classifies metadata as directories/files to build the bounded, symlink-rejecting content checksum for host-tool lock verification. | Host-tool package identity and trust inputs, owned by `sifr_package`. Keep inventoried until a package-aware snapshot owns directory membership, file kinds, and content identity; not a general tooling exception. |
 
 The SQLx offline preflight's current package-source, query-file, and metadata
 probes are inventoried in the driver row above. These are package
@@ -87,6 +113,8 @@ Permitted exceptions for the source-provider implementation:
 - CLI stdin reads are not workspace identity until later explicitly modeled.
 - Generated-output and test-harness reads under tests, verification, and
   generated artifact checks are outside the source-provider semantic scope.
+  This includes the specifically classified inline-test observations above,
+  which remain in the inventory scan; it does not exempt their containing files.
 - Codegen intrinsics that emit `std::fs::*` for user programs are not compiler
   service reads.
 - Build artifact cache metadata in `crates/sifr_driver/src/build/workspace.rs:223`,

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -2,6 +2,117 @@
 
 Status: active
 
+## Current orchestration: 12K blocked; bounded tooling owners (2026-09-06)
+
+This section supersedes older pending original12K review/gate statements, not
+their historical evidence. Arendt is closed after its [terminal receipt](https://github.com/sifr-lang/sifr/pull/3717#issuecomment-5561937700).
+Original12K is **approved, externally blocked, not merged**. Exact reviewed and
+gated candidate `56907f59cc7d9f9fedb89434970c074c0247dee9`, record
+`057dd2e2caf1f84306b370cee2c3be39918cbec3`, assessed main
+`f11e1cd7eef16a02063555bccc9fd8e19287833b`, corpus
+`8bcbe7ab7939e5c8362c10f61a80e368022cc372`. PR #3717 remains draft;
+corpus #48 remains unmerged. Preserved checkout:
+`/private/tmp/sifr-item12k-delivery.4J6JeK/sifr`, local branch
+`codex/item12k-final-delivery`; remote PR branch `codex/item12k-final-integration`.
+
+Its [integration review](https://github.com/sifr-lang/sifr/pull/3717#issuecomment-5561494295)
+is SATISFIED/no blockers across 202 changed paths. Counts consumed: one initial
+review, zero remediation, one provider request, zero retries, zero create-pr
+gates, **one failed merge gate**, zero Sifr/corpus merges. All handles completed.
+The 3736.19s gate passed all 13 guardrails and Rust10/readiness4/core5/CPython2/
+Python30 (all five suites)/diagnostics184/runtime30 (three explicit policy skips)/
+algorithmic12. Developer tooling failed three of 42 variants. Full E2E, migrated
+stdlib and normally ignored driver builds remain unreached, not certified.
+Actual main-ref materialization and manifest checks resolved #3721; its historical
+B5 gate stays failed. No allowance resets and no second original12K gate.
+
+Terminal ledger under that checkout:
+`target/verification/areas/item12k-delivery-terminal.json`, SHA256
+`bc8051b763ed7f43a54f524dad97686420681e3d8593f090659821f0c93a244b`.
+Final-evidence JSON SHA256 `edf9ce8c890b80af771ce8cd56ccedc143cb9e69d93d25e853d13d73bdb51d0a`
+authenticates 54 current and 104 retained artifacts; full provenance enumerates
+32088 tracked entries and 16 exact clean submodules. Gate log at sibling
+`evidence/merge.log`, SHA256 `336f5b1345f2495c7a197d81658f36ddfbcebf9c57b110675c5dc4b5c8f219b3`.
+Preserve all
+predecessor checkouts/targets; terminal own target23GiB/free67GiB.
+
+### Sequential later items and named validation
+
+Execution order: **12K-B7, 12K-B8, 12K-B9**, then adjudicate original12K delivery
+using their qualified receipts and the consumed-gate rule. No later emitted-code
+item becomes ready merely because these narrow checks pass. After valid 12K
+delivery, retain 12D,12E,12F,retained Item12,docs-only12A order. Parent only
+orchestrates; each new worker owns one fresh checkout/branch/index/temp root.
+
+- **12K-B7 / [#3722](https://github.com/sifr-lang/sifr/issues/3722)**: ready;
+  depends on the terminal12K diagnosis, not on unmerged integration delivery.
+  Restore the TypeScript-Go direct filesystem inventory for all 22 pre-existing
+  sites in six missing paths. Explicitly adjudicate inline-test inventory
+  boundaries; preserve meaningful source-provider ownership and enforcement.
+  Do not change compiler behavior or broadly suppress observations. Named tests:
+  `python3 verification/areas/developer_tooling/check_typescript_go_transfer_guardrails.py`
+  and the same command with `--self-test`; `git diff --check`;
+  `python3 scripts/check_file_size_guardrails.py`. Register any necessary focused
+  new regression command before execution. Expected scope is inventory Markdown
+  and, only if necessary, its owning checker/tests. Use current main for a narrow
+  independently deliverable PR; retain the integration checkout as read-only
+  provenance. One exact-SHA review plus at most one remediation. No Sifr gates
+  absent compiler/lockfile/fixture/workflow changes. Merge/update owner and stop.
+- **12K-B8 / [#3723](https://github.com/sifr-lang/sifr/issues/3723)**: recorded;
+  execution dependency B7 terminal/merged. Distinguish three legitimate SQL
+  dialect `bigint` spellings from removed Sifr scalar support. Preserve SQL names
+  and real compatibility rejection; no broad suppression. Named tests:
+  `python3 verification/areas/developer_tooling/check_no_pre_v1_compatibility.py`
+  and its `--self-test`, plus focused SQL-spelling versus removed-language-type
+  regressions registered before execution, diff and file-size checks. Narrow
+  guard owner; no unrelated SQL/compiler behavior changes.
+- **12K-B9 / [#3724](https://github.com/sifr-lang/sifr/issues/3724)**: recorded;
+  execution dependency B8 terminal/merged. Reconcile formatter preview reference
+  with actual supported behavior and existing capability/CLI manifests, including
+  all eight failed checks. Do not infer or introduce a formatter mechanism fix.
+  Named tests: `python3 verification/areas/developer_tooling/check_formatter_rules_manifests.py`
+  and its `--self-test`, diff and file-size checks. Expected documentation-only.
+
+12K-B7 dispatched to Aristotle (`01a07867-1267-7321-aecc-7afdf3864dc4`),
+fresh no-history gpt-6-astra high worker. Arendt is closed; one live implementer.
+Exact base prompt and separate onboarding supplied. No B7 review/gate consumed
+at dispatch; its narrow main-based delivery must not absorb original12K's stack.
+
+## Item 12K-B7: direct filesystem inventory restoration (2026-09-06)
+
+Owner: [#3722](https://github.com/sifr-lang/sifr/issues/3722). This section
+executes only B7 from the copied orchestration registration above; historic
+main records below are preserved. Latest remote main was fetched and verified
+as `f11e1cd7eef16a02063555bccc9fd8e19287833b` before implementation.
+
+Sole implementer owns clone `/private/tmp/sifr-item12k-b7.afEJYk/sifr`, branch
+`codex/item12k-b7-inventory`, its independent Git index, and sibling `evidence/`.
+Parent and predecessor checkouts remain read-only. No integration ancestry is
+required for this independent documentation correction.
+
+Implementation: restore all six missing paths and 22 matching source lines in
+`internal_docs/typescript_go_architecture_transfer_guardrails.md`, using exact
+main line references. Classify five inline-test lines separately from 17
+production lines, retain inline-test scanning and every existing exclusion,
+and distinguish CLI execution/sandbox effects, generated outputs, package/build
+identity inputs, and unresolved SQL editor provider/snapshot obligations.
+Path membership is the existing automated enforcement boundary; row ownership
+is not a blanket exemption. No checker mechanism change or new regression
+command is necessary.
+
+Named validation, after the implementation batch:
+
+- `python3 verification/areas/developer_tooling/check_typescript_go_transfer_guardrails.py`
+- `python3 verification/areas/developer_tooling/check_typescript_go_transfer_guardrails.py --self-test`
+- `git diff --check`
+- `python3 scripts/check_file_size_guardrails.py`
+
+Only inventory and phase Markdown change. Per the item and user rules, no
+create-pr or merge-profile gate is required. One initial exact-SHA Opus review
+and at most one remediation remain available before review; results will be
+published outside the reviewed tree, followed by the merged receipt here.
+B8, B9, original12K qualification, and later emitted-code work are not started.
+
 ## Item 12K-B2: canonical diagnostic reference identity (2026-09-06)
 
 Owner: [#3704](https://github.com/sifr-lang/sifr/issues/3704), OPEN at dispatch.


### PR DESCRIPTION
Restores the six missing filesystem inventory paths reported by #3722: 22 scanner lines, with 17 production lines and five inline-test observations. Records concrete ownership for host-tool execution and confinement, generated-output materialization, package/build identity, and SQL editor readiness; inline tests remain scanned and SQL editor provider obligations remain explicit.

Only the inventory and phase Markdown change. The checker, compiler, locks, fixtures, and workflows are unchanged. Current orchestration registration is copied into the independently owned phase record without removing historical main contents.

Validation on candidate `186365fb11abf7391db02d17c30a3c6d612d6658`: TypeScript-Go guard and `--self-test` PASS; `git diff --check` PASS; file-size guard PASS (3,756 files). Per the item/user rules, zero create-pr/merge gates. One exact-SHA Opus review SATISFIED, no blockers or remediation: https://github.com/sifr-lang/sifr/pull/3725#issuecomment-5561995836. Nonblocking future enforcement work is recorded in #3726 and not started.

Closes #3722. Does not qualify original12K or start B8/B9.
