### PR TITLE
[12K-B20] Correct formatter discovery and preserve startup attribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7539,6 +7539,7 @@ name = "sifr"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "ignore",
  "ruff_python_ast",
  "ruff_text_size",
  "serde",

--- a/crates/sifr/Cargo.toml
+++ b/crates/sifr/Cargo.toml
@@ -25,6 +25,7 @@ sifr_sysroot = { workspace = true }
 sifr_syntax = { workspace = true }
 sifr_sql_contract = { workspace = true }
 clap = { version = "4.6.6", features = ["derive"] }
+ignore = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/sifr/src/check_and_package_commands.rs
+++ b/crates/sifr/src/check_and_package_commands.rs
@@ -7,6 +7,7 @@ use super::diagnostic_rendering_and_run::{
     current_session_package_id, execute_cargo_plan, render_diagnostics,
 };
 use super::formatter_cli::FmtArgs;
+use super::formatter_discovery::FormatterGitignore;
 use super::package_graph_context::load_package_graph_context_for_entrypoint;
 use super::package_session_cli::package_session_for_cwd;
 use super::python_runtime_context::{package_python_runtime, package_python_runtime_for_check};
@@ -578,9 +579,11 @@ pub(super) fn fmt_entrypoint(
         args.paths.clone()
     };
     let mut diagnostics = Vec::new();
