### PR TITLE
Prepare exact-revision generated Cargo graphs before offline qualification

### DIFF
--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -49,7 +49,7 @@ Execution order: **12K-B10, 12K-B11**, then an explicit delivery authorization
 checkpoint. After valid12K delivery, retain 12D,12E,12F,retained Item12,docs-only12A.
 One live implementer; parent does not implement, test, review or run Sifr gates.
 
-- **12K-B10 / [#3731](https://github.com/sifr-lang/sifr/issues/3731)**: in progress;
+- **12K-B10 / [#3731](https://github.com/sifr-lang/sifr/issues/3731)**: merged;
   depends on terminal original12K evidence, not unmerged integration delivery.
   Reconcile ERQ-032's stale current-source semantic anchor with its actual owning
   implementation, preserving audit disposition and meaningful stale-anchor
@@ -64,7 +64,7 @@ One live implementer; parent does not implement, test, review or run Sifr gates.
   checker/tests only if necessary for this bounded mechanism. One exact-SHA
   Opus review plus at most one remediation. No Sifr gates absent compiler,
   lockfile, fixture or workflow changes. Merge and update owner/phase, then stop.
-- **12K-B11 / [#3732](https://github.com/sifr-lang/sifr/issues/3732)**: queued;
+- **12K-B11 / [#3732](https://github.com/sifr-lang/sifr/issues/3732)**: in progress;
   execution dependency B10 merged/terminal. Diagnose and fully correct preparation
   of the actual exact-revision generated Cargo dependency graph before enforced
   offline qualification. Workspace locked fetch alone did not populate the
@@ -76,6 +76,89 @@ One live implementer; parent does not implement, test, review or run Sifr gates.
   before executing them, plus diff/file-size checks. Do not rerun original12K's
   gate or reset its reviews. Read issue3732 and preserved terminal evidence before
   selecting this owner's exact implementation/validation paths.
+
+12K-B10 Lagrange (`01a078e3-a9cc-7da0-8cc4-9b76af3a6760`) is closed after
+verified [PR3733 merge](https://github.com/sifr-lang/sifr/pull/3733), candidate
+`4147d9235462178e870342abf2a390ac5ab3f890`, basefc9dbf047, normal main merge
+`66363d81c8bc5256988b4cfea5d3b95b65c5caa2`. Owner3731 CLOSED. All four named
+checks pass (33 findings/29 actionable/4 rejected; file-size3757). Two missing
+submodule setup failures retained; only affected inventory commands reran after
+materializing existing pinned corpus `ad116aa8dcae51b7db1bdf0052470456d671d31b`.
+One initial SATISFIED review, zero remediation/retry/gates, one provider request,
+one normal merge. Two paths only: ERQ-032 audit JSON and phase Markdown.
+[Review/validation](https://github.com/sifr-lang/sifr/pull/3733#issuecomment-5562746452),
+[terminal receipt](https://github.com/sifr-lang/sifr/pull/3733#issuecomment-5562761993).
+Preserved clean clone `/private/tmp/sifr-item12k-b10.LrJOME/sifr`, post-merge record
+`fb92a15cea2b3e3cbe3c1b3826caecc9557feea2` pushed on
+`codex/item12k-b10-audit-anchor`, not main; next worker carries closure receipt.
+Sibling `evidence/terminal.json` SHA256
+`42daa70ed47efb8802b91353fdb88bed08c74ca49843b9245617126bf765b007`;
+candidate validation SHA256
+`6f1213d6174b2d165977f3fe795ed8bcbe2d3d474ac94bfdfc21388aa1b39c5e`;
+review SHA256 `7299f770a512c7a2c3f8b848fd24cbf764523c4b643afa620c090f9a0a003a81`.
+No live handles. Optional title/anchor-maintenance suggestions are later3734,
+not an established new mechanism defect or automatic delivery dependency.
+
+B11 named runner validation additionally includes the documented
+`uv run --project verification python -m sifr_verify --self-test`,
+`git diff --check`, and `python3 scripts/check_file_size_guardrails.py`.
+Register exact focused clean-cache positive/negative commands after read-only
+diagnosis and before execution. Exercise production preparation before enforced
+offline materialization of the actual exact-revision generated graph, including
+runtime and stdlib demand and relevant corpus/positive-Clippy/demo entry modes;
+do not substitute manual cache prewarming for that production path. Preserve
+workspace setup, immutable revision identity, lock enforcement, offline execution
+and fail-closed preparation. Candidate must be pushed if remote exact-revision
+resolution requires it. No parent implementation or original12K gate is authorized.
+
+### 12K-B11 implementation and focused validation registration (2026-09-07)
+
+Owned clone `/private/tmp/sifr-item12k-b11.sasFlU/sifr`, branch
+`codex/item12k-b11-offline-preparation`, base
+`66363d81c8bc5256988b4cfea5d3b95b65c5caa2`. Actual main was fetched with
+`+refs/heads/main:refs/remotes/origin/main`. Parent and predecessor trees,
+indexes, caches and records are read-only.
+
+Diagnosis: the root lock resolves workspace path packages, whereas actual
+portable generated manifests and locks identify runtime/stdlib by self-Git
+URL plus exact SHA. Root-only fetch cannot populate that separate source.
+The profile prelude now builds/materializes after workspace preparation,
+fetches each complete positive-manifest graph with `--locked`, rejects stale
+revision/local-source graphs, and verifies immutable manifest/lock bytes.
+Execution uses a revision-scoped materialization root and remains offline;
+corpus/demo Cargo check and positive Clippy explicitly enforce `--locked`.
+Full/companion selections also prepare their authoritative companion graphs.
+No compiler, tracked lockfile, fixture, workflow or manifest changes.
+
+Exact commands registered BEFORE test execution:
+
+- `uv run --project verification python -m sifr_verify.generated_cargo_setup_checks policy`
+- `uv run --project verification python -m sifr_verify --self-test`
+- `uv run --project verification python -m sifr_verify.generated_cargo_setup_checks clean-cache`
+- `git diff --check`
+- `python3 scripts/check_file_size_guardrails.py`
+
+The clean-cache command creates a new owned empty Cargo home, invokes the
+production profile preparation, then performs locked/offline Cargo metadata
+resolution for every actual prepared generated graph. It re-enters the shared
+materialization path used by corpus, positive Clippy and demos, requires both
+runtime and stdlib dependency demand, and verifies rejection with a second
+empty offline cache and with changed generated requirements under locked fetch.
+This certifies graph preparation/resolution, not compiler lint or whole-suite
+semantic outcomes. Policy tests cover prelude ordering, failure before offline
+activation, complete positive/companion selection, exact SHA namespace,
+stale/local identities, missing locks and lock mutation rejection.
+
+Execution environment: `CARGO_TARGET_DIR` unset, `CARGO_BUILD_JOBS=6`,
+`RUST_TEST_THREADS=1`; owned `TMPDIR`, `UV_CACHE_DIR`, and
+`PYTHONPYCACHEPREFIX` under the sibling owner root. Use
+`CARGO_PROFILE_DEV_DEBUG=0` and `CARGO_PROFILE_DEV_INCREMENTAL=false` to bound
+this fresh clone's build storage. No cold-cache performance claim.
+Candidate publication precedes remote exact-SHA checks. Raw logs and Opus
+response remain in sibling evidence; canonical JSON under own
+`target/verification/areas`. One initial Opus plus at most one remediation;
+no Sifr gates for these runner/helper/record-only categories. Original12K's
+consumed reviews and gates remain unchanged.
 
 ### Retained B9 terminal receipt (historical)
 

--- a/verification/areas/generated_code_quality/generated_code_quality.py
+++ b/verification/areas/generated_code_quality/generated_code_quality.py
@@ -476,7 +476,7 @@ def gate_corpus(entries: list[Entry], args: argparse.Namespace) -> None:
         for entry in selected_positive_entries(entries, args.group):
             def check_entry() -> Path:
                 crate_root_inner = materialize_entry(entry, run_root)
-                run_command(["cargo", "check", "--manifest-path", str(crate_root_inner / "Cargo.toml")])
+                run_command(["cargo", "check", "--locked", "--manifest-path", str(crate_root_inner / "Cargo.toml")])
                 return crate_root_inner
 
             crate_root = timed_case("generated_code_quality", f"corpus/{entry.id}", check_entry)

--- a/verification/areas/generated_code_quality/source_quality_checks.py
+++ b/verification/areas/generated_code_quality/source_quality_checks.py
@@ -163,6 +163,7 @@ def run_strict_clippy(
             "--message-format=json",
             "--manifest-path",
             str(manifest),
+            "--locked",
             "--",
             *strict_clippy_args,
         ],

--- a/verification/runner/sifr_verify/cargo_setup.py
+++ b/verification/runner/sifr_verify/cargo_setup.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import os
 import shlex
+import subprocess
+import sys
 from typing import Any, Callable
+
+from .paths import REPO_ROOT
 
 CANONICAL_SETUP_COMMAND = "cargo fetch --locked"
 
@@ -30,12 +34,25 @@ def prepare_cargo_cache(
     env: dict[str, str],
     command_runner: Callable[..., None],
 ) -> None:
-    """Populate the exact lock graph before profile execution becomes offline."""
+    """Populate workspace and generated lock graphs before offline execution."""
     command = cargo_setup_command(profile)
     setup_env = env.copy()
     setup_env.pop("CARGO_NET_OFFLINE", None)
     print(f"[sifr-profile-setup] command={' '.join(command)}")
     command_runner(command, env=setup_env)
+    if any(area["area"] == "generated_code_quality" for area in profile.get("selected_areas", [])):
+        revision = subprocess.check_output(
+            ["git", "rev-parse", "--verify", "HEAD^{commit}"], cwd=REPO_ROOT, text=True
+        ).strip()
+        # A source-identical later commit still names a different Cargo Git source.
+        shared_root = REPO_ROOT / "target" / "sifr_generated_code_quality" / f"{profile['name']}.{revision}.shared"
+        env["SIFR_GCQ_SHARED_ROOT"] = str(shared_root)
+        setup_env["SIFR_GCQ_SHARED_ROOT"] = str(shared_root)
+        command_runner(
+            [sys.executable, "-m", "sifr_verify.generated_cargo_setup",
+             "--profile", str(profile["name"]), "--revision", revision],
+            env=setup_env,
+        )
 
 
 def enable_offline_cargo(env: dict[str, str]) -> None:

--- a/verification/runner/sifr_verify/generated_cargo_setup.py
+++ b/verification/runner/sifr_verify/generated_cargo_setup.py
@@ -1,0 +1,111 @@
+"""Prepare real portable generated Cargo graphs during the online profile prelude."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+from .paths import REPO_ROOT
+from .profile_commands import run_command
+from .profiles import load_profile
+
+GIT_SOURCE = "https://github.com/sifr-lang/sifr.git"
+
+
+def quality_module():
+    sys.path.insert(0, str(REPO_ROOT / "verification" / "areas" / "generated_code_quality"))
+    import generated_code_quality
+
+    return generated_code_quality
+
+
+def preparation_entries(quality, suites: list[str]):
+    # Preparation covers the complete positive manifest, independently of the
+    # execution adapter's smoke/representative limits or inherited CLI filters.
+    entries = [entry for entry in quality.load_manifest(quality.MANIFEST)
+               if entry.group in quality.POSITIVE_GROUPS]
+    if "full" in suites or "companions" in suites:
+        entries.extend(entry for _, entry in quality.authoritative_companion_entries())
+    return list({entry.id: entry for entry in entries}.values())
+
+
+def portable_graph(crate_root: Path, revision: str) -> dict[str, str]:
+    """Reject stale/local graphs before Cargo can use them or change a lock."""
+    if re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+        raise ValueError("generated Cargo preparation requires an exact Git revision")
+    manifest_path = crate_root / "Cargo.toml"
+    lock_path = crate_root / "Cargo.lock"
+    manifest = tomllib.loads(manifest_path.read_text())
+    lock = tomllib.loads(lock_path.read_text())
+    if manifest.get("patch") or manifest.get("replace"):
+        raise ValueError(f"{manifest_path}: portable graph must not override sources")
+    sections = [manifest, *manifest.get("target", {}).values()]
+    for section in sections:
+        for kind in ("dependencies", "dev-dependencies", "build-dependencies"):
+            for name, spec in section.get(kind, {}).items():
+                if not isinstance(spec, dict):
+                    continue
+                if "path" in spec:
+                    raise ValueError(f"{manifest_path}: local dependency {name}")
+                if spec.get("git") == GIT_SOURCE and spec.get("rev") != revision:
+                    raise ValueError(f"{manifest_path}: stale Sifr revision for {name}")
+    expected_source = f"git+{GIT_SOURCE}?rev={revision}#{revision}"
+    for package in lock.get("package", []):
+        if package["name"] in {"sifr_runtime", "sifr_stdlib"}:
+            if package.get("source") != expected_source:
+                raise ValueError(f"{lock_path}: nonportable or stale {package['name']}")
+    return {name: hashlib.sha256((crate_root / name).read_bytes()).hexdigest()
+            for name in ("Cargo.toml", "Cargo.lock")}
+
+
+def fetch_generated_graph(crate_root: Path, revision: str, command_runner=run_command):
+    before = portable_graph(crate_root, revision)
+    command_runner(["cargo", "fetch", "--locked", "--manifest-path", str(crate_root / "Cargo.toml")],
+                   env=os.environ.copy())
+    if portable_graph(crate_root, revision) != before:
+        raise ValueError(f"{crate_root}: preparation changed the generated manifest or lock")
+    return before
+
+
+def prepare_generated_graphs(profile: dict, revision: str) -> dict:
+    if os.environ.get("CARGO_NET_OFFLINE", "").lower() in {"true", "1"}:
+        raise ValueError("generated Cargo preparation must precede offline execution")
+    quality = quality_module()
+    suites = [suite for area in profile["selected_areas"] if area["area"] == "generated_code_quality"
+              for suite in area["suites"]]
+    # This build uses the outer workspace target; generated commands retain
+    # their existing separate target through SIFR_GCQ_SHARED_ROOT.
+    run_command(["cargo", "build", "--locked", "-p", "sifr"], env=os.environ.copy())
+    shared_root = quality.shared_artifact_root()
+    if shared_root is None:
+        raise ValueError("generated Cargo preparation requires its profile-owned artifact root")
+    records = []
+    for entry in preparation_entries(quality, suites):
+        crate_root = quality.materialize_entry(entry, shared_root / "preparation")
+        hashes = fetch_generated_graph(crate_root, revision)
+        records.append({"id": entry.id, "group": entry.group,
+                        "crate_root": str(crate_root.relative_to(REPO_ROOT)), **hashes})
+        print(f"[sifr-profile-setup] generated={entry.id} revision={revision} status=pass", flush=True)
+    report = {"revision": revision, "profile": profile["name"], "entries": records}
+    path = REPO_ROOT / "target" / "verification" / "areas" / f"generated-cargo-setup-{profile['name']}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2) + "\n")
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--revision", required=True)
+    args = parser.parse_args()
+    prepare_generated_graphs(load_profile(args.profile), args.revision)
+
+
+if __name__ == "__main__":
+    main()

--- a/verification/runner/sifr_verify/generated_cargo_setup_checks.py
+++ b/verification/runner/sifr_verify/generated_cargo_setup_checks.py
@@ -1,0 +1,240 @@
+"""Focused policy and clean-cache qualification of generated Cargo preparation."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from .cargo_setup import enable_offline_cargo, prepare_cargo_cache
+from .generated_cargo_setup import (
+    GIT_SOURCE, fetch_generated_graph, portable_graph, preparation_entries, quality_module,
+)
+from .paths import REPO_ROOT
+from .profile_commands import CommandFailed, run_command
+from .profile_runner import ProfileRunner
+from .profiles import load_profile
+
+REVISION = "a" * 40
+
+
+class SetupPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.manifest = self.root / "Cargo.toml"
+        self.lock = self.root / "Cargo.lock"
+        self.manifest.write_text(
+            '[package]\nname = "probe"\nversion = "0.1.0"\n[dependencies]\n'
+            f'sifr_runtime = {{ git = "{GIT_SOURCE}", rev = "{REVISION}" }}\n'
+        )
+        self.lock.write_text(
+            'version = 4\n[[package]]\nname = "sifr_runtime"\nversion = "0.0.0"\n'
+            f'source = "git+{GIT_SOURCE}?rev={REVISION}#{REVISION}"\n'
+        )
+
+    def test_profile_order_environment_and_exact_source_namespace(self):
+        env = {"CARGO_NET_OFFLINE": "true", "CARGO_HOME": "/owned/cache"}
+        commands = []
+        with patch("sifr_verify.cargo_setup.subprocess.check_output", return_value=REVISION):
+            prepare_cargo_cache(load_profile("merge"), env,
+                                lambda args, **kw: commands.append((args, kw["env"])))
+        self.assertEqual(commands[0][0], ["cargo", "fetch", "--locked"])
+        self.assertIn("sifr_verify.generated_cargo_setup", commands[1][0])
+        self.assertEqual(commands[1][0][-1], REVISION)
+        for _, setup_env in commands:
+            self.assertNotIn("CARGO_NET_OFFLINE", setup_env)
+            self.assertEqual(setup_env["CARGO_HOME"], "/owned/cache")
+        self.assertIn(REVISION, env["SIFR_GCQ_SHARED_ROOT"])
+        self.assertEqual(env["CARGO_NET_OFFLINE"], "true")
+
+    def test_workspace_failure_does_not_prepare_generated_graphs(self):
+        calls = []
+        def fail(args, **kw):
+            calls.append(args)
+            raise CommandFailed(101)
+        with self.assertRaises(CommandFailed):
+            prepare_cargo_cache(load_profile("merge"), {}, fail)
+        self.assertEqual(len(calls), 1)
+
+    def test_setup_failure_prevents_offline_switch_and_execution(self):
+        with patch.dict(os.environ, {}, clear=True):
+            runner = ProfileRunner("merge", [])
+            with patch.object(runner, "prepare_step_budget", return_value=None), \
+                 patch.object(runner, "prepare_cargo_cache", side_effect=CommandFailed(101)), \
+                 patch.object(runner, "run_guardrail") as guard, \
+                 patch("sifr_verify.profile_runner.enable_profile_offline_cargo") as offline:
+                self.assertEqual(runner.run(), 101)
+                offline.assert_not_called()
+                guard.assert_not_called()
+
+    def test_constructor_does_not_build_before_preparation(self):
+        with patch("sifr_verify.profile_runner.resolve_sifr_binary") as resolve:
+            ProfileRunner("merge", [])
+            resolve.assert_not_called()
+
+    def test_complete_positive_selection_ignores_execution_filters(self):
+        quality = quality_module()
+        with patch.dict(os.environ, {"SIFR_GCQ_MAX_ENTRIES": "1", "SIFR_GCQ_ENTRY_IDS": "missing"}):
+            selected = preparation_entries(quality, ["representative"])
+        expected = [entry for entry in quality.load_manifest(quality.MANIFEST)
+                    if entry.group in quality.POSITIVE_GROUPS]
+        self.assertEqual(selected, expected)
+        self.assertGreater(len(selected), 12)
+        self.assertIn("demos-required", {entry.group for entry in selected})
+
+    def test_full_selection_includes_companions(self):
+        quality = quality_module()
+        extra = quality.Entry("extra", "companions", "extra.sifr", "build", "test")
+        with patch.object(quality, "authoritative_companion_entries", return_value=[(None, extra)]):
+            self.assertIn(extra, preparation_entries(quality, ["full"]))
+            self.assertIn(extra, preparation_entries(quality, ["companions"]))
+
+    def test_locked_fetch_preserves_graph(self):
+        commands = []
+        before = portable_graph(self.root, REVISION)
+        actual = fetch_generated_graph(self.root, REVISION,
+                                       lambda args, **kw: commands.append(args))
+        self.assertEqual(actual, before)
+        self.assertEqual(commands, [["cargo", "fetch", "--locked", "--manifest-path", str(self.manifest)]])
+
+    def test_local_dependency_rejected_before_fetch(self):
+        self.manifest.write_text(self.manifest.read_text() + 'other = { path = "/tmp/local" }\n')
+        with self.assertRaisesRegex(ValueError, "local dependency"):
+            fetch_generated_graph(self.root, REVISION, lambda *a, **k: self.fail("fetch ran"))
+
+    def test_stale_manifest_revision_rejected(self):
+        with self.assertRaisesRegex(ValueError, "stale Sifr revision"):
+            portable_graph(self.root, "b" * 40)
+
+    def test_stale_lock_revision_rejected(self):
+        self.lock.write_text(self.lock.read_text().replace(REVISION, "b" * 40))
+        with self.assertRaisesRegex(ValueError, "nonportable or stale"):
+            portable_graph(self.root, REVISION)
+
+    def test_missing_lock_rejected_before_fetch(self):
+        self.lock.unlink()
+        with self.assertRaises(FileNotFoundError):
+            fetch_generated_graph(self.root, REVISION, lambda *a, **k: self.fail("fetch ran"))
+
+    def test_changed_lock_rejected(self):
+        def change(*args, **kw):
+            self.lock.write_text(self.lock.read_text() + "\n# unexpected rewrite\n")
+        with self.assertRaisesRegex(ValueError, "preparation changed"):
+            fetch_generated_graph(self.root, REVISION, change)
+
+
+def policy_checks() -> None:
+    result = unittest.TextTestRunner(verbosity=2).run(unittest.defaultTestLoader.loadTestsFromTestCase(SetupPolicyTests))
+    if not result.wasSuccessful():
+        raise AssertionError("generated Cargo setup policy checks failed")
+
+
+def clean_cache_checks() -> None:
+    """Exercise the actual profile prelude, then resolve every prepared graph offline."""
+    (REPO_ROOT / "target").mkdir(exist_ok=True)
+    root = Path(tempfile.mkdtemp(prefix="b11-clean-cache-", dir=REPO_ROOT / "target"))
+    cargo_home = root / "cargo-home"
+    cargo_home.mkdir()
+    revision = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, text=True).strip()
+    with patch.dict(os.environ, {"CARGO_HOME": str(cargo_home), "CARGO_NET_OFFLINE": "true"}):
+        # No manual fetch/cache population: the production prelude owns both graphs.
+        runner = ProfileRunner("merge", [])
+        runner.prepare_cargo_cache()
+        enable_offline_cargo(runner.env)
+        report_path = REPO_ROOT / "target/verification/areas/generated-cargo-setup-merge.json"
+        report = json.loads(report_path.read_text())
+        if report["revision"] != revision:
+            raise AssertionError("preparation did not cover the candidate SHA")
+        quality = quality_module()
+        expected = preparation_entries(quality, ["representative"])
+        if {entry.id for entry in expected} != {entry["id"] for entry in report["entries"]}:
+            raise AssertionError("incomplete generated preparation coverage")
+        demand = set()
+        for record in report["entries"]:
+            crate_root = REPO_ROOT / record["crate_root"]
+            before = portable_graph(crate_root, revision)
+            metadata = subprocess.run(
+                ["cargo", "metadata", "--format-version", "1", "--locked", "--offline",
+                 "--manifest-path", str(crate_root / "Cargo.toml")],
+                cwd=REPO_ROOT, env=runner.env, text=True, capture_output=True, check=True,
+            )
+            demand.update(package["name"] for package in json.loads(metadata.stdout)["packages"])
+            if portable_graph(crate_root, revision) != before:
+                raise AssertionError("offline resolution mutated the graph")
+            print(f"[b11-offline-graph] {record['id']} status=pass", flush=True)
+        if not {"sifr_runtime", "sifr_stdlib"}.issubset(demand):
+            raise AssertionError("runtime and stdlib graph demand was not covered")
+
+        # Re-enter materialization through the same path used by corpus, positive
+        # Clippy, and demos, after preparation has made networking unavailable.
+        with patch.dict(os.environ, runner.env):
+            entries = {entry.id: entry for entry in expected}
+            for mode, group in (("corpus", "concurrency-runtime-readiness"),
+                                ("clippy", "stdlib-flows"), ("demos", "demos-required")):
+                entry = next(entry for entry in expected if entry.group == group)
+                crate_root = quality.materialize_entry(entries[entry.id], root / mode)
+                run_command(["cargo", "metadata", "--format-version", "1", "--no-deps", "--locked",
+                             "--offline", "--manifest-path", str(crate_root / "Cargo.toml")], env=runner.env)
+
+        # A genuinely empty second cache must fail on that same exact Git graph.
+        empty_home = root / "negative-empty-home"
+        empty_home.mkdir()
+        graph = REPO_ROOT / report["entries"][0]["crate_root"]
+        command = ["cargo", "metadata", "--format-version", "1", "--locked", "--offline",
+                   "--manifest-path", str(graph / "Cargo.toml")]
+        negative = subprocess.run(command, cwd=REPO_ROOT,
+                                  env={**runner.env, "CARGO_HOME": str(empty_home)},
+                                  text=True, capture_output=True)
+        if negative.returncode == 0 or "offline" not in negative.stderr:
+            raise AssertionError("unprepared exact Git graph did not fail offline")
+        (root / "negative-empty-cache.log").write_text(negative.stderr)
+
+        # A real generated manifest with changed dependency requirements cannot
+        # escape --locked in production fetch, even with its cache prepared.
+        invalid = root / "negative-lock-drift"
+        shutil.copytree(graph, invalid)
+        manifest = invalid / "Cargo.toml"
+        packages = tomllib.loads((invalid / "Cargo.lock").read_text())["package"]
+        dependency = next(package for package in packages if package["name"] == "num-traits")
+        manifest.write_text(manifest.read_text() + '\n[dependencies.b11_lock_drift]\n'
+                            f'package = "num-traits"\nversion = "={dependency["version"]}"\n')
+        def locked_failure(args, **kw):
+            proc = subprocess.run(args, cwd=REPO_ROOT, text=True, capture_output=True, **kw)
+            (root / "negative-lock-drift.log").write_text(proc.stderr)
+            if proc.returncode and "--locked" in proc.stderr:
+                raise CommandFailed(proc.returncode)
+            raise AssertionError(f"lock drift did not fail specifically under --locked: {proc.stderr}")
+        try:
+            fetch_generated_graph(invalid, revision, locked_failure)
+        except CommandFailed:
+            pass
+        else:
+            raise AssertionError("changed generated requirements passed locked fetch")
+    evidence = {"revision": revision, "status": "pass", "prepared_graphs": len(expected),
+                "offline_graphs": len(expected), "entry_modes": ["corpus", "clippy", "demos"],
+                "runtime_and_stdlib": True, "negative_checks": ["empty-cache", "lock-drift"],
+                "cargo_home": str(cargo_home), "setup_report": str(report_path),
+                "setup_report_sha256": hashlib.sha256(report_path.read_bytes()).hexdigest()}
+    destination = REPO_ROOT / "target/verification/areas/item12k-b11-clean-cache.json"
+    destination.write_text(json.dumps(evidence, indent=2) + "\n")
+    print(json.dumps(evidence, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=["policy", "clean-cache"])
+    args = parser.parse_args()
+    if args.mode == "policy":
+        policy_checks()
+    else:
+        clean_cache_checks()

--- a/verification/runner/sifr_verify/profile_runner.py
+++ b/verification/runner/sifr_verify/profile_runner.py
@@ -81,14 +81,14 @@ class ProfileRunner:
         self.profile_name = str(self.profile["name"])
         self.forward_args = forward_args
         self.env = os.environ.copy()
+        target_root = Path(self.env.get("CARGO_TARGET_DIR", REPO_ROOT / "target"))
+        if not target_root.is_absolute():
+            target_root = REPO_ROOT / target_root
         configured_sifr_binary = self.env.get("SIFR_GCQ_BIN") or self.env.get("SIFR_RUNTIME_PLATFORM_BIN")
         sifr_binary = (
             Path(configured_sifr_binary)
             if configured_sifr_binary
-            else resolve_sifr_binary(
-                REPO_ROOT,
-                default_binary=REPO_ROOT / "target" / "debug" / "sifr",
-            )
+            else target_root / "debug" / "sifr"
         )
         self.env.setdefault("SIFR_GCQ_BIN", str(sifr_binary))
         self.env.setdefault("SIFR_RUNTIME_PLATFORM_BIN", str(sifr_binary))
@@ -143,6 +143,11 @@ class ProfileRunner:
     def prepare_cargo_cache(self) -> None:
         try:
             prepare_profile_cargo_cache(self.profile, self.env, run_command)
+            if not (os.environ.get("SIFR_GCQ_BIN") or os.environ.get("SIFR_RUNTIME_PLATFORM_BIN")):
+                # Resolve/build only after the workspace setup has succeeded.
+                binary = resolve_sifr_binary(REPO_ROOT)
+                self.env["SIFR_GCQ_BIN"] = str(binary)
+                self.env["SIFR_RUNTIME_PLATFORM_BIN"] = str(binary)
         except ValueError as exc:
             raise ProfileRunnerError(str(exc)) from exc
 
@@ -235,9 +240,6 @@ class ProfileRunner:
         self.run_python(path, "--self-test")
 
     def run_area(self, area: str, suites: list[str]) -> None:
-        if area == "generated_code_quality":
-            shared_root = REPO_ROOT / "target" / "sifr_generated_code_quality" / f"{self.profile_name}.shared"
-            self.env["SIFR_GCQ_SHARED_ROOT"] = str(shared_root.relative_to(REPO_ROOT))
         result_slug = CRITICAL_RESULT_SLUGS.get(area, area.replace("_", "-"))
         run_selected_area(
             area=area,

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -16,6 +16,7 @@ from verification.json_schema_202012 import lint_schema
 
 from .areas import discover_areas
 from .cargo_setup import cargo_setup_command
+from .generated_cargo_setup_checks import policy_checks as generated_cargo_setup_policy_checks
 from .errors import SchemaError
 from .profile_area_steps import run_selected_area
 from .profile_results import AreaResultError, validate_area_result
@@ -48,6 +49,7 @@ from .step_budgets import run_self_test as step_budget_self_test
 
 def run_all() -> list[str]:
     checks = [
+        ("generated Cargo setup policy checks", generated_cargo_setup_policy_checks),
         ("schema self-tests", _schema_self_test),
         ("profile schema self-test", _profile_schema_self_test),
         ("cache-aware step budget self-test", step_budget_self_test),


### PR DESCRIPTION
When offline qualification reached a portable generated Cargo project, workspace-only cache preparation had not fetched its exact-revision Sifr Git dependencies. Prepare the real generated manifests and locks during the online profile prelude, before enabling offline execution.

The prelude covers the complete positive corpus and selected companion graphs, uses revision-scoped materialization, preserves manifest and lock bytes, and rejects stale or local source identities. Corpus/demo checks and positive Clippy explicitly retain locked execution. Compiler sources, tracked locks, fixtures, workflows, and corpus manifests are unchanged.

Scope: item 12K-B11, fixes #3732. This does not deliver original12K or reset its exhausted reviews/gates.

Validation and exact-SHA Opus review evidence will be attached before merge. Only the item's registered policy, runner self-test, clean-cache offline graph checks, diff and file-size checks apply; no Sifr gate is required for these file categories.
