### PR TITLE
Reject retired dependencies and Testcontainers APIs across Python runners

### DIFF
--- a/verification/areas/python_interop/runner/binding_authoring.py
+++ b/verification/areas/python_interop/runner/binding_authoring.py
@@ -12,6 +12,7 @@ AREA_ROOT = REPO_ROOT / "verification" / "areas" / "python_interop"
 COMMON_ROOT = REPO_ROOT / "verification" / "areas" / "common"
 sys.path.insert(0, str(COMMON_ROOT))
 
+# Direct script execution needs the common runner directory above before import.
 from sifr_binary import resolve_sifr_binary  # noqa: E402
 
 

--- a/verification/areas/python_interop/runner/dependency_versions.py
+++ b/verification/areas/python_interop/runner/dependency_versions.py
@@ -56,7 +56,7 @@ PROJECT_PATHS = {
 }
 NORMALIZED_NAME = re.compile(r"[-_.]+")
 REQUIREMENT_NAME = re.compile(r"^[A-Za-z0-9._-]+")
-RETIRED_PYTHON_INTEROP_PACKAGES = frozenset({"httpcore", "httpx"})
+RETIRED_DISTRIBUTIONS = frozenset({"httpcore", "httpx"})
 EXPECTED_SERVICE_IMAGES = frozenset({"localstack", "redis"})
 
 
@@ -170,6 +170,8 @@ def validate_project(
 ) -> list[str]:
     errors: list[str] = []
     direct = direct_dependency_names(project)
+    for name in sorted(RETIRED_DISTRIBUTIONS.intersection(direct)):
+        errors.append(f"{label}: retired direct dependency: {name}")
     for name in sorted(expected.difference(direct)):
         errors.append(f"{label}: missing direct dependency {name}")
 
@@ -181,9 +183,8 @@ def validate_project(
         for package in locked_packages
         if isinstance(package, dict)
     }
-    if label == "python-interop":
-        for name in sorted(RETIRED_PYTHON_INTEROP_PACKAGES.intersection(locked_names)):
-            errors.append(f"{label}: retired package remains locked: {name}")
+    for name in sorted(RETIRED_DISTRIBUTIONS.intersection(locked_names)):
+        errors.append(f"{label}: retired package remains locked: {name}")
     for name in sorted(expected):
         matching = [
             package
@@ -354,18 +355,32 @@ def run_self_tests(audit: dict[str, object]) -> int:
     if not validate_project(project_name, expected, releases, missing_direct, lock):
         raise AssertionError("direct-dependency mutation was not rejected")
 
-    retired_dependency = copy.deepcopy(lock)
-    retired_dependency["package"].append({"name": "httpx", "version": "0.28.1"})
-    if not validate_project(
-        project_name, expected, releases, project, retired_dependency
-    ):
-        raise AssertionError("retired HTTP client mutation was not rejected")
+    retired_mutations = 0
+    for label in (*projects, "renamed-owner"):
+        for retired in sorted(RETIRED_DISTRIBUTIONS):
+            retired_dependency = copy.deepcopy(lock)
+            retired_dependency["package"].append(
+                {"name": retired.upper(), "version": "0.0.0"}
+            )
+            errors = validate_project(
+                label, expected, releases, project, retired_dependency
+            )
+            if errors != [f"{label}: retired package remains locked: {retired}"]:
+                raise AssertionError(f"retired lock mutation failed: {label}/{retired}")
+            retired_direct = copy.deepcopy(project)
+            retired_direct["project"]["dependencies"].append(
+                f"{retired.upper()}[extra]>=0; python_version >= '3.14'"
+            )
+            errors = validate_project(label, expected, releases, retired_direct, lock)
+            if errors != [f"{label}: retired direct dependency: {retired}"]:
+                raise AssertionError(f"retired direct mutation failed: {label}/{retired}")
+            retired_mutations += 2
 
     stale_image = copy.deepcopy(audit)
     stale_image["service_images"][0]["latest_stable"] = "4.13.1"
     if not validate_service_images(stale_image):
         raise AssertionError("stale service-image mutation was not rejected")
-    return 7
+    return 6 + retired_mutations
 
 
 def main() -> int:

--- a/verification/areas/python_interop/runner/example_packages.py
+++ b/verification/areas/python_interop/runner/example_packages.py
@@ -25,6 +25,7 @@ COMMON_ROOT = str(Path(__file__).resolve().parents[2] / "common")
 if COMMON_ROOT not in sys.path:
     sys.path.insert(0, COMMON_ROOT)
 
+# This standalone runner module bootstraps the shared resolver's import directory.
 from sifr_binary import resolve_sifr_binary  # noqa: E402
 
 EXAMPLE_TIMEOUT_SECONDS = 600

--- a/verification/areas/python_interop/runner/live_policy.py
+++ b/verification/areas/python_interop/runner/live_policy.py
@@ -6,6 +6,10 @@ from pathlib import Path
 from typing import Any, Callable
 
 from env import RunnerPaths
+from testcontainers_policy import (
+    run_testcontainers_self_tests,
+    validate_runner_testcontainers,
+)
 
 REQUIRED_POLICY_KEYS = {
     "schema_version",
@@ -61,6 +65,7 @@ def build_live_policy_report(paths: RunnerPaths) -> dict[str, Any]:
     _validate_live_profile(profile, policy)
     _validate_offline_profiles(paths.repo_root, policy)
     _validate_service_runner_boundary(paths.area_root)
+    validate_runner_testcontainers(paths.area_root)
     return {
         "schema_version": 1,
         "area": "python_interop",
@@ -83,6 +88,7 @@ def run_live_policy_self_tests(paths: RunnerPaths) -> None:
         paths.repo_root / "verification" / "profiles" / f"{policy['profile']}.json"
     )
     build_live_policy_report(paths)
+    run_testcontainers_self_tests(paths.area_root)
 
     missing_key_policy = dict(policy)
     del missing_key_policy["result_statuses"]
@@ -139,13 +145,6 @@ def run_live_policy_self_tests(paths: RunnerPaths) -> None:
             "from kafka import KafkaProducer\nexecute_live_binary(binary, environment)\n"
         ),
         "runner owns service clients",
-    )
-    _expect_policy_failure(
-        lambda: _validate_service_runner_source(
-            "from testcontainers.redis import RedisContainer\n"
-            "execute_live_binary(binary, environment)\n"
-        ),
-        "legacy Testcontainers Redis import",
     )
 
 
