### PR TITLE
12K-B8: distinguish SQL integer spellings in compatibility guard

### DIFF
--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -44,7 +44,7 @@ item becomes ready merely because these narrow checks pass. After valid 12K
 delivery, retain 12D,12E,12F,retained Item12,docs-only12A order. Parent only
 orchestrates; each new worker owns one fresh checkout/branch/index/temp root.
 
-- **12K-B7 / [#3722](https://github.com/sifr-lang/sifr/issues/3722)**: ready;
+- **12K-B7 / [#3722](https://github.com/sifr-lang/sifr/issues/3722)**: merged;
   depends on the terminal12K diagnosis, not on unmerged integration delivery.
   Restore the TypeScript-Go direct filesystem inventory for all 22 pre-existing
   sites in six missing paths. Explicitly adjudicate inline-test inventory
@@ -58,7 +58,7 @@ orchestrates; each new worker owns one fresh checkout/branch/index/temp root.
   independently deliverable PR; retain the integration checkout as read-only
   provenance. One exact-SHA review plus at most one remediation. No Sifr gates
   absent compiler/lockfile/fixture/workflow changes. Merge/update owner and stop.
-- **12K-B8 / [#3723](https://github.com/sifr-lang/sifr/issues/3723)**: recorded;
+- **12K-B8 / [#3723](https://github.com/sifr-lang/sifr/issues/3723)**: ready;
   execution dependency B7 terminal/merged. Distinguish three legitimate SQL
   dialect `bigint` spellings from removed Sifr scalar support. Preserve SQL names
   and real compatibility rejection; no broad suppression. Named tests:
@@ -73,10 +73,77 @@ orchestrates; each new worker owns one fresh checkout/branch/index/temp root.
   Named tests: `python3 verification/areas/developer_tooling/check_formatter_rules_manifests.py`
   and its `--self-test`, diff and file-size checks. Expected documentation-only.
 
-12K-B7 dispatched to Aristotle (`01a07867-1267-7321-aecc-7afdf3864dc4`),
-fresh no-history gpt-6-astra high worker. Arendt is closed; one live implementer.
-Exact base prompt and separate onboarding supplied. No B7 review/gate consumed
-at dispatch; its narrow main-based delivery must not absorb original12K's stack.
+12K-B7 Aristotle (`01a07867-1267-7321-aecc-7afdf3864dc4`) is closed after
+verified [PR3725 merge](https://github.com/sifr-lang/sifr/pull/3725), candidate
+`186365fb11abf7391db02d17c30a3c6d612d6658`, merge
+`4faa76803da67d22a2dfffdb81cc63bf16304fe0`. Four named checks pass, file-size3756;
+one SATISFIED initial review, zero remediation/retries/gates, one normal merge.
+Two Markdown paths only: transfer inventory and own phase record. All six paths
+and 22 scanner-line observations covered (17 production, five inline tests),
+without changing scanner behavior. Owner3722 is closed. [Review/evidence](https://github.com/sifr-lang/sifr/pull/3725#issuecomment-5561995836),
+[terminal handoff](https://github.com/sifr-lang/sifr/pull/3725#issuecomment-5562009279).
+Preserved clone `/private/tmp/sifr-item12k-b7.afEJYk/sifr`; post-merge record
+`daff4efbd00e5e922c1f2ce9a9eff686388a5da6` pushed on
+`codex/item12k-b7-inventory`, not merged to main. Next worker must carry this
+closure receipt into its own phase record so main does not retain stale status.
+Terminal manifest at sibling `evidence/terminal.json`, SHA256
+`f42226a2db1767794d9c68ca253235e88f92c732b95f6fd03e3245373ab80e09`.
+No live worker handles remain from B7. Original12K stack remains unmerged.
+
+12K-B8 dispatched to Copernicus (`01a07871-4fd6-7b02-a3be-b6f9cde8d518`),
+fresh no-history gpt-6-astra high, exact base prompt plus independent main-based
+onboarding. All predecessors closed; one live implementer. B8 starts with no
+review/provider/gate allowance consumed. B9 remains next.
+
+Later nonblocking tooling owner [#3726](https://github.com/sifr-lang/sifr/issues/3726)
+records existing path-only inventory enforcement and multiple calls per source
+line. It is not a new B7 defect, no per-site contract is inferred from line
+counts, and it does not change B8/B9 order or authorize integration requalification.
+
+These owners are authorized bounded dependency work. They must not repair the
+next owner, restart original12K qualification, merge its inherited stack, or
+conduct whole-phase review. Preserve completed and failed evidence accurately.
+
+## Item 12K-B8: SQL integer spelling guard boundary (2026-09-06)
+
+Owner: [#3723](https://github.com/sifr-lang/sifr/issues/3723). B7 is merged and
+its owner is closed, as recorded above. This section executes only B8; existing
+phase history below is preserved. Explicitly fetched `origin/main` and base:
+`4faa76803da67d22a2dfffdb81cc63bf16304fe0`.
+
+The sole implementer owns clone `/private/tmp/sifr-item12k-b8.TS6YQA/sifr`,
+branch `codex/item12k-b8-sql-compatibility`, independent Git index and sibling
+`evidence/`. Parent's two intentional Markdown edits and every predecessor
+checkout/target remain read-only. No original12K integration ancestry is imported.
+
+Implementation: recognize the three existing SQL database-integer mapping
+expressions in their exact owner paths, and exempt only each external spelling's
+matched literal span from `public-bigint`. Require the database representation,
+64-bit width, PostgreSQL aliases/signedness, and MySQL sign binding. Every other
+match (including on the same line) and every other guard rule remains enforced.
+Register the external SQL integer contract in the existing retained-contract
+registry. Preserve PostgreSQL/MySQL compiler sources and SQL behavior byte-for-byte.
+
+Named validation, registered before execution and run after implementation:
+
+- `python3 verification/areas/developer_tooling/check_no_pre_v1_compatibility.py`
+- `python3 verification/areas/developer_tooling/check_no_pre_v1_compatibility.py --self-test`
+- `python3 -m unittest discover -s verification/areas/developer_tooling -p test_no_pre_v1_compatibility.py -v`
+- `git diff --check`
+- `python3 scripts/check_file_size_guardrails.py`
+
+Focused regressions cover all three real source sites; whitespace and Unicode
+offsets; altered database types, widths, aliases and sign bindings; wrong owner
+paths; removed Sifr types, spellings and diagnostics across scan roots; same-line,
+nearby and intra-expression forbidden matches; other rules; and retained registry
+membership. Only the checker, its Python tests, retained-contract registry and
+this phase record change. No compiler, lockfile, fixture or workflow changes:
+zero create-pr or merge-profile gates per user instruction.
+
+One exact-candidate Opus review is allowed, plus at most one remediation.
+Review evidence stays outside the reviewed tree and is published keyed by SHA.
+After the independent main merge, update this record and owner, publish the
+terminal receipt, and stop. B9 and original12K requalification are not started.
 
 ## Item 12K-B7: direct filesystem inventory restoration (2026-09-06)
 

--- a/verification/areas/developer_tooling/check_no_pre_v1_compatibility.py
+++ b/verification/areas/developer_tooling/check_no_pre_v1_compatibility.py
@@ -59,6 +59,7 @@ REQUIRED_CONTRACT_IDS = {
     "retained-external-file-formats",
     "retained-release-bootstrap-legacy-index",
     "retained-lint-deprecated-status",
+    "retained-sql-integer-spellings",
 }
 ALLOWED_CONTRACT_KINDS = {
     "external-dependency",
@@ -87,6 +88,47 @@ class Rule:
 
 def words_pattern(words: tuple[str, ...]) -> re.Pattern[str]:
     return re.compile(r"\b(?:" + "|".join(re.escape(word) for word in words) + r")\b")
+
+
+# These are external SQL contracts, not public Sifr scalar registrations.
+# Recognize the complete database mapping, then exempt only its literal span.
+# A path alone, a nearby SQL name, or another match on the same line grants
+# no exemption. Unrecognized/changed expressions fail closed for owner review.
+SQL_INTEGER_SPELLINGS = {
+    "crates/sifr_sql_postgresql/src/types.rs": re.compile(
+        r'\(\s*&\[\s*"int8"\s*,\s*(?P<spelling>"bigint")\s*,\s*'
+        r'"pg_catalog\.int8"\s*\]\s*,\s*DatabaseType::Integer\s*\{\s*'
+        r'sign:\s*IntegerSign::Signed\s*,\s*'
+        r'width:\s*IntegerWidth::Bits64\s*,?\s*\}\s*,?\s*\)'
+    ),
+    "crates/sifr_sql_mysql/src/types.rs": re.compile(
+        r'(?P<spelling>"bigint")\s*=>\s*DatabaseType::Integer\s*\{\s*'
+        r'sign\s*,\s*width:\s*IntegerWidth::Bits64\s*,?\s*\}\s*,'
+    ),
+    "crates/sifr_sql_postgresql/tests/postgresql_regressions.rs": re.compile(
+        r'\bDatabaseType::Integer\s*\{\s*'
+        r'width:\s*sifr_sql_contract::IntegerWidth::Bits64\s*,\s*'
+        r'\.\.\s*\}\s*=>\s*(?P<spelling>"bigint")\s*,'
+    ),
+}
+
+
+def sql_integer_spelling_spans(source: str, relative: str) -> set[tuple[int, int]]:
+    pattern = SQL_INTEGER_SPELLINGS.get(relative)
+    if pattern is None:
+        return set()
+    return {match.span("spelling") for match in pattern.finditer(source)}
+
+
+def rule_matches(
+    rule: Rule, line: str, offset: int, sql_spans: set[tuple[int, int]]
+) -> bool:
+    for pattern in rule.patterns:
+        for match in pattern.finditer(line):
+            span = (offset + match.start(), offset + match.end())
+            if rule.rule_id != "public-bigint" or span not in sql_spans:
+                return True
+    return False
 
 
 PUBLIC_STDLIB_ALIASES = (
@@ -362,19 +404,23 @@ def scan(root: Path) -> list[Failure]:
                 if should_skip(relative):
                     continue
                 try:
-                    lines = path.read_text(encoding="utf-8").splitlines()
+                    source = path.read_text(encoding="utf-8")
                 except UnicodeDecodeError:
                     continue
                 relative_text = relative.as_posix()
+                sql_spans = sql_integer_spelling_spans(source, relative_text)
                 if re.search(joined("SIFR-WORKSPACE-", "010") + r"[1-4]", filename):
                     failures.append(Failure("workspace-diagnostic-codes", relative, 1, "legacy workspace diagnostic code filename"))
-                for line_number, line in enumerate(lines, 1):
+                offset = 0
+                for line_number, raw_line in enumerate(source.splitlines(keepends=True), 1):
+                    line = raw_line.rstrip("\r\n")
                     alias = public_stdlib_alias(line, relative_text)
                     if alias is not None:
                         failures.append(Failure("public-stdlib-aliases", relative, line_number, f"public alias {alias}"))
                     for rule in RULES:
-                        if rule.applies_to(relative_text) and any(pattern.search(line) for pattern in rule.patterns):
+                        if rule.applies_to(relative_text) and rule_matches(rule, line, offset, sql_spans):
                             failures.append(Failure(rule.rule_id, relative, line_number, rule.description))
+                    offset += len(raw_line)
     return failures
 
 

--- a/verification/areas/developer_tooling/test_no_pre_v1_compatibility.py
+++ b/verification/areas/developer_tooling/test_no_pre_v1_compatibility.py
@@ -1,0 +1,175 @@
+"""SQL spelling versus removed Sifr scalar regressions for the compatibility guard."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_no_pre_v1_compatibility as guard
+
+
+BIGINT = guard.joined("big", "int")
+PG_PATH = "crates/sifr_sql_postgresql/src/types.rs"
+MYSQL_PATH = "crates/sifr_sql_mysql/src/types.rs"
+PG_TEST_PATH = "crates/sifr_sql_postgresql/tests/postgresql_regressions.rs"
+SQL_EXPRESSIONS = {
+    PG_PATH: '''(
+        &["int8", "BIGINT", "pg_catalog.int8"],
+        DatabaseType::Integer {
+            sign: IntegerSign::Signed,
+            width: IntegerWidth::Bits64,
+        },
+    )'''.replace("BIGINT", BIGINT),
+    MYSQL_PATH: '''"BIGINT" => DatabaseType::Integer {
+        sign,
+        width: IntegerWidth::Bits64,
+    },'''.replace("BIGINT", BIGINT),
+    PG_TEST_PATH: '''DatabaseType::Integer {
+        width: sifr_sql_contract::IntegerWidth::Bits64,
+        ..
+    } => "BIGINT",'''.replace("BIGINT", BIGINT),
+}
+REMOVED_SURFACES = (
+    f'let public_name = "{BIGINT}";',
+    f"let public_name = '{BIGINT}';",
+    guard.joined("Type::Big", "Int"),
+    guard.joined("KnownType::Big", "Int"),
+    guard.joined("SIFR-INT-", "0011"),
+    guard.joined("SIFR-TYPE-", "0006"),
+)
+
+
+class SqlIntegerSpellingTests(unittest.TestCase):
+    def scan_source(self, relative: str, source: str) -> list[guard.Failure]:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            path = root / relative
+            path.parent.mkdir(parents=True)
+            path.write_text(source, encoding="utf-8")
+            return guard.scan(root)
+
+    def assert_public_failure(self, relative: str, source: str) -> None:
+        failures = self.scan_source(relative, source)
+        self.assertTrue(failures, (relative, source))
+        self.assertEqual({failure.rule_id for failure in failures}, {"public-bigint"})
+        self.assertEqual({failure.path for failure in failures}, {Path(relative)})
+
+    def test_three_external_sql_mappings_are_accepted(self) -> None:
+        for relative, source in SQL_EXPRESSIONS.items():
+            with self.subTest(path=relative):
+                self.assertEqual(self.scan_source(relative, source), [])
+
+    def test_real_repository_sites_match_exactly_one_literal_each(self) -> None:
+        for relative in SQL_EXPRESSIONS:
+            with self.subTest(path=relative):
+                source = (guard.REPO_ROOT / relative).read_text(encoding="utf-8")
+                spans = guard.sql_integer_spelling_spans(source, relative)
+                self.assertEqual(len(spans), 1)
+                self.assertEqual({source[start:end] for start, end in spans}, {f'"{BIGINT}"'})
+                self.assertEqual(self.scan_source(relative, source), [])
+
+    def test_whitespace_line_endings_and_unicode_offsets(self) -> None:
+        for relative, original in SQL_EXPRESSIONS.items():
+            for separator in (" ", "\n", "\r\n", "\t"):
+                source = "// π database spelling\n\n" + separator.join(original.split())
+                with self.subTest(path=relative, separator=repr(separator)):
+                    self.assertEqual(self.scan_source(relative, source), [])
+
+    def test_database_shape_and_width_are_required(self) -> None:
+        for relative, source in SQL_EXPRESSIONS.items():
+            for old, new in (
+                ("Bits64", "Bits32"),
+                ("DatabaseType::Integer", "Type::Integer"),
+                ("DatabaseType::Integer", "OtherDatabaseType::Integer"),
+            ):
+                with self.subTest(path=relative, mutation=(old, new)):
+                    self.assert_public_failure(relative, source.replace(old, new))
+
+    def test_postgres_aliases_and_signedness_are_required(self) -> None:
+        source = SQL_EXPRESSIONS[PG_PATH]
+        for old, new in (
+            ('"int8"', '"int4"'),
+            ('"pg_catalog.int8"', '"pg_catalog.int4"'),
+            ("IntegerSign::Signed", "IntegerSign::Unsigned"),
+        ):
+            with self.subTest(mutation=(old, new)):
+                self.assert_public_failure(PG_PATH, source.replace(old, new))
+
+    def test_mysql_sign_binding_is_preserved(self) -> None:
+        source = SQL_EXPRESSIONS[MYSQL_PATH]
+        for sign in ("IntegerSign::Signed", "IntegerSign::Unsigned", "Type::Integer"):
+            with self.subTest(sign=sign):
+                self.assert_public_failure(MYSQL_PATH, source.replace("sign,", f"sign: {sign},"))
+
+    def test_sql_paths_are_not_blanket_exemptions(self) -> None:
+        for relative in SQL_EXPRESSIONS:
+            for surface in REMOVED_SURFACES:
+                with self.subTest(path=relative, surface=surface):
+                    self.assert_public_failure(relative, surface)
+
+    def test_removed_language_support_still_fails_across_scan_roots(self) -> None:
+        for relative in (
+            "crates/compiler/src/types.rs", "stdlib/sifr/numeric.sifr",
+            "demos/scalar/main.sifr", "verification/scalar_check.py",
+        ):
+            for surface in REMOVED_SURFACES:
+                with self.subTest(path=relative, surface=surface):
+                    self.assert_public_failure(relative, surface)
+
+    def test_sql_shapes_in_other_paths_are_not_exempt(self) -> None:
+        for owner, source in SQL_EXPRESSIONS.items():
+            for relative in (
+                "crates/compiler/src/types.rs", owner + ".rs",
+                "stdlib/sifr/sql.sifr", "verification/sql.py",
+                *[path for path in SQL_EXPRESSIONS if path != owner],
+            ):
+                with self.subTest(owner=owner, path=relative):
+                    self.assert_public_failure(relative, source)
+
+    def test_multiple_matches_on_same_line_remain_rejected(self) -> None:
+        for relative, expression in SQL_EXPRESSIONS.items():
+            compact = " ".join(expression.split())
+            for surface in REMOVED_SURFACES:
+                for source in (surface + " " + compact, compact + " " + surface):
+                    with self.subTest(path=relative, source=source):
+                        failures = self.scan_source(relative, source)
+                        self.assertEqual([(f.rule_id, f.line) for f in failures], [("public-bigint", 1)])
+
+    def test_nearby_lines_remain_rejected_with_exact_locations(self) -> None:
+        for relative, expression in SQL_EXPRESSIONS.items():
+            source = REMOVED_SURFACES[0] + "\n" + expression + "\n" + REMOVED_SURFACES[1]
+            with self.subTest(path=relative):
+                failures = self.scan_source(relative, source)
+                self.assertEqual(
+                    [(f.rule_id, f.line) for f in failures],
+                    [("public-bigint", 1), ("public-bigint", len(source.splitlines()))],
+                )
+
+    def test_extra_literal_inside_mapping_is_not_exempt(self) -> None:
+        for relative, expression in SQL_EXPRESSIONS.items():
+            with self.subTest(path=relative):
+                self.assert_public_failure(
+                    relative, expression.replace("Bits64", f'Bits64 /* "{BIGINT}" */')
+                )
+
+    def test_other_rules_apply_beside_sql_mapping(self) -> None:
+        hidden = guard.joined("__compat_", "sifr_scalar")
+        for relative, expression in SQL_EXPRESSIONS.items():
+            with self.subTest(path=relative):
+                source = " ".join(expression.split()) + " " + hidden
+                failures = self.scan_source(relative, source)
+                self.assertEqual([(f.rule_id, f.line) for f in failures], [("hidden-compat-names", 1)])
+
+    def test_retained_contract_is_mandatory(self) -> None:
+        payload = json.loads(guard.CONTRACTS_PATH.read_text(encoding="utf-8"))
+        payload["contracts"] = [
+            row for row in payload["contracts"] if row["id"] != "retained-sql-integer-spellings"
+        ]
+        with self.assertRaises(guard.ContractError):
+            guard.validate_contracts(payload, guard.REPO_ROOT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verification/compatibility/retained_compatibility_contracts.json
+++ b/verification/compatibility/retained_compatibility_contracts.json
@@ -86,6 +86,13 @@
       "evidence": ["scripts/distribution/materialize_schema_bootstrap_evidence.py", "verification/areas/distribution_release/governance/schema_bootstrap.py", "plans/phases/40_stable_channel_ga_promotion_and_release_governance.md"]
     },
     {
+      "id": "retained-sql-integer-spellings",
+      "kind": "external-format",
+      "owner": "contract:sql-dialect-integer-types",
+      "contract": "PostgreSQL bigint/int8/pg_catalog.int8 spellings denote signed 64-bit DatabaseType integers; MySQL bigint retains signed or unsigned 64-bit DatabaseType integers; PostgreSQL regression output names 64-bit database integers bigint. These external SQL mappings do not restore a public Sifr scalar.",
+      "evidence": ["crates/sifr_sql_postgresql/src/types.rs", "crates/sifr_sql_mysql/src/types.rs", "crates/sifr_sql_postgresql/tests/postgresql_regressions.rs", "verification/areas/developer_tooling/test_no_pre_v1_compatibility.py"]
+    },
+    {
       "id": "retained-lint-deprecated-status",
       "kind": "current-product",
       "owner": "contract:lint-rule-lifecycle",


### PR DESCRIPTION
The compatibility guard rejected three existing PostgreSQL/MySQL `bigint` spellings as removed Sifr scalar support. Recognize only the literal spans in their owned 64-bit `DatabaseType` mappings, retaining every other match and rule, including forbidden matches on the same line. SQL/compiler behavior is unchanged.

Register the external SQL contract, add 14 focused positive/negative regression tests, and carry B7's merged closure receipt into the phase record. This PR closes only 12K-B8; it does not requalify or merge original12K or start B9.

Validation on candidate `4eb6426f81db75a8b562cfc0572f26027c37159c`, base `4faa76803da67d22a2dfffdb81cc63bf16304fe0`:

- Compatibility guard and `--self-test`: PASS.
- `python3 -m unittest discover -s verification/areas/developer_tooling -p test_no_pre_v1_compatibility.py -v`: 14 tests PASS.
- Diff check: PASS; file-size guard: PASS (3757 files).
- Zero create-pr/merge gates: only checker, Python tests, retained-contract registry and phase documentation changed.

Exact-SHA Opus review: SATISFIED, no blockers. One initial review, zero remediation/retries. [Complete review and validation receipt](https://github.com/sifr-lang/sifr/pull/3727#issuecomment-5562074224) is published outside the reviewed tree. Optional design observations are recorded separately in #3728 and are not delivery dependencies.

Closes #3723.
