### PR TITLE
Verify Python feature identities against the stable audit (item 55)

### DIFF
--- a/verification/areas/python_interop/README.md
+++ b/verification/areas/python_interop/README.md
@@ -131,16 +131,23 @@ default; live suites must declare their own `network_mode` and resource classes.
   report output.
 - `env`: interpreter, venv, ABI, platform, lock/env freshness, and probe rejection fixture coverage.
 - `dependency-versions`: exact PyPI stable versions and audited artifact hashes
-  for the maintained Python lock owners. Six mutations cover stale versions in
+  for the maintained Python lock owners. Mutations cover stale versions in
   both locks, a missing artifact, a missing declaration, retired HTTP client
-  packages, and a stale service image.
+  packages, a stale service image, installed runtime drift, and markers following
+  changed audited versions.
 - `minor-train-features`: direct runtime coverage for the new Schwifty 2026.7
-  checksum-solving `BBAN.random` implementation.
+  checksum-solving `BBAN.random` implementation, with generated counts and an
+  installed-version marker checked against `data/latest_stable_python.json`.
 - `crypto-abi-features`: CFFI 2.1 source generation through `cffi.gen_src`.
 - `redis-service-features`: Redis 8.1 commands, Fakeredis RESP3 behavior,
   Hiredis RESP3 parsing, and Testcontainers 4.15 community APIs.
 - `numeric-dataframe-features`: NumPy 2.5 descending sorts and Pandas 3 string
-  dtype, copy-on-write, and column expressions.
+  dtype, copy-on-write, column expressions, and the public `pandas` DataFrame
+  producer-module identity. This suite and `redis-service-features` derive exact
+  installed-version checks and markers from the same stable audit.
+  The Redis runner treats deprecations as errors only around Testcontainers
+  imports and API checks, then restores the caller's warning policy. It does
+  not suppress warnings; the numeric/dataframe runner installs no warning filter.
 - `imports`: root imports and native extension load diagnostics.
 - `native`: trusted native Python package load/use smoke.
 - `async`: Python event-loop/client behavior under Sifr blocking semantics.
@@ -224,7 +231,14 @@ and verifies that ordinary object/leak diagnostics return to their baseline:
 
 - biip GTIN parsing and schwifty BIC validation.
 - PyArrow 25 array compute, the `hypot` kernel, table-to-tensor conversion,
-  and Arrow PyCapsule metadata/release.
+  and Arrow PyCapsule metadata/release. These exercise APIs in the Arrow 25
+  release line, not fixes specific to maintenance release 25.0.1. The stable
+  audit owns the exact selected version and wheel hash. The hermetic PyArrow
+  bridge also retains its existing exact module-version assertion: it checks
+  the loaded runtime module, while the audit checks declarations and locks.
+  A future PyArrow upgrade must update that fixture-owned assertion together
+  with its lock/audit selection; the feature runners do not import audit data
+  into hermetic package bridges.
 - FastAPI frontend serving with dependency headers and background tasks.
   The same bridge validates Pydantic conversion, Starlette 1.6 body limits,
   and Starlette response rendering through HTTPX2.

--- a/verification/areas/python_interop/runner/dependency_versions.py
+++ b/verification/areas/python_interop/runner/dependency_versions.py
@@ -7,6 +7,7 @@ import json
 import re
 import tomllib
 from datetime import date
+from importlib.metadata import version
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -106,6 +107,63 @@ def release_map(audit: dict[str, object]) -> dict[str, dict[str, object]]:
     if releases.keys() != expected:
         raise ValueError("audited package set differs from the maintained package set")
     return releases