+    let gitignore = FormatterGitignore::load(&cwd, config.respect_gitignore, &mut provider)?;
     for target in targets {
         let explicit_target = provider.is_file(&target);
-        let files = select_formatter_files(&target, &config, explicit_target, &mut provider)?;
+        let files =
+            select_formatter_files(&target, &config, &gitignore, explicit_target, &mut provider)?;
         for file in files {
             if args.check {
                 diagnostics.extend(sifr_format::check_path_with_options(
@@ -694,46 +697,21 @@ fn flag_override(enable: bool, disable: bool) -> Option<bool> {
 fn select_formatter_files(
     target: &Path,
     config: &EffectiveFormatConfig,
+    gitignore: &FormatterGitignore,
     explicit_target: bool,
     provider: &mut impl SourceProvider,
 ) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
     let files = sifr_format::collect_sifr_files(target, provider)?;
     let mut selected = Vec::new();
-    let ignore_patterns = if config.respect_gitignore {
-        read_gitignore_patterns(provider)?
-    } else {
-        Vec::new()
-    };
     for file in files {
         let excluded =
-            pattern_matches(&file, &config.exclude) || pattern_matches(&file, &ignore_patterns);
+            pattern_matches(&file, &config.exclude) || gitignore.is_ignored(&file, provider)?;
         if excluded && (!explicit_target || config.force_exclude) {
             continue;
         }
         selected.push(file);
     }
     Ok(selected)
-}
-
-fn read_gitignore_patterns(
-    provider: &mut impl SourceProvider,
-) -> Result<Vec<String>, Vec<RenderedDiagnostic>> {
-    let path = Path::new(".gitignore");
-    if !provider.is_file(path) {
-        return Ok(Vec::new());
-    }
-    let source = provider.read_file(path).map_err(|err| {
-        vec![formatter_cli_diagnostic(format!(
-            "could not read .gitignore for formatter discovery: {err}"
-        ))]
-    })?;
-    Ok(source
-        .as_str()
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with('#'))
-        .map(str::to_string)
-        .collect())
 }
 
 fn pattern_matches(path: &Path, patterns: &[String]) -> bool {
@@ -854,6 +832,6 @@ fn formatting_drift_for_path(source: &str, path: &Path) -> RenderedDiagnostic {
     }
 }
 
-fn formatter_cli_diagnostic(message: impl Into<String>) -> RenderedDiagnostic {
+pub(super) fn formatter_cli_diagnostic(message: impl Into<String>) -> RenderedDiagnostic {
     diagnostic_with_code(message, DiagnosticCode::FMT_FORMATTING_DRIFT)
 }

--- a/crates/sifr/src/formatter_discovery.rs
+++ b/crates/sifr/src/formatter_discovery.rs
@@ -1,14 +1,14 @@
 //! Interpret the working directory's gitignore at its own path boundary.
 
 use super::check_and_package_commands::formatter_cli_diagnostic;
-use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use ignore::gitignore::GitignoreBuilder;
 use sifr_diagnostics::RenderedDiagnostic;
 use sifr_frontend::SourceProvider;
 use std::path::{Component, Path, PathBuf};
 
 pub(super) struct FormatterGitignore {
     root: PathBuf,
-    matcher: Gitignore,
+    rules: Vec<String>,
 }
 
 impl FormatterGitignore {
@@ -20,6 +20,7 @@ impl FormatterGitignore {
         let root = normalize_path(cwd);
         let path = root.join(".gitignore");
         let mut builder = GitignoreBuilder::new(&root);
+        let mut rules = Vec::new();
         if enabled && provider.is_file(&path) {
             let source = provider.read_file(&path).map_err(|error| {
                 vec![formatter_cli_diagnostic(format!(
@@ -41,15 +42,12 @@ impl FormatterGitignore {
                             index + 1
                         ))]
                     })?;
+                if !line.is_empty() && !line.starts_with('#') {
+                    rules.push(line.to_string());
+                }
             }
         }
-        let matcher = builder.build().map_err(|error| {
-            vec![formatter_cli_diagnostic(format!(
-                "could not compile formatter gitignore {}: {error}",
-                path.display()
-            ))]
-        })?;
-        Ok(Self { root, matcher })
+        Ok(Self { root, rules })
     }
 
     pub(super) fn is_ignored(
@@ -57,7 +55,7 @@ impl FormatterGitignore {
         path: &Path,
         provider: &mut impl SourceProvider,
     ) -> Result<bool, Vec<RenderedDiagnostic>> {
-        if self.matcher.is_empty() {
+        if self.rules.is_empty() {
             return Ok(false);
         }
         let absolute = self.root.join(path);
@@ -75,19 +73,54 @@ impl FormatterGitignore {
                 parent.display()
             ))]
         })?;
-        Ok(self.matches_resolved_path(&parent.join(name)))
+        self.matches_resolved_path(&parent.join(name))
     }
 
-    fn matches_resolved_path(&self, path: &Path) -> bool {
+    fn matches_resolved_path(&self, path: &Path) -> Result<bool, Vec<RenderedDiagnostic>> {
         let absolute = normalize_path(&self.root.join(path));
         // A working-directory gitignore has no authority over an outside target.
         let Ok(relative) = absolute.strip_prefix(&self.root) else {
-            return false;
+            return Ok(false);
         };
-        self.matcher
+        // Skip automaton construction only when a mandatory literal cannot
+        // occur in this path or its parents. The gitignore engine still owns
+        // all possible matches and their ordering.
+        let mut builder = GitignoreBuilder::new(&self.root);
+        let mut relevant = false;
+        for rule in &self.rules {
+            if could_match(rule, relative) {
+                relevant = true;
+                builder.add_line(None, rule).map_err(ignore_error)?;
+            }
+        }
+        if !relevant {
+            return Ok(false);
+        }
+        Ok(builder
+            .build()
+            .map_err(ignore_error)?
             .matched_path_or_any_parents(relative, false)
-            .is_ignore()
+            .is_ignore())
     }
+}
+
+fn ignore_error(error: ignore::Error) -> Vec<RenderedDiagnostic> {
+    vec![formatter_cli_diagnostic(format!(
+        "could not compile formatter gitignore: {error}"
+    ))]
+}
+
+fn could_match(rule: &str, path: &Path) -> bool {
+    let Some(path) = path.to_str() else {
+        return true;
+    };
+    if rule.contains(['\\', '[', ']', '{', '}']) {
+        return true;
+    }
+    let rule = rule.trim_end();
+    let rule = rule.strip_prefix('!').unwrap_or(rule);
+    rule.split(['*', '?', '/'])
+        .all(|literal| path.contains(literal))
 }
 
 fn normalize_path(path: &Path) -> PathBuf {
@@ -125,28 +158,97 @@ mod tests {
             PathBuf::from("project/main.sifr"),
             PathBuf::from("./project/../project/main.sifr"),
         ] {
-            assert!(!ignore.matches_resolved_path(&path), "{}", path.display());
+            assert!(
+                !ignore.matches_resolved_path(&path).unwrap(),
+                "{}",
+                path.display()
+            );
         }
-        assert!(ignore.matches_resolved_path(&root.join("tmp/main.sifr")));
-        assert!(ignore.matches_resolved_path(Path::new("project/a.generated.sifr")));
-        assert!(!ignore.matches_resolved_path(&dir.path().join("outside/a.generated.sifr")));
-        assert!(!ignore.matches_resolved_path(Path::new("../outside/a.generated.sifr")));
+        assert!(
+            ignore
+                .matches_resolved_path(&root.join("tmp/main.sifr"))
+                .unwrap()
+        );
+        assert!(
+            ignore
+                .matches_resolved_path(Path::new("project/a.generated.sifr"))
+                .unwrap()
+        );
+        assert!(
+            !ignore
+                .matches_resolved_path(&dir.path().join("outside/a.generated.sifr"))
+                .unwrap()
+        );
+        assert!(
+            !ignore
+                .matches_resolved_path(Path::new("../outside/a.generated.sifr"))
+                .unwrap()
+        );
     }
 
     #[test]
     fn formatter_discovery_uses_globs_components_and_negation() {
         let dir = tempfile::tempdir().unwrap();
         let ignore = matcher(dir.path(), "build/\n*.sifr\n!keep.sifr\n", true);
-        assert!(ignore.matches_resolved_path(Path::new("nested/build/main.sifr")));
-        assert!(ignore.matches_resolved_path(Path::new("nested/main.sifr")));
-        assert!(!ignore.matches_resolved_path(Path::new("nested/keep.sifr")));
-        assert!(!ignore.matches_resolved_path(Path::new("rebuild/readme.txt")));
+        assert!(
+            ignore
+                .matches_resolved_path(Path::new("nested/build/main.sifr"))
+                .unwrap()
+        );
+        assert!(
+            ignore
+                .matches_resolved_path(Path::new("nested/main.sifr"))
+                .unwrap()
+        );
+        assert!(
+            !ignore
+                .matches_resolved_path(Path::new("nested/keep.sifr"))
+                .unwrap()
+        );
+        assert!(
+            !ignore
+                .matches_resolved_path(Path::new("rebuild/readme.txt"))
+                .unwrap()
+        );
     }
 
     #[test]
     fn formatter_discovery_disabled_ignores_select_all_files() {
         let dir = tempfile::tempdir().unwrap();
         let ignore = matcher(dir.path(), "*\n", false);
-        assert!(!ignore.matches_resolved_path(&dir.path().join("main.sifr")));
+        assert!(
+            !ignore
+                .matches_resolved_path(&dir.path().join("main.sifr"))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn formatter_discovery_literal_filter_agrees_with_complete_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = "/tmp/\n*.sifr\n!keep.sifr\nfoo/**/bar\n[ab].txt\n\\#name\n{one,two}.rs\n";
+        let ignore = matcher(dir.path(), rules, true);
+        let mut full = GitignoreBuilder::new(dir.path());
+        for rule in rules.lines() {
+            full.add_line(None, rule).unwrap();
+        }
+        let full = full.build().unwrap();
+        for name in [
+            "tmp/a.sifr",
+            "keep.sifr",
+            "other/a.sifr",
+            "foo/x/bar/baz",
+            "a.txt",
+            "#name",
+            "one.rs",
+            "unknown.txt",
+        ] {
+            let path = Path::new(name);
+            assert_eq!(
+                ignore.matches_resolved_path(path).unwrap(),
+                full.matched_path_or_any_parents(path, false).is_ignore(),
+                "{name}"
+            );
+        }
     }
 }

--- a/crates/sifr/src/formatter_discovery.rs
+++ b/crates/sifr/src/formatter_discovery.rs
@@ -1,0 +1,152 @@
+//! Interpret the working directory's gitignore at its own path boundary.
+
+use super::check_and_package_commands::formatter_cli_diagnostic;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use sifr_diagnostics::RenderedDiagnostic;
+use sifr_frontend::SourceProvider;
+use std::path::{Component, Path, PathBuf};
+
+pub(super) struct FormatterGitignore {
+    root: PathBuf,
+    matcher: Gitignore,
+}
+
+impl FormatterGitignore {
+    pub(super) fn load(
+        cwd: &Path,
+        enabled: bool,
+        provider: &mut impl SourceProvider,
+    ) -> Result<Self, Vec<RenderedDiagnostic>> {
+        let root = normalize_path(cwd);
+        let path = root.join(".gitignore");
+        let mut builder = GitignoreBuilder::new(&root);
+        if enabled && provider.is_file(&path) {
+            let source = provider.read_file(&path).map_err(|error| {
+                vec![formatter_cli_diagnostic(format!(
+                    "could not read .gitignore for formatter discovery: {error}"
+                ))]
+            })?;
+            for (index, line) in source.as_str().lines().enumerate() {
+                let line = if index == 0 {
+                    line.trim_start_matches('\u{feff}')
+                } else {
+                    line
+                };
+                builder
+                    .add_line(Some(path.clone()), line)
+                    .map_err(|error| {
+                        vec![formatter_cli_diagnostic(format!(
+                            "invalid formatter gitignore {}:{}: {error}",
+                            path.display(),
+                            index + 1
+                        ))]
+                    })?;
+            }
+        }
+        let matcher = builder.build().map_err(|error| {
+            vec![formatter_cli_diagnostic(format!(
+                "could not compile formatter gitignore {}: {error}",
+                path.display()
+            ))]
+        })?;
+        Ok(Self { root, matcher })
+    }
+
+    pub(super) fn is_ignored(
+        &self,
+        path: &Path,
+        provider: &mut impl SourceProvider,
+    ) -> Result<bool, Vec<RenderedDiagnostic>> {
+        if self.matcher.is_empty() {
+            return Ok(false);
+        }
+        let absolute = self.root.join(path);
+        let Some(parent) = absolute.parent() else {
+            return Ok(false);
+        };
+        let Some(name) = absolute.file_name() else {
+            return Ok(false);
+        };
+        // Resolve directory aliases (e.g. macOS /var -> /private/var), but
+        // preserve a file symlink's name for gitignore matching.
+        let parent = provider.canonicalize(parent).map_err(|error| {
+            vec![formatter_cli_diagnostic(format!(
+                "could not resolve formatter discovery path {}: {error}",
+                parent.display()
+            ))]
+        })?;
+        Ok(self.matches_resolved_path(&parent.join(name)))
+    }
+
+    fn matches_resolved_path(&self, path: &Path) -> bool {
+        let absolute = normalize_path(&self.root.join(path));
+        // A working-directory gitignore has no authority over an outside target.
+        let Ok(relative) = absolute.strip_prefix(&self.root) else {
+            return false;
+        };
+        self.matcher
+            .matched_path_or_any_parents(relative, false)
+            .is_ignore()
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sifr_frontend::DiskSourceProvider;
+
+    fn matcher(root: &Path, rules: &str, enabled: bool) -> FormatterGitignore {
+        std::fs::create_dir_all(root).unwrap();
+        std::fs::write(root.join(".gitignore"), rules).unwrap();
+        FormatterGitignore::load(root, enabled, &mut DiskSourceProvider::new()).unwrap()
+    }
+
+    #[test]
+    fn formatter_discovery_root_ignores_do_not_match_host_ancestors() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("tmp/checkout");
+        let ignore = matcher(&root, "/tmp/\n*.generated.sifr\n", true);
+        for path in [
+            root.join("project/main.sifr"),
+            PathBuf::from("project/main.sifr"),
+            PathBuf::from("./project/../project/main.sifr"),
+        ] {
+            assert!(!ignore.matches_resolved_path(&path), "{}", path.display());
+        }
+        assert!(ignore.matches_resolved_path(&root.join("tmp/main.sifr")));
+        assert!(ignore.matches_resolved_path(Path::new("project/a.generated.sifr")));
+        assert!(!ignore.matches_resolved_path(&dir.path().join("outside/a.generated.sifr")));
+        assert!(!ignore.matches_resolved_path(Path::new("../outside/a.generated.sifr")));
+    }
+
+    #[test]
+    fn formatter_discovery_uses_globs_components_and_negation() {
+        let dir = tempfile::tempdir().unwrap();
+        let ignore = matcher(dir.path(), "build/\n*.sifr\n!keep.sifr\n", true);
+        assert!(ignore.matches_resolved_path(Path::new("nested/build/main.sifr")));
+        assert!(ignore.matches_resolved_path(Path::new("nested/main.sifr")));
+        assert!(!ignore.matches_resolved_path(Path::new("nested/keep.sifr")));
+        assert!(!ignore.matches_resolved_path(Path::new("rebuild/readme.txt")));
+    }
+
+    #[test]
+    fn formatter_discovery_disabled_ignores_select_all_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let ignore = matcher(dir.path(), "*\n", false);
+        assert!(!ignore.matches_resolved_path(&dir.path().join("main.sifr")));
+    }
+}

--- a/crates/sifr/src/formatter_discovery.rs
+++ b/crates/sifr/src/formatter_discovery.rs
@@ -8,7 +8,12 @@ use std::path::{Component, Path, PathBuf};
 
 pub(super) struct FormatterGitignore {
     root: PathBuf,
-    rules: Vec<String>,
+    rules: Vec<Rule>,
+}
+
+struct Rule {
+    source: String,
+    mandatory_literal: Option<String>,
 }
 
 impl FormatterGitignore {
@@ -43,7 +48,10 @@ impl FormatterGitignore {
                         ))]
                     })?;
                 if !line.is_empty() && !line.starts_with('#') {
-                    rules.push(line.to_string());
+                    rules.push(Rule {
+                        source: line.to_string(),
+                        mandatory_literal: mandatory_literal(line),
+                    });
                 }
             }
         }