@@ -262,11 +261,6 @@ def _validate_service_runner_source(source: str) -> None:
         "get_client(": "testcontainers service client",
         "psycopg": "Postgres client",
         "redis.Redis": "Redis client",
-        "testcontainers.kafka": "legacy Testcontainers Kafka import",
-        "testcontainers.localstack": "legacy Testcontainers LocalStack import",
-        "testcontainers.postgres": "legacy Testcontainers Postgres import",
-        "testcontainers.redis": "legacy Testcontainers Redis import",
-        "wait_for_logs": "legacy Testcontainers wait helper",
     }
     observed = sorted(label for token, label in forbidden.items() if token in source)
     if observed:

--- a/verification/areas/python_interop/runner/readonly_check_doctor.py
+++ b/verification/areas/python_interop/runner/readonly_check_doctor.py
@@ -11,6 +11,7 @@ AREA_ROOT = REPO_ROOT / "verification" / "areas" / "python_interop"
 COMMON_ROOT = REPO_ROOT / "verification" / "areas" / "common"
 sys.path.insert(0, str(COMMON_ROOT))
 
+# Direct script execution needs the common runner directory above before import.
 from sifr_binary import resolve_sifr_binary  # noqa: E402
 
 COMMAND_HANG_TIMEOUT_SECONDS = 300