+
+
+def runtime_version_marker(*names: str) -> str:
+    """Validate installed feature dependencies against the canonical audit."""
+    audit = json.loads(AUDIT_PATH.read_text(encoding="utf-8"))
+    releases = release_map(audit)
+    markers = []
+    for name in names:
+        expected = releases[name]["latest_stable"]
+        installed = version(name)
+        if installed != expected:
+            raise RuntimeError(
+                f"{name}: expected audited release {expected}, found {installed}"
+            )
+        markers.append(f"{name}={installed}")
+    return " ".join(markers)
+
+
+def run_runtime_version_self_tests(audit: dict[str, object]) -> int:
+    from unittest.mock import patch
+
+    names = (
+        "schwifty", "numpy", "pandas", "redis", "fakeredis", "hiredis", "testcontainers"
+    )
+    releases = release_map(audit)
+    installed = {name: releases[name]["latest_stable"] for name in names}
+    with patch(f"{__name__}.version", side_effect=installed.__getitem__):
+        expected = " ".join(f"{name}={installed[name]}" for name in names)
+        if runtime_version_marker(*names) != expected:
+            raise AssertionError("runtime version markers differ from audited releases")
+        for name in names:
+            original = installed[name]
+            installed[name] = "0.0.0"
+            try:
+                runtime_version_marker(*names)
+            except RuntimeError as error:
+                if str(error) != (
+                    f"{name}: expected audited release {original}, found {installed[name]}"
+                ):
+                    raise AssertionError(
+                        "runtime version mismatch lost its identity"
+                    ) from error
+            else:
+                raise AssertionError(f"stale installed release was accepted: {name}")
+            finally:
+                installed[name] = original
+
+        changed = copy.deepcopy(audit)
+        for package in changed["packages"]:
+            if package["name"] in names:
+                package["latest_stable"] = installed[package["name"]] = "99.0.1"
+        with patch(f"{__name__}.AUDIT_PATH") as audit_path:
+            audit_path.read_text.return_value = json.dumps(changed)
+            expected_changed = " ".join(f"{name}=99.0.1" for name in names)
+            if runtime_version_marker(*names) != expected_changed:
+                raise AssertionError("runtime version markers did not follow the audit")
+    return len(names) + 1
 
 
 def project_map(
@@ -380,7 +438,7 @@ def run_self_tests(audit: dict[str, object]) -> int:
     stale_image["service_images"][0]["latest_stable"] = "4.13.1"
     if not validate_service_images(stale_image):
         raise AssertionError("stale service-image mutation was not rejected")
-    return 6 + retired_mutations
+    return 6 + retired_mutations + run_runtime_version_self_tests(audit)
 
 
 def main() -> int:

--- a/verification/areas/python_interop/runner/minor_train_features.py
+++ b/verification/areas/python_interop/runner/minor_train_features.py
@@ -4,8 +4,11 @@ import random
 
 from schwifty import BBAN
 
+from dependency_versions import runtime_version_marker
+
 
 def main() -> int:
+    versions = runtime_version_marker("schwifty")
     random.seed(25)
     country_codes = ("BE", "DE", "ES", "FR", "IT", "NL", "NO", "PL")
     generated = [
@@ -15,7 +18,10 @@ def main() -> int:
         raise RuntimeError(
             "Schwifty generated a BBAN with an invalid national checksum"
         )
-    print("python minor train features ok: countries=8 schwifty-bban-checksums=32")
+    print(
+        f"python minor train features ok: {versions} "
+        f"countries={len(country_codes)} schwifty-bban-checksums={len(generated)}"
+    )
     return 0
 
 

--- a/verification/areas/python_interop/runner/numeric_dataframe_features.py
+++ b/verification/areas/python_interop/runner/numeric_dataframe_features.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
-from importlib.metadata import version
-
 import numpy as np
 import pandas as pd
 
+from dependency_versions import runtime_version_marker
+
 
 def main() -> int:
-    if version("numpy") != "2.5.2":
-        raise RuntimeError("NumPy is not at the audited stable release")
-    if version("pandas") != "3.0.5":
-        raise RuntimeError("Pandas is not at the audited stable release")
+    versions = runtime_version_marker("numpy", "pandas")
 
     values = np.array([3, 1, 2], dtype=np.int64)
     if np.sort(values, descending=True).tolist() != [3, 2, 1]:
@@ -19,6 +16,8 @@ def main() -> int:
         raise RuntimeError("NumPy descending argsort behavior drifted")
 
     frame = pd.DataFrame({"city": ["oslo", None, "paris"], "value": [2, 3, 5]})
+    if type(frame).__module__ != "pandas":
+        raise RuntimeError("Pandas DataFrame producer module is not public pandas")
     if str(frame["city"].dtype) != "str" or not pd.isna(frame.iloc[1, 0]):
         raise RuntimeError("Pandas dedicated string dtype behavior drifted")
 
@@ -32,8 +31,9 @@ def main() -> int:
         raise RuntimeError("Pandas column-expression behavior drifted")
 
     print(
-        "python numeric/dataframe features ok: numpy=2.5.2 pandas=3.0.5 "
-        "descending-sort=ok string-dtype=ok copy-on-write=ok pd-col=ok"
+        f"python numeric/dataframe features ok: {versions} "
+        "descending-sort=ok string-dtype=ok copy-on-write=ok pd-col=ok "
+        "dataframe-producer=pandas"
     )
     return 0
 

--- a/verification/areas/python_interop/runner/redis_service_features.py
+++ b/verification/areas/python_interop/runner/redis_service_features.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
 import warnings
-from importlib.metadata import version
 
 import fakeredis
 import hiredis
 from redis import Redis
 
+from dependency_versions import runtime_version_marker
+
 
 def main() -> int:
-    if version("redis") != "8.1.0":
-        raise RuntimeError("Redis is not at the audited stable release")
-    if version("fakeredis") != "2.37.1":
-        raise RuntimeError("Fakeredis is not at the audited stable release")
-    if version("hiredis") != "3.4.1":
-        raise RuntimeError("Hiredis is not at the audited stable release")
-    if version("testcontainers") != "4.15.0":
-        raise RuntimeError("Testcontainers is not at the audited stable release")
+    versions = runtime_version_marker("redis", "fakeredis", "hiredis", "testcontainers")
 
     for command in ("sdiffcard", "sunioncard", "lmovem"):
         if not callable(getattr(Redis, command, None)):
@@ -32,6 +26,8 @@ def main() -> int:
     if reader.gets() != {b"safe": 1, b"count": 2}:
         raise RuntimeError("Hiredis RESP3 map parsing drifted")
 
+    # Only the Testcontainers import/API contract requires deprecations as errors.
+    # Restore the caller's warning policy after this block; do not suppress warnings.
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         from testcontainers.community.redis import RedisContainer
@@ -48,10 +44,7 @@ def main() -> int:
         if strategy.with_startup_timeout(60) is not strategy:
             raise RuntimeError("Testcontainers wait strategy configuration drifted")
 
-    print(
-        "python Redis service features ok: redis=8.1.0 fakeredis=2.37.1 "
-        "hiredis=3.4.1 testcontainers=4.15.0"
-    )
+    print(f"python Redis service features ok: {versions}")
     return 0
 
 


### PR DESCRIPTION
Python feature runners duplicated audited version strings and did not directly verify the public Pandas DataFrame module identity. They now validate installed versions and generate markers from the canonical audit; the numeric suite explicitly requires the public `pandas` identity.

Item 55 also records the inspected Testcontainers warning scope and the retained hermetic Arrow runtime assertion, and distinguishes Arrow 25 API coverage from patch-specific fixes. No package, compiler, lockfile, fixture, or workflow changes.

Validation on exact candidate `0705776ec206da3cc7aa5ffa1450f025be27d414`: `minor-train-features`, `numeric-dataframe-features`, and `dependency-versions` passed (3 variants, 26 audit mutations). `git diff --check` and the file-size guardrail passed. The authorized runner-only policy excludes create-PR and merge-profile gates. The one exact-SHA Opus review returned SATISFIED with no blocking findings; no remediation review. Nonblocking suggestions are recorded in #3773. Validation and review provenance are published in PR comments.