@@ -90,7 +98,7 @@ impl FormatterGitignore {
         for rule in &self.rules {
             if could_match(rule, relative) {
                 relevant = true;
-                builder.add_line(None, rule).map_err(ignore_error)?;
+                builder.add_line(None, &rule.source).map_err(ignore_error)?;
             }
         }
         if !relevant {
@@ -110,17 +118,24 @@ fn ignore_error(error: ignore::Error) -> Vec<RenderedDiagnostic> {
     ))]
 }
 
-fn could_match(rule: &str, path: &Path) -> bool {
-    let Some(path) = path.to_str() else {
-        return true;
-    };
+// Compute this necessary condition once, rather than rescanning every rule
+// for each selected source. Escaped or compound syntax stays with the engine.
+fn mandatory_literal(rule: &str) -> Option<String> {
     if rule.contains(['\\', '[', ']', '{', '}']) {
-        return true;
+        return None;
     }
     let rule = rule.trim_end();
     let rule = rule.strip_prefix('!').unwrap_or(rule);
     rule.split(['*', '?', '/'])
-        .all(|literal| path.contains(literal))
+        .max_by_key(|literal| literal.len())
+        .map(str::to_string)
+}
+
+fn could_match(rule: &Rule, path: &Path) -> bool {
+    match (&rule.mandatory_literal, path.to_str()) {
+        (Some(literal), Some(path)) => path.contains(literal),
+        _ => true,
+    }
 }
 
 fn normalize_path(path: &Path) -> PathBuf {
@@ -226,7 +241,7 @@ mod tests {
     #[test]
     fn formatter_discovery_literal_filter_agrees_with_complete_engine() {
         let dir = tempfile::tempdir().unwrap();
-        let rules = "/tmp/\n*.sifr\n!keep.sifr\nfoo/**/bar\n[ab].txt\n\\#name\n{one,two}.rs\n";
+        let rules = "/tmp/\n*.sifr\n!keep.sifr\nfoo/**/bar\n[ab].txt\n\\#name\n{one,two}.rs\né?*.log\nspace\\ \n";
         let ignore = matcher(dir.path(), rules, true);
         let mut full = GitignoreBuilder::new(dir.path());
         for rule in rules.lines() {
@@ -242,6 +257,10 @@ mod tests {
             "#name",
             "one.rs",
             "unknown.txt",
+            "other/foo/x/bar/a.txt",
+            "éx.log",
+            "space ",
+            "nested/space ",
         ] {
             let path = Path::new(name);
             assert_eq!(

--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -24,6 +24,7 @@ mod diagnostic_rendering_and_run;
 mod diagnostic_test_sink;
 mod explain_cli;
 mod formatter_cli;
+mod formatter_discovery;
 mod host_tool_cli;
 mod host_tool_sandbox;
 mod lint_cli;

--- a/crates/sifr/tests/formatter_discovery.rs
+++ b/crates/sifr/tests/formatter_discovery.rs
@@ -1,0 +1,49 @@
+//! Exercise discovery through the real CLI, including a known drift sentinel.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn check(root: &Path, target: &Path, extra: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_sifr"))
+        .current_dir(root)
+        .args(["fmt", "--check", "--no-cache"])
+        .args(extra)
+        .arg(target)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn formatter_discovery_absolute_and_relative_paths_detect_the_same_drift() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("tmp/checkout");
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(root.join(".gitignore"), "/tmp/\n").unwrap();
+    std::fs::write(project.join("main.sifr"), "def main( ):\n    pass\n").unwrap();
+    for target in [project.as_path(), Path::new("project")] {
+        let result = check(&root, target, &[]);
+        assert_eq!(result.status.code(), Some(1), "{result:?}");
+        assert!(String::from_utf8_lossy(&result.stderr).contains("SIFR-FMT-0001"));
+    }
+}
+
+#[test]
+fn formatter_discovery_preserves_explicit_file_and_exclusion_controls() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let project = root.join("ignored");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(root.join(".gitignore"), "/ignored/\n").unwrap();
+    let file = project.join("main.sifr");
+    std::fs::write(&file, "def main( ):\n    pass\n").unwrap();
+    for (target, args, expected) in [
+        (project.as_path(), vec![], 0),
+        (project.as_path(), vec!["--no-respect-gitignore"], 1),
+        (file.as_path(), vec![], 1),
+        (file.as_path(), vec!["--force-exclude"], 0),
+    ] {
+        let result = check(root, target, &args);
+        assert_eq!(result.status.code(), Some(expected), "{result:?}");
+    }
+}

--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -2,6 +2,66 @@
 
 Status: active
 
+## Item12K-B20 qualification candidate: discovery corrected, causal acceptance open (2026-09-08)
+
+B20 alone owns producer-boundary attribution and causal correction along
+`formatter-corpus-001-project-check`: CLI/config/discovery/file I/O/parser/
+formatter, process/runtime and measurement accounting. Owner
+[#3776](https://github.com/sifr-lang/sifr/issues/3776) remains OPEN. This is
+NOT closure, NOT merge approval, and NOT original3717/corpus48 delivery.
+Base/full predecessor record is `fb66ed00d7672b9f5c623e3291d1b8498d50ec45`;
+owned clone `/private/tmp/sifr-b20.bj6Au6/sifr`, sibling `evidence`, branch
+`codex/item12k-b20-attribution`. Parent and all predecessor trees/targets remain
+read-only. All16 gitlinks and corpus8bcbe7ab are retained; excluded8ad089 is out.
+
+The concrete discovery defect is proven: root `.gitignore` `/tmp/` was reduced
+to an unanchored substring and matched `/private/tmp/` in an absolute host path.
+The exact benchmark therefore checked zero source files. Six LLDB launches
+reached discovery but never parsing/formatting; a clean/drift × absolute/relative
+four-process intervention produced exits0/0/0/1. The correction applies the
+working-directory ignore at its own relative boundary, handles directory aliases,
+preserves explicit-file/force-exclude/no-respect controls, and uses the existing
+ignore engine for patterns/ordering. Absolute and relative drift checks now both
+fail1. Production checkpoints a0d0122 and d294 correct matching and eager matcher
+construction; aff93db2ff199488d191b0e32584f9a4c4a0cbbd precomputes the mandatory
+literal filter after measured repeated rule scans. Focused unit/CLI regressions
+are included. No thresholds, baselines, fixtures, retries or workload shrinkage.
+
+Startup variability is not claimed solved by this independent discovery fix.
+Experiment09's five measured in-image snapshots put26.04M..30.36M instructions
+before the first Sifr initializer, while main-to-CLI-completion stays near17.8M;
+both intended files actually reach formatting. Raw/external counters are retained.
+The process/core/address-layout controls did not establish a corrective mechanism.
+Suspended-spawn10 samples only thousands of instructions before user entry, but
+its stable observations are not a production remedy. System Trace11 identifies
+dyld opcode rebasing with107 copy-on-write/108 file-backed faults. Diagnostic
+chained-link comparison12 lowers startup mean by about6M but retains variability;
+the link flag is NOT adopted. CPU profiles13 are sparse and their effective
+high-frequency setting is0; timer profile14 confirms100us and kernel stacks,
+including SHA-256/VM/security work, without proving which mechanism causes warm
+variation. No unavailable host intervention or specific OS defect is established.
+All temporary source instrumentation is removed; patches/binaries/traces remain
+outside Git. No further granular profiling or unchanged acceptance retries.
+
+Experiment02 chronology is explicit:02 symbol-resolution failure launched0
+targets;02b embedded-Python host-monitor setup failure launched0;02c was separately
+registered before execution with external system-Python monitoring and launched
+exactly6. The old coordinator snapshot of unused target budget preceded02c and
+is not current. Earlier stop/no-retry language stopped those failed setups; no
+target acquisition was retried unchanged. All setup failures are retained.
+
+Final named qualification is registered in sibling
+`evidence/final-qualification-registration.md`: benchmark/budget selftests,
+focused formatter-discovery unit/CLI tests, Rust formatting, file-size/diff guards,
+then exactly the representative benchmark-subset/dependent budget-subset using
+unchanged controlled-work criteria. No redundant standalone formatter acquisition.
+`sifr_format` has no final source diff. One exact-SHA Opus review of full actual
+B20 acceptance, at most one remediation; no third review. Compiler/lock edge
+changed, so at most one merge-profile gate only after qualification/approval;
+skip create-pr gate, no second gate. Remaining causal acceptance stays explicit
+even if a targeted test passes. At this record, final tests/review/gates are
+UNEXECUTED; no PASS or completion is inferred from diagnostic controls.
+
 ## Item12K-B19 terminal: incomplete causal investigation, not merged (2026-09-08)
 
 Status: NEEDS-NEW-SCOPE / NOT COMPLETE / NOT MERGED. B19 owner


### PR DESCRIPTION
## Scope

Only item12K-B20; stacked on exact B19 full record
`fb66ed00d7672b9f5c623e3291d1b8498d50ec45`. Candidate
`ac4c277b30c6cac046ab1746fe4020c04df7eaf1`.

Correct formatter discovery: root `.gitignore` must not exclude files merely
because the absolute checkout path contains `/tmp/`. Preserve explicit-file,
force-exclude and no-respect controls; add focused regression coverage and
avoid eager irrelevant matcher construction/repeated rule scans.

NOT full B20 closure or merge approval. Startup variability was localized before
Sifr initialization, but no complete causal runtime correction was established.
Diagnostic chained linking lowered mean work but retained variation and was not
adopted. All temporary probes are removed; no workload/budget/limit weakening.
Owner https://github.com/sifr-lang/sifr/issues/3776 remains open. No original
PR3717/corpus48 main delivery.

## Exact-candidate evidence

- PASS benchmark/budget selftests;4 discovery unit tests;2 CLI regressions;
  cargo fmt; file-size guardrail; working-tree and base diff checks.
- One representative subset attempt: INVALID_ISOLATION_ABORTED. My launcher
  omitted an owned TMPDIR. First project-build warmup timed out at120004.340ms;
  time wrapper ended but owned compiler child85215 survived, overlapping the
  next sample3862 in ownedPGID84008. Descendant Cargo targeted shared system-temp
  Rust probe storage. No external cache defect is inferred from my omission.
- Exact owned group stopped/snapshotted/terminated; no shared cleanup. Formatter,
  remaining cases and dependent budget were UNREACHED. No canonical aggregate
  report or controlled-host PASS is claimed. No replay; zero gates.

Preserved evidence root `/private/tmp/sifr-b20.bj6Au6/evidence`: final-tests,
final-profile/abort-record.json and raw timeout/process receipt, all registrations,
raw observations and profiler traces. Exact-SHA read-only Opus review pending.
Parent will scope any later owner from the evidence; no next-item implementation.