--- a/verification/areas/python_interop/runner/testcontainers_policy.py
+++ b/verification/areas/python_interop/runner/testcontainers_policy.py
@@ -1,0 +1,132 @@
+"""Reject retired Testcontainers APIs in every runner module's executable code."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+RETIRED_MODULES = (
+    "testcontainers.kafka",
+    "testcontainers.localstack",
+    "testcontainers.postgres",
+    "testcontainers.redis",
+    "testcontainers.core.waiting_utils",
+)
+RETIRED_WAIT_HELPERS = ("wait_for_logs", "wait_container_is_ready")
+
+
+def validate_testcontainers_source(source: str, path: Path) -> None:
+    module = ast.parse(source, filename=str(path))
+    aliases: dict[str, str] = {}
+
+    def reject_retired(name: str, line: int) -> None:
+        if any(name == old or name.startswith(old + ".") for old in RETIRED_MODULES):
+            raise SystemExit(f"{path}:{line}: retired Testcontainers API: {name}")
+
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                reject_retired(alias.name, node.lineno)
+                aliases[alias.asname or alias.name.split(".")[0]] = (
+                    alias.name if alias.asname else alias.name.split(".")[0]
+                )
+        elif isinstance(node, ast.ImportFrom) and node.level == 0:
+            for alias in node.names:
+                name = f"{node.module}.{alias.name}"
+                reject_retired(name, node.lineno)
+                aliases[alias.asname or alias.name] = name
+
+    def qualified_name(node: ast.AST) -> str:
+        if isinstance(node, ast.Name):
+            return aliases.get(node.id, node.id)
+        if isinstance(node, ast.Attribute):
+            return f"{qualified_name(node.value)}.{node.attr}"
+        return ""
+
+    for node in ast.walk(module):
+        if isinstance(node, (ast.Name, ast.Attribute)):
+            reject_retired(qualified_name(node), node.lineno)
+            name = node.id if isinstance(node, ast.Name) else node.attr
+            if name in RETIRED_WAIT_HELPERS:
+                raise SystemExit(
+                    f"{path}:{node.lineno}: retired Testcontainers wait helper: {name}"
+                )
+
+
+def runner_modules(area_root: Path) -> list[Path]:
+    return [area_root / "runner.py", *sorted((area_root / "runner").rglob("*.py"))]
+
+
+def validate_runner_testcontainers(area_root: Path) -> None:
+    for path in runner_modules(area_root):
+        validate_testcontainers_source(path.read_text(encoding="utf-8"), path)
+
+
+def run_testcontainers_self_tests(area_root: Path) -> None:
+    accepted = (
+        "from testcontainers.community.redis import RedisContainer\n"
+        "from testcontainers.core.wait_strategies import LogMessageWaitStrategy\n"
+        "# from testcontainers.redis import RedisContainer\n"
+        "example = 'wait_for_logs(container, pattern)'\n"
+    )
+    validate_testcontainers_source(accepted, Path("accepted.py"))
+    mutations = []
+    for module in RETIRED_MODULES:
+        parent, _, child = module.rpartition(".")
+        mutations.extend(
+            (
+                f"import {module}\n",
+                f"import {module} as retired\n",
+                f"from {module} import Example as renamed\n",
+                f"from {parent} import (\n    {child} as retired,\n)\n",
+                f"import {parent} as parent\nparent.{child}.Example()\n",
+            )
+        )
+    for helper in RETIRED_WAIT_HELPERS:
+        mutations.extend(
+            (
+                f"from testcontainers.core.waiting_utils import {helper} as wait\n",
+                f"{helper}(container, pattern)\n",
+                f"container.{helper}(pattern)\n",
+            )
+        )
+    for index, source in enumerate(mutations):
+        path = Path(f"mutation-{index}.py")
+        try:
+            validate_testcontainers_source(source, path)
+        except SystemExit as error:
+            if (
+                str(path) not in str(error)
+                or "retired Testcontainers" not in str(error)
+            ):
+                raise AssertionError(f"unexpected policy failure: {error}") from error
+        else:
+            raise AssertionError(f"retired Testcontainers mutation accepted: {source}")
+
+    # Exercise actual discovery for every maintained module, plus a new nested owner.
+    relative_paths = [path.relative_to(area_root) for path in runner_modules(area_root)]
+    relative_paths.append(Path("runner/new_owner/nested.py"))
+    with TemporaryDirectory(prefix="sifr-testcontainers-policy-") as directory:
+        root = Path(directory)
+        for relative in relative_paths:
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(accepted, encoding="utf-8")
+        validate_runner_testcontainers(root)
+        for relative in relative_paths:
+            path = root / relative
+            path.write_text(mutations[0], encoding="utf-8")
+            try:
+                validate_runner_testcontainers(root)
+            except SystemExit as error:
+                if str(path) not in str(error):
+                    raise AssertionError(f"wrong mutation owner: {error}") from error
+            else:
+                raise AssertionError(f"runner module escaped policy scan: {relative}")
+            finally:
+                path.write_text(accepted, encoding="utf-8")
+    print(
+        f"Testcontainers runner policy self-test ok: forms={len(mutations)} "
+        f"modules={len(relative_paths)}"
+    )


### PR DESCRIPTION
Item 39 rejects retired HTTP distributions regardless of project labels and rejects retired Testcontainers imports and wait helpers throughout the Python interop runner, including nested modules. AST inspection excludes comments and example strings; self-tests mutate each forbidden form and every discovered module. The three standalone import bootstrap suppressions now explain their purpose.

Validated the exact candidate `9b17c2dad02f66c91536182889bf5d35686c6316` with the named Python interop suites: self-test, dependency-versions, redis-service-features and live-policy (4 passed), plus diff and file-size guards. No Sifr gate applies to this runner-only change.

The orchestrator transferred the conflicting fixture-owned Redis numkeys clause to later Item 63 before review; fixtures and current dependency selections remain unchanged. Item-scoped exact-SHA Opus review is pending.
