### PR TITLE
Require permanent designated-maintainer approval for stable publication

### DIFF
--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -147,17 +147,8 @@ jobs:
       SITE_WORKFLOW_RULESET_ID: "19899766"
       SITE_WORKFLOW_RULESET_UPDATED_AT: "2026-07-28T13:22:41.496Z"
       SITE_WORKFLOW_SHA256: a9360c82395f6e9d9822f201e56cc0f2eabab1bacda01c31e4e9f22d0202b3af
-      SINGLE_MAINTAINER_APPROVAL_WAIVER: plans/releases/single-maintainer-approval-waiver.json
-      SINGLE_MAINTAINER_APPROVAL_WAIVER_SHA256: b9630cc060ca281946da76a9cb9bc67564759c8d5446b6a33157a7d138080008
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: env.STABLE_MUTATION_OPERATION != 'true'
-        with:
-          ref: ${{ inputs.source_commit }}
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: env.STABLE_MUTATION_OPERATION == 'true'
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -243,25 +234,15 @@ jobs:
             exit 2
           }
           if [[ "${GOVERNANCE_MODE}" == bootstrap-* ]]; then
-            waiver_sha256="$(
-              sha256sum "${SINGLE_MAINTAINER_APPROVAL_WAIVER}" | awk '{print $1}'
-            )"
-            test "${waiver_sha256}" = "${SINGLE_MAINTAINER_APPROVAL_WAIVER_SHA256}" || {
-              echo "::error::single-maintainer approval waiver digest drifted"
-              exit 2
-            }
-            gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" \
-              >protected-prepare/approvals.json
             approval_json="$(
               scripts/distribution/release_governance.py resolve-publication-approvers \
-                --approvals protected-prepare/approvals.json \
                 --initiator "${GITHUB_TRIGGERING_ACTOR}" \
                 --environment stable-release \
                 --repository "${GITHUB_REPOSITORY}" \
                 --operation "${GOVERNANCE_MODE}" \
-                --single-maintainer-waiver "${SINGLE_MAINTAINER_APPROVAL_WAIVER}" \
-                --expected-waiver-sha256 "${SINGLE_MAINTAINER_APPROVAL_WAIVER_SHA256}" \
+                --run-id "${GITHUB_RUN_ID}" --run-attempt "${GITHUB_RUN_ATTEMPT}" \
+                --evidence protected-prepare/summary.json \
+                --expected-evidence-sha256 "${PREPARE_SUMMARY_SHA256}" \
                 --include-policy
             )"
             {
@@ -831,12 +812,6 @@ jobs:
           VSCE_BIN: ${{ github.workspace }}/stable-source/editor_integrations/vscode/node_modules/.bin/vsce
         run: |
           set -euo pipefail
-          approval_waiver_args=()
-          if [[ "${GOVERNANCE_MODE}" == "ga-activation" ]]; then
-            approval_waiver_args=(
-              --approval-waiver "${SINGLE_MAINTAINER_APPROVAL_WAIVER}"
-            )
-          fi
           scripts/distribution/run_stable_publication.sh \
             --operation "${GOVERNANCE_MODE}" --mode "${PUBLICATION_MODE}" \
             --repository "${GITHUB_REPOSITORY}" --evidence-root stable-evidence \
@@ -849,8 +824,6 @@ jobs:
             --workflow-ref "${GITHUB_REF}" --workflow-commit "${GITHUB_SHA}" \
             --run-id "${GITHUB_RUN_ID}" --run-attempt "${GITHUB_RUN_ATTEMPT}" \
             --initiator "${GITHUB_TRIGGERING_ACTOR}" \
-            "${approval_waiver_args[@]}" \
-            --expected-approval-waiver-sha256 "${SINGLE_MAINTAINER_APPROVAL_WAIVER_SHA256}" \
             --site-repository "${SITE_REPOSITORY}" \
             --site-workflow "${SITE_WORKFLOW}" \
             --site-workflow-ref "${SITE_WORKFLOW_REF}" \

--- a/.github/workflows/schema-bootstrap-recovery.yml
+++ b/.github/workflows/schema-bootstrap-recovery.yml
@@ -131,7 +131,8 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/actions/runs/${ORIGINAL_RUN_ID}/approvals" \
             >original-approvals.json
           scripts/distribution/release_governance.py \
-            resolve-publication-approvers \
+            inspect-historical-publication-approval \
+            --original-run original-run.json \
             --approvals original-approvals.json \
             --initiator "${original_initiator}" \
             --environment stable-release \
@@ -262,7 +263,8 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/actions/runs/${ORIGINAL_RUN_ID}/approvals" \
             >original-approvals.json
           scripts/distribution/release_governance.py \
-            resolve-publication-approvers \
+            inspect-historical-publication-approval \
+            --original-run original-run.json \
             --approvals original-approvals.json \
             --initiator "${original_initiator}" \
             --environment stable-release \
@@ -280,19 +282,15 @@ jobs:
             exit 2
           }
 
-          gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" \
-            >recovery-approvals.json
           scripts/distribution/release_governance.py \
             resolve-publication-approvers \
-            --approvals recovery-approvals.json \
             --initiator "${GITHUB_TRIGGERING_ACTOR}" \
             --environment stable-release \
             --repository "${GITHUB_REPOSITORY}" \
-            --operation bootstrap-index \
-            --single-maintainer-waiver \
-              plans/releases/single-maintainer-approval-waiver.json \
-            --expected-waiver-sha256 "${WAIVER_SHA256}" \
+            --operation bootstrap-recovery \
+            --run-id "${GITHUB_RUN_ID}" --run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --evidence protected-prepare/summary.json \
+            --expected-evidence-sha256 "${EXPECTED_RECOVERY_SUMMARY_SHA256}" \
             --include-policy >recovery-approval-decision.json
 
           [[ -n "${SITE_TOKEN}" ]] || {

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -1765,12 +1765,14 @@ Generation reservation, exact resume, site reconciliation, public
 install/update/recovery smoke, Marketplace verification, and release/incident
 sign-off remain fail-closed. The one-time schema-epoch bootstrap is separately
 bound to the exact opaque pre-epoch asset identity and protected approval. The
-user-directed single-maintainer exception for that bootstrap and first GA is
-itself a canonical, expiring governance artifact. It permits only the named
-owner and those three operations, requires a real `stable-release` approval,
-is pinned by digest, prefers a distinct approval when one is available, and binds
-the selected approval policy plus initiator into retained evidence; normal and
-incident operations require distinct approval. The
+permanent live `solo-maintainer` policy requires explicit GitHub-recorded
+`stable-release` approval by `yaseralnajjar` for each exact run/attempt and
+prepare-summary evidence, including normal, rollback, incident, and recovery
+operations. Self-review is allowed and admin bypass is disabled. Governance
+executes from the workflow revision and checks the designated reviewer and
+current run before publication. Old waiver/report/signoff bytes remain immutable
+historical evidence; historical inspection evaluates the original event time
+and cannot authorize a new run. The
 post-index bootstrap recovery path revalidates the failed mutation and site
 attempts, both protected approvals, the already-live generation-1 bytes, and
 the reproducible site inputs before retrying only site publication and public

--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -686,16 +686,17 @@ and deployed commit. Each protected run retains its own
 `stable-release-signoff-<version>-attempt-<run>-<attempt>.json`, so a completed
 sign-off never has to be rewritten and a later resume remains convergent.
 
-The temporary initial-stable single-maintainer exception is a canonical, expiring
-waiver under `plans/releases/`. It authorizes only `bootstrap-alpha`,
-`bootstrap-index`, and first `ga-activation`; the protected job must still
-pause for a GitHub-recorded `stable-release` approval by the named owner and
-admin bypass remains disabled. Bootstrap evidence and stable sign-off record
-the approval mode and waiver SHA-256. The workflow pins the checked-in waiver
-digest, prefers any distinct environment reviewer over owner self-approval,
-and derives the retained mode from that selected approval set before
-publication. `normal`, `rollback`, and `incident-roll-forward` cannot select
-the waiver.
+Every stable publication, bootstrap, recovery, rollback, and incident roll-forward
+requires explicit GitHub-recorded approval by `yaseralnajjar` for its exact run,
+attempt, and reviewer-visible release evidence. The `stable-release` environment
+designates only that user, permits self-review, and disables admin bypass.
+The canonical live policy is `solo-maintainer`, with `waiver_sha256: none`.
+Governance runs from the workflow revision; selected release source and evidence
+retain their own exact commits. The resolver fetches the current run, environment
+configuration, and approval history from GitHub and checks the prepare-summary
+digest before publication. Chat authorization and agent review cannot approve a
+release run. The expired waiver remains immutable historical evidence and has
+no live selection path.
 
 `rollback` and `incident-roll-forward` enter the same protected `publish` job
 from an exact incident evidence commit. The read-only prepare path verifies the
@@ -737,12 +738,8 @@ migration, or fallback is retained.
 
 Both bootstrap stages run in the `stable-release` environment. Publish reads
 the workflow run's GitHub approval history and fails unless it contains an
-authorized environment reviewer. The default requires a login distinct from
-`GITHUB_TRIGGERING_ACTOR`; the canonical unexpired single-maintainer waiver
-allows the named owner only for the two bootstrap stages. Its checked-in digest
-is pinned by the protected workflow, and any distinct reviewer takes precedence
-over the waiver. The final evidence binds the selected approval mode and waiver
-digest, plus the alpha-stage evidence
+explicit approval by `yaseralnajjar` under the live policy above. The final
+evidence binds the selected approval policy plus the alpha-stage evidence
 digest, run/attempt, initiator, approvers, and prepare-summary digest as well as
 the final stage's own prepare-summary digest. The final stage
 reserves `channels-generation-1.json`, replaces only `channels.json`,
@@ -779,8 +776,7 @@ Activation advances the live index to generation 2; doing that first
 intentionally makes the generation-1 recovery precondition fail and forfeits
 the one-time bootstrap evidence. For candidate `0.1.0`, protected GA prepare
 must begin before `2026-08-21T02:17:30Z` so the qualification still has the
-required seven full days remaining. The later single-maintainer-waiver expiry
-does not extend that candidate deadline.
+required seven full days remaining. The permanent approval policy does not extend that historical candidate deadline.
 
 Run the protected bootstrap and incident-specific suites, plus the capability
 demo, with:

--- a/internal_docs/stable_incident_response.md
+++ b/internal_docs/stable_incident_response.md
@@ -10,9 +10,10 @@ release-publication workflow.
 
 - Release owner: `release/distribution`.
 - Incident owner: `release/distribution`.
-- Approval authority: a protected `stable-release` environment approval from
-  `release/distribution` for a run not initiated by the same person. Initial
-  and resume attempts require distinct recorded approvals.
+- Approval authority: explicit GitHub-recorded `stable-release` approval by
+  `yaseralnajjar` for the exact run, attempt, and release evidence. Self-review
+  is allowed; admin bypass is disabled. Initial and resume attempts each
+  require approval. Chat authorization and agent review are not release approval.
 - Acknowledgement target: 30 minutes from a qualifying trigger. This is
   deliberately longer than the bounded 20-minute site-deployment wait, so a
   terminal site timeout can release the metadata lease and be included in the

--- a/plans/issues/active/ad-hoc-distinct-release-reviewer-restoration.md
+++ b/plans/issues/active/ad-hoc-distinct-release-reviewer-restoration.md
@@ -1,20 +1,15 @@
-# Ad Hoc Issue: Distinct Release Reviewer Restoration
+# Ad Hoc Issue: Permanent Solo-Maintainer Release Approval
 
 ## Status
 
-Active blocking follow-up. The user-directed Phase 40 single-maintainer
-approval exception expired on 2026-08-27.
+Implementation owned by latest-stable convergence Item 65. On 2026-09-08 the
+user permanently superseded the distinct-person requirement: `stable-release`
+requires explicit GitHub-recorded approval by `yaseralnajjar`, permits self-review,
+and disables admin bypass. This decision approves policy only, not any release
+run or publication. No second-person invitation is a prerequisite.
 
-The repository currently has one maintainer. Phase 40 bootstrap and first-GA
-publication may therefore use the canonical, expiring
-`plans/releases/single-maintainer-approval-waiver.json`. The exception does
-not remove protected approval: `stable-release` must require a GitHub-recorded
-approval, admin bypass must be disabled, the approver must equal the named
-owner, and retained evidence must bind the waiver digest.
-
-The waiver expires on 2026-08-27 and authorizes only `bootstrap-alpha`,
-`bootstrap-index`, and `ga-activation`. It cannot authorize `normal`,
-`rollback`, or `incident-roll-forward`.
+Historical waiver, report, and signoff bytes and digests remain immutable.
+The expiry failure below is retained evidence, not a reason to renew the waiver.
 
 ## Blocking Evidence
 
@@ -32,34 +27,22 @@ The report SHA-256 is
 The evidence is in the
 [#3551 gate comment](https://github.com/sifr-lang/sifr/pull/3551#issuecomment-5432642050).
 
-Do not extend the waiver or weaken its expiry check. A distinct human reviewer
-must accept repository access. The `stable-release` environment must then use
-that reviewer with self-review and admin bypass disabled. Latest-stable Item
-31 remains draft and cannot consume a second merge gate under its current
-phase rules.
+Do not extend the waiver or alter historical identities. Latest-stable Item 31
+remains draft and cannot consume a second merge gate under its current rules.
 
-## Scope
+## Scope and acceptance
 
-- Add a genuinely distinct human release/distribution reviewer with repository
-  access.
-- Configure `stable-release` with that user or team as required reviewer,
-  `prevent_self_review: true`, and admin bypass disabled.
-- Keep historical bootstrap and first-GA evidence readable with its exact
-  single-maintainer waiver identity.
-- Remove the live waiver input from publication workflows after the environment
-  has a distinct reviewer.
-- Prove self-approval fails for every future stable and incident operation.
+- Require the designated maintainer for every exact protected run/attempt and
+  release evidence, including normal, rollback, incident roll-forward, and recovery.
+- Read back `stable-release`: reviewer `yaseralnajjar`,
+  `prevent_self_review: false`, `can_admins_bypass: false`.
+- Remove live waiver selection from workflows and direct approval entrypoints.
+- Preserve historical validity at the original event time separately from new-use
+  authorization; do not reconstruct missing original receipts.
+- Reject absent/non-designated approvals, mismatched run/evidence identities,
+  bypass-enabled configuration, and new use of the retired waiver.
+- Qualify Item 65 with its named focused suites, one exact-SHA Opus review
+  (at most one remediation), and one final-candidate merge gate.
 
-## Acceptance Criteria
-
-- [ ] A distinct reviewer or release/distribution team has accepted repository
-  access.
-- [ ] `stable-release` requires that reviewer/team, prevents self-review, and
-  disallows admin bypass.
-- [ ] Bootstrap and first-GA evidence produced under the expired waiver remains
-  canonical and validates as historical evidence.
-- [ ] No workflow can select the expired waiver for a new publication.
-- [ ] Normal, rollback, and incident roll-forward operations reject initiating
-  owner self-approval.
-- [ ] Focused distribution suites, workflow contracts, the authoritative local
-  gates, and repeated agent review pass.
+Completion and exact evidence are recorded in
+[latest-stable convergence](ad-hoc-latest-stable-release-convergence.md).

--- a/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
+++ b/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
@@ -1,5 +1,48 @@
 # Ad Hoc Phase: Latest Stable Release Convergence
 
+### Item 65 — permanent solo-maintainer approval migration
+
+State: implementation resumed from main `6bd085f40e42c04b1d81a09ce1660a392541bd1e`,
+adopting preserved candidate `3c481750c977d182464cdd90932843eabaedbc48`.
+Items 66 and 67 have discharged the recorded qualification prerequisites.
+The 2026-09-08 user policy decision supersedes the distinct-human E1 prerequisite.
+The sole live policy requires explicit GitHub-recorded approval by `yaseralnajjar`
+for every exact stable publication run/attempt and release evidence. Self-review
+is allowed; admin bypass remains disabled. This authorizes policy implementation,
+not release approval or publication.
+
+Owned scope: release governance validators, schemas, signoff, fixtures/contracts,
+maintained publication/recovery workflows and directly invoked approval scripts,
+current policy docs and E1. The publication root must execute governance from
+the workflow revision; release-source/evidence checkouts retain exact commits.
+The corresponding exact `NON_SOURCE_CHECKOUTS` identity and mutations are owned.
+No parser weakening, compiler/package, custody, or performance repair is in scope.
+Historical waiver/report/signoff bytes and identities remain immutable; historical
+validation uses the original event time and cannot authorize new publication.
+
+Acceptance: remove all live waiver selection; reject absent/non-designated
+approval, mismatched run/attempt/evidence, bypass-enabled configuration, and
+new use of retired waiver flags. Read back `stable-release` with designated
+reviewer `yaseralnajjar`, `prevent_self_review: false`, and
+`can_admins_bypass: false`. Preserve unrelated environment settings.
+
+Named focused suites: `distribution_release: epoch-bootstrap, qualification,
+evidence-custody, incident-governance, protected-drill, stable-prepare,
+stable-publish-primitives, stable-publication`; the stable publication workflow
+contract; submodule ownership guard and self-test; diff/file-size/local doc-link
+checks. If required to resolve the precise E2 uncertainty, only
+`coverage_matrix: readiness` is an additional allowed preflight. Item 66 has
+discharged the feature-sensitive Rusqlite assertion prerequisite. An actual
+external qualification failure must be recorded and handed to its owner.
+
+One exact-SHA Opus review, at most one remediation review, then one merge-profile
+gate on the final candidate because workflows/fixtures change. Skip create-pr;
+do not rerun a consumed gate. Coordinate heavy host capacity before Cargo or
+broad validation. Preserve the original Kafka and partial Item 65 worktrees.
+The owned continuation worktree is
+`/private/tmp/sifr-item65-delivery.zoLQU3/codebase`, branch
+`codex/solo-maintainer-approval-item65-delivery`.
+
 Status: active on 2026-09-08. Items 0–30, 36–39, 54–55 and 66–67 are complete. Item 39 closed
 the runner dependency/API invariants; independent work can proceed under the continuation
 ledger while Kafka and gate-bearing items retain explicit prerequisites.
@@ -170,9 +213,9 @@ instructions below; historical gate and review evidence remains unchanged.
 - Return merged, blocked, or needs-new-scope, with item ID, PR, SHA, evidence,
   and blocker. Do not start or implement another item. Record a new mechanism
   defect as a later item rather than adding review rounds.
-- Preserve the stable-release human-reviewer and expiring-waiver mechanisms.
-  The latest user direction is to wait for human approval; do not renew the
-  expired waiver or substitute automated review for the required human.
+- Preserve mandatory GitHub-recorded stable-release approval by the designated
+  human under Item 65's permanent policy. Never renew the historical waiver or
+  substitute automated review or chat authorization for release approval.
 - Whole-phase Opus review belongs only to one docs-only closer, dispatched
   after every implementation item is merged. Item 35's implementation-bearing
   audit follow-ups must be separate, bounded items before that closer.
@@ -567,7 +610,7 @@ transferred into this phase:
 
 | ID | Owner and current state | Required evidence / consumers |
 | --- | --- | --- |
-| E1 | [Distinct release reviewer restoration](ad-hoc-distinct-release-reviewer-restoration.md), blocked on a human | GitHub currently requires only `yaseralnajjar`, self-review is allowed, admin bypass is disabled, and invitations are empty. Wait for the required distinct human approval/access and protected-environment restoration. Preserve expiring-waiver and human-review mechanisms; never renew the waiver. This owner also must separate historical waiver validation from new-use expiry in `verification/areas/distribution_release/governance/approval_waiver_selftest.py`, whose real-waiver self-test currently requires it to be unexpired. Named qualification: distribution_release suites `epoch-bootstrap`, `qualification`, `evidence-custody`, `protected-drill`, `stable-prepare`, `stable-publication`, plus `bash verification/areas/distribution_release/cases/stable_publication_workflow_contract.sh`. The owner's existing rules govern external work. Blocks any candidate whose required merge gate would encounter the recorded expiry failure. |
+| E1 | [Permanent solo-maintainer release approval](ad-hoc-distinct-release-reviewer-restoration.md), owned by Item 65 | The user's 2026-09-08 policy decision supersedes the distinct-person requirement. Every exact stable publication run/attempt and evidence requires explicit GitHub-recorded approval by `yaseralnajjar`; self-review is allowed and admin bypass is disabled. Item 65 owns live validators, workflows/direct entrypoints, schemas/signoff, tests, and current docs. Retained waiver/report/signoff bytes remain immutable historical evidence, checked at their original event time. No waiver renewal or publication authorization is implied. Qualification remains pending until Item 65's exact candidate passes its named suites, review, and single merge gate. |
 | E2 | PR #3717 / issue #3744 and the Python qualification issue, externally owned and unmerged | Require an actual merged implementation SHA and its attributable qualification, not a draft or body claim. Named affected suites from that owner: python_interop `binding-authoring`, `callback-examples`, `async-declaration-examples`, `async-context-examples`, and coverage_matrix `readiness`. Blocks dependent compiled Python integration and a full merge gate while those known prerequisite failures remain on main. No repair, merge, gate retry, or reset of their histories is authorized here. |
 
 E1/E2 are **merge-readiness prerequisites** for gate-bearing rows, not technical
@@ -3295,9 +3338,9 @@ single-maintainer approval waiver because it expired at
 Neither gate was rerun. The exact evidence is in the
 [#3551 gate comment](https://github.com/sifr-lang/sifr/pull/3551#issuecomment-5432642050).
 
-The blocker belongs to
-`plans/issues/active/ad-hoc-distinct-release-reviewer-restoration.md`. A
-distinct human release reviewer must accept repository access, and the
-protected `stable-release` environment must require that reviewer. Do not
-extend the expired waiver or add a fallback. Item 31 cannot consume a second
-merge gate under the current phase rules.
+The historical blocker belongs to
+`plans/issues/active/ad-hoc-distinct-release-reviewer-restoration.md`.
+Item 65's user-approved permanent policy supersedes the earlier second-person
+requirement. It still requires explicit GitHub-recorded approval by the
+designated maintainer for each publication. Do not extend the historical waiver.
+Item 31 cannot consume a second merge gate under the current phase rules.

--- a/scripts/check_submodule_ownership.py
+++ b/scripts/check_submodule_ownership.py
@@ -128,7 +128,7 @@ end
 class NonSourceCheckout:
     workflow: str
     job: str
-    condition: str
+    condition: str | None
     inputs: dict[str, object]
     purpose: str
 
@@ -139,17 +139,9 @@ class NonSourceCheckout:
 # Match the full input identity, job, and condition, never a step name or ordinal.
 NON_SOURCE_CHECKOUTS = (
     NonSourceCheckout(
-        "release-publication.yml", "publish",
-        "env.STABLE_MUTATION_OPERATION != 'true'",
-        {"ref": "${{ inputs.source_commit }}", "fetch-depth": 0,
-         "persist-credentials": False},
-        "preview/bootstrap governance and prebuilt release artifacts",
-    ),
-    NonSourceCheckout(
-        "release-publication.yml", "publish",
-        "env.STABLE_MUTATION_OPERATION == 'true'",
+        "release-publication.yml", "publish", None,
         {"fetch-depth": 0, "persist-credentials": False},
-        "stable publication governance scripts at the workflow revision",
+        "publication governance scripts at the workflow revision",
     ),
     NonSourceCheckout(
         "release-publication.yml", "publish",
@@ -420,12 +412,21 @@ def run_workflow_self_tests() -> None:
     for owner in NON_SOURCE_CHECKOUTS:
         at = REPO_ROOT / ".github/workflows" / owner.workflow
         step = {"uses": "actions/checkout@v7", "if": owner.condition, "with": owner.inputs}
+        if owner.condition is None:
+            del step["if"]
 
         def document(candidate: dict[str, object], job: str = owner.job) -> str:
             # JSON is a YAML subset and keeps exact expressions quoted.
             return json.dumps({"jobs": {job: {"steps": [candidate]}}})
 
         check(owner.purpose, document(step), accepted=True, at=at)
+        if owner.workflow == "release-publication.yml" and not owner.condition:
+            check("governance cannot select old source policy", document({
+                **step, "with": {**owner.inputs, "ref": "${{ inputs.source_commit }}"},
+            }), at=at)
+            check("retired conditional governance checkout", document({
+                **step, "if": "env.STABLE_MUTATION_OPERATION == 'true'",
+            }), at=at)
         check("wrong workflow: " + owner.purpose, document(step))
         check("wrong job: " + owner.purpose, document(step, "other"), at=at)
         check("wrong condition: " + owner.purpose, document({**step, "if": "true"}), at=at)

--- a/scripts/distribution/materialize_schema_bootstrap_evidence.py
+++ b/scripts/distribution/materialize_schema_bootstrap_evidence.py
@@ -27,7 +27,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--approval-mode",
         required=True,
-        choices=("distinct-reviewer", "single-maintainer-waiver"),
+        choices=("distinct-reviewer", "single-maintainer-waiver", "solo-maintainer"),
     )
     parser.add_argument("--approval-waiver-sha256", required=True)
     parser.add_argument("--approvers-json", required=True)

--- a/scripts/distribution/materialize_stable_publication.py
+++ b/scripts/distribution/materialize_stable_publication.py
@@ -43,7 +43,7 @@ def parse_args() -> argparse.Namespace:
     signoff.add_argument(
         "--approval-mode",
         required=True,
-        choices=("distinct-reviewer", "single-maintainer-waiver"),
+        choices=("distinct-reviewer", "single-maintainer-waiver", "solo-maintainer"),
     )
     signoff.add_argument("--approval-waiver-sha256", required=True)
     signoff.add_argument("--out", type=Path, required=True)

--- a/scripts/distribution/release_governance.py
+++ b/scripts/distribution/release_governance.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+from datetime import datetime
 import re
 import subprocess
 import sys
@@ -52,6 +53,7 @@ from governance.approval_waiver import (  # noqa: E402
     validate_repository_approval_waiver,
     validate_single_maintainer_waiver,
 )
+from governance.approval_live_cli import resolve_publication_approvers  # noqa: E402
 from governance.incident_evidence import validate_incident_evidence_commit  # noqa: E402
 from governance.incident_planner import materialize_incident_mutation  # noqa: E402
 from governance.planner import (  # noqa: E402
@@ -250,13 +252,24 @@ def parse_args() -> argparse.Namespace:
     incident_prepare.add_argument("--artifact-root")
     incident_prepare.add_argument("--out", required=True)
     approvers = commands.add_parser("resolve-publication-approvers")
-    approvers.add_argument("--approvals", required=True)
     approvers.add_argument("--initiator", required=True)
     approvers.add_argument("--environment", default="stable-release")
     approvers.add_argument("--repository", default="sifr-lang/sifr")
-    approvers.add_argument("--operation", default="")
-    approvers.add_argument("--single-maintainer-waiver")
-    approvers.add_argument("--expected-waiver-sha256")
+    approvers.add_argument("--operation", required=True)
+    approvers.add_argument("--run-id", required=True, type=int)
+    approvers.add_argument("--run-attempt", required=True, type=int)
+    approvers.add_argument("--evidence", required=True)
+    approvers.add_argument("--expected-evidence-sha256", required=True)
+    historical = commands.add_parser("inspect-historical-publication-approval")
+    historical.add_argument("--approvals", required=True)
+    historical.add_argument("--initiator", required=True)
+    historical.add_argument("--environment", default="stable-release")
+    historical.add_argument("--repository", default="sifr-lang/sifr")
+    historical.add_argument("--operation", required=True)
+    historical.add_argument("--single-maintainer-waiver", required=True)
+    historical.add_argument("--expected-waiver-sha256", required=True)
+    historical.add_argument("--original-run", required=True)
+    historical.add_argument("--include-policy", action="store_true")
     approvers.add_argument("--include-policy", action="store_true")
     return parser.parse_args()
 
@@ -296,6 +309,8 @@ def main() -> int:
             prepare_stable_publication(args)
         elif args.command == "prepare-incident-publication":
             prepare_incident_publication(args)
+        elif args.command == "inspect-historical-publication-approval":
+            inspect_historical_publication_approval(args)
         elif args.command == "resolve-publication-approvers":
             resolve_publication_approvers(args)
         else:
@@ -315,7 +330,7 @@ def validate_command(args: argparse.Namespace) -> None:
         "schema-bootstrap-evidence": validate_bootstrap_evidence,
         "single-maintainer-approval-waiver": (
             lambda payload: validate_repository_approval_waiver(
-                payload, require_unexpired=True
+                payload, require_unexpired=False
             )
         ),
         "release-plan": validate_release_plan,
@@ -643,7 +658,16 @@ def prepare_incident_publication(args: argparse.Namespace) -> None:
     write_canonical_json(Path(args.out), summary, refuse_existing=True)
 
 
-def resolve_publication_approvers(args: argparse.Namespace) -> None:
+def inspect_historical_publication_approval(args: argparse.Namespace) -> None:
+    original = load_json_strict(Path(args.original_run))
+    if original.get("status") != "completed":
+        raise GovernanceError("historical inspection requires a completed original run")
+    if original.get("triggering_actor", {}).get("login") != args.initiator:
+        raise GovernanceError("historical initiator does not match original run")
+    try:
+        event_time = datetime.fromisoformat(original["updated_at"].replace("Z", "+00:00"))
+    except (KeyError, TypeError, ValueError):
+        raise GovernanceError("historical inspection requires the original event time")
     waiver_path = None
     waiver_sha256 = "none"
     if args.single_maintainer_waiver:
@@ -670,6 +694,7 @@ def resolve_publication_approvers(args: argparse.Namespace) -> None:
             operation=args.operation,
             initiator=args.initiator,
             require_unexpired=True,
+            now=event_time,
         )
         if waiver["owner_login"].casefold() != decision["approvers"][0].casefold():
             raise GovernanceError("waiver owner does not match the recorded approver")

--- a/scripts/distribution/run_incident_publication.sh
+++ b/scripts/distribution/run_incident_publication.sh
@@ -296,15 +296,18 @@ fi
 fetch_governance "${work}/governance-initial"
 revalidate "${work}/governance-initial"
 
-gh api "repos/${repository}/actions/runs/${run_id}/approvals" \
-  >"${work}/approvals.json"
-approvers="$(
+approval="$(
   scripts/distribution/release_governance.py resolve-publication-approvers \
-    --approvals "${work}/approvals.json" \
     --initiator "${initiator}" \
-    --environment stable-release
+    --environment stable-release \
+    --repository "${repository}" --operation "${operation}" \
+    --run-id "${run_id}" --run-attempt "${run_attempt}" \
+    --evidence "${prepare_summary}" \
+    --expected-evidence-sha256 "${expected_summary_sha256}" --include-policy
 )"
-approver="$(jq -er '.[0]' <<<"${approvers}")"
+approver="$(jq -er '.approvers[0]' <<<"${approval}")"
+approval_mode="$(jq -er '.approval_policy.mode' <<<"${approval}")"
+approval_waiver_sha256="$(jq -er '.approval_policy.waiver_sha256' <<<"${approval}")"
 
 GH_TOKEN="${site_token}" \
   scripts/distribution/verify_site_workflow_identity.sh \
@@ -513,7 +516,9 @@ if [[ "${operation}" == "incident-roll-forward" ]]; then
     --release-assets "${work}/stable-staged/release-assets" \
     --site-facts "${work}/incident-staged/stable-site-release-facts.json" \
     --site-run "${work}/site-run.json" --smoke "${work}/stable-smoke" \
-    --run-id "${run_id}" --approver "${approver}" --out "${release_signoff}"
+    --run-id "${run_id}" --initiator "${initiator}" --approver "${approver}" \
+    --approval-mode "${approval_mode}" \
+    --approval-waiver-sha256 "${approval_waiver_sha256}" --out "${release_signoff}"
   release_signoff_arguments=(--release-signoff "${release_signoff}")
 fi
 mkdir "${work}/incident-smoke"

--- a/scripts/distribution/run_stable_publication.sh
+++ b/scripts/distribution/run_stable_publication.sh
@@ -12,7 +12,6 @@ Usage: scripts/distribution/run_stable_publication.sh \
   --prepare-summary PATH --expected-summary-sha256 SHA256 \
   --workflow-ref REF --workflow-commit COMMIT \
   --run-id ID --run-attempt N --initiator LOGIN \
-  [--approval-waiver PATH --expected-approval-waiver-sha256 SHA256] \
   --site-repository OWNER/REPO --site-workflow FILE --site-workflow-ref REF \
   --site-ruleset-id ID --site-ruleset-updated-at TIMESTAMP \
   --site-workflow-sha256 SHA256
@@ -35,8 +34,6 @@ workflow_commit=""
 run_id=""
 run_attempt=""
 initiator=""
-approval_waiver=""
-expected_approval_waiver_sha256=""
 site_repository=""
 site_workflow=""
 site_workflow_ref=""
@@ -60,9 +57,6 @@ while [[ $# -gt 0 ]]; do
     --run-id) run_id="${2:-}"; shift 2 ;;
     --run-attempt) run_attempt="${2:-}"; shift 2 ;;
     --initiator) initiator="${2:-}"; shift 2 ;;
-    --approval-waiver) approval_waiver="${2:-}"; shift 2 ;;
-    --expected-approval-waiver-sha256)
-      expected_approval_waiver_sha256="${2:-}"; shift 2 ;;
     --site-repository) site_repository="${2:-}"; shift 2 ;;
     --site-workflow) site_workflow="${2:-}"; shift 2 ;;
     --site-workflow-ref) site_workflow_ref="${2:-}"; shift 2 ;;
@@ -94,12 +88,6 @@ done
 for path in "${evidence_root}" "${source_root}"; do
   [[ -d "${path}" && ! -L "${path}" ]] || usage
 done
-if [[ "${operation}" == "ga-activation" ]]; then
-  [[ -f "${approval_waiver}" && ! -L "${approval_waiver}" &&
-    "${expected_approval_waiver_sha256}" =~ ^[0-9a-f]{64}$ ]] || usage
-elif [[ -n "${approval_waiver}" ]]; then
-  usage
-fi
 [[ -f "${prepare_summary}" && ! -L "${prepare_summary}" ]] || usage
 [[ -n "${SITE_TOKEN:-}" ]] || {
   echo "stable-publication: SITE_TOKEN is required" >&2
@@ -226,24 +214,15 @@ python3 scripts/distribution/fetch_qualification_artifacts.py \
 fetch_governance "${work}/governance-initial"
 revalidate "${work}/governance-initial"
 
-gh api "repos/${repository}/actions/runs/${run_id}/approvals" \
-  >"${work}/approvals.json"
-approval_waiver_args=()
-if [[ "${operation}" == "ga-activation" ]]; then
-  approval_waiver_args=(
-    --repository "${repository}"
-    --operation "${operation}"
-    --single-maintainer-waiver "${approval_waiver}"
-    --expected-waiver-sha256 "${expected_approval_waiver_sha256}"
-  )
-fi
 approval="$(
   scripts/distribution/release_governance.py resolve-publication-approvers \
-    --approvals "${work}/approvals.json" \
     --initiator "${initiator}" \
     --environment stable-release \
-    --include-policy \
-    "${approval_waiver_args[@]}"
+    --repository "${repository}" --operation "${operation}" \
+    --run-id "${run_id}" --run-attempt "${run_attempt}" \
+    --evidence "${prepare_summary}" \
+    --expected-evidence-sha256 "${expected_summary_sha256}" \
+    --include-policy
 )"
 approver="$(jq -er '.approvers[0]' <<<"${approval}")"
 approval_mode="$(jq -er '.approval_policy.mode' <<<"${approval}")"

--- a/verification/areas/distribution_release/cases/preview_release_workflow_yaml_parses.sh
+++ b/verification/areas/distribution_release/cases/preview_release_workflow_yaml_parses.sh
@@ -62,7 +62,7 @@ publication_required = (
     "'sifr-release-drill' || 'sifr-release-index'",
     "uses: ./.github/workflows/release-publication-prepare.yml",
     "name: ${{ inputs.governance_mode == 'preview' && 'preview-release' || 'stable-release' }}",
-    "actions/runs/${GITHUB_RUN_ID}/approvals",
+    '--run-id "${GITHUB_RUN_ID}" --run-attempt "${GITHUB_RUN_ATTEMPT}"',
     "resolve-publication-approvers",
     "--initiator \"${GITHUB_TRIGGERING_ACTOR}\"",
     "generate-schema-bootstrap-index",

--- a/verification/areas/distribution_release/cases/schema_epoch_bootstrap_workflow_contract.sh
+++ b/verification/areas/distribution_release/cases/schema_epoch_bootstrap_workflow_contract.sh
@@ -53,12 +53,10 @@ for fragment in (
     "uses: ./.github/workflows/release-publication-prepare.yml",
     "name: ${{ needs.prepare.outputs.summary_artifact_name }}",
     "name: ${{ inputs.governance_mode == 'preview' && 'preview-release' || 'stable-release' }}",
-    "actions/runs/${GITHUB_RUN_ID}/approvals",
     "--initiator \"${GITHUB_TRIGGERING_ACTOR}\"",
-    "--single-maintainer-waiver \"${SINGLE_MAINTAINER_APPROVAL_WAIVER}\"",
-    "SINGLE_MAINTAINER_APPROVAL_WAIVER_SHA256: b9630cc060ca281946da76a9cb9bc67564759c8d5446b6a33157a7d138080008",
-    'test "${waiver_sha256}" = "${SINGLE_MAINTAINER_APPROVAL_WAIVER_SHA256}"',
-    "--expected-waiver-sha256 \"${SINGLE_MAINTAINER_APPROVAL_WAIVER_SHA256}\"",
+    "resolve-publication-approvers",
+    '--evidence protected-prepare/summary.json',
+    '--run-id "${GITHUB_RUN_ID}" --run-attempt "${GITHUB_RUN_ATTEMPT}"',
     "--include-policy",
     "jq -r '.approval_policy.mode'",
     "--approval-mode \"${APPROVAL_MODE}\"",
@@ -102,6 +100,9 @@ assert publication.index("Run protected public schema-bootstrap smoke") < public
     "Retain final protected schema-bootstrap evidence"
 )
 assert publication.count("--clobber") == 1
+assert "SINGLE_MAINTAINER_APPROVAL_WAIVER" not in publication
+assert "--single-maintainer-waiver" not in publication
+assert '--expected-evidence-sha256 "${EXPECTED_RECOVERY_SUMMARY_SHA256}"' in recovery
 assert "contents: write" not in prepare
 assert "environment:" not in prepare
 for fragment in (
@@ -123,8 +124,11 @@ for fragment in (
     "name: stable-release",
     "plans/releases/schema-bootstrap-recovery/prepare-summary-${{ inputs.original_run_id }}-${{ inputs.original_run_attempt }}.json",
     "actions/runs/${ORIGINAL_RUN_ID}/approvals",
-    "actions/runs/${GITHUB_RUN_ID}/approvals",
+    "resolve-publication-approvers",
     "--operation bootstrap-index",
+    "inspect-historical-publication-approval",
+    "--original-run original-run.json",
+    "--operation bootstrap-recovery",
     "--expected-waiver-sha256 \"${WAIVER_SHA256}\"",
     "failed site run identity/status drifted",
     'gh run view "${FAILED_SITE_RUN_ID}"',

--- a/verification/areas/distribution_release/cases/stable_publication_workflow_contract.sh
+++ b/verification/areas/distribution_release/cases/stable_publication_workflow_contract.sh
@@ -81,10 +81,12 @@ assert orchestrator.count("--clobber") == 1
 assert "channels.json" in orchestrator
 assert "resolve-publication-approvers" in orchestrator
 assert "--environment stable-release" in orchestrator
-assert "--single-maintainer-waiver" in orchestrator
-assert 'if [[ "${operation}" == "ga-activation" ]]; then' in orchestrator
-assert 'elif [[ -n "${approval_waiver}" ]]; then' in orchestrator
-assert "--expected-waiver-sha256" in orchestrator
+assert "--single-maintainer-waiver" not in orchestrator
+assert "--approval-waiver)" not in orchestrator
+assert "--expected-waiver-sha256" not in orchestrator
+assert '--run-id "${run_id}" --run-attempt "${run_attempt}"' in orchestrator
+assert '--evidence "${prepare_summary}"' in orchestrator
+assert '--expected-evidence-sha256 "${expected_summary_sha256}"' in orchestrator
 assert "--include-policy" in orchestrator
 assert "'.approval_policy.mode'" in orchestrator
 assert "--approval-mode" in orchestrator

--- a/verification/areas/distribution_release/governance/approval_live_cli.py
+++ b/verification/areas/distribution_release/governance/approval_live_cli.py
@@ -1,0 +1,51 @@
+"""Fetch current GitHub approval authority; no caller-supplied history or waiver."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .approval_policy import ENVIRONMENT, REPOSITORY, resolve_live_approval
+from .common import GovernanceError, require_sha256, sha256_file
+
+
+def _github(endpoint: str) -> Any:
+    result = subprocess.run(["gh", "api", endpoint], text=True, capture_output=True)
+    if result.returncode:
+        raise GovernanceError("could not read GitHub approval authority")
+    try:
+        return json.loads(result.stdout)
+    except ValueError as exc:
+        raise GovernanceError("invalid GitHub approval response") from exc
+
+
+def resolve_publication_approvers(args: argparse.Namespace) -> None:
+    if args.environment != ENVIRONMENT or args.repository != REPOSITORY:
+        raise GovernanceError("live approval requires sifr-lang/sifr stable-release")
+    # Prevent a direct script invocation from selecting a different run/attempt.
+    for name, expected in (
+        ("GITHUB_ACTIONS", "true"), ("GITHUB_REPOSITORY", args.repository),
+        ("GITHUB_RUN_ID", str(args.run_id)),
+        ("GITHUB_RUN_ATTEMPT", str(args.run_attempt)),
+        ("GITHUB_TRIGGERING_ACTOR", args.initiator),
+    ):
+        if os.environ.get(name) != expected:
+            raise GovernanceError(f"{name} does not match current publication")
+    require_sha256(args.expected_evidence_sha256, "release evidence SHA-256")
+    if sha256_file(Path(args.evidence)) != args.expected_evidence_sha256:
+        raise GovernanceError("release evidence digest does not match approval context")
+    run_endpoint = f"repos/{args.repository}/actions/runs/{args.run_id}"
+    decision = resolve_live_approval(
+        _github(f"{run_endpoint}/approvals"),
+        configuration=_github(f"repos/{args.repository}/environments/{ENVIRONMENT}"),
+        run=_github(run_endpoint), repository=args.repository,
+        operation=args.operation, initiator=args.initiator,
+        run_id=args.run_id, run_attempt=args.run_attempt,
+        evidence_sha256=args.expected_evidence_sha256,
+    )
+    print(json.dumps(decision if args.include_policy else decision["approvers"],
+                     separators=(",", ":")))

--- a/verification/areas/distribution_release/governance/approval_policy.py
+++ b/verification/areas/distribution_release/governance/approval_policy.py
@@ -1,0 +1,81 @@
+"""The sole live stable-release policy; retained waiver history is separate."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .common import fail, require_array, require_object, require_positive_int, require_sha256
+
+MAINTAINER = "yaseralnajjar"
+REPOSITORY = "sifr-lang/sifr"
+ENVIRONMENT = "stable-release"
+SOLO_MAINTAINER = "solo-maintainer"
+OPERATIONS = {
+    "bootstrap-alpha", "bootstrap-index", "ga-activation", "normal",
+    "rollback", "incident-roll-forward", "bootstrap-recovery",
+}
+
+
+def validate_environment(payload: Any) -> None:
+    environment = require_object(payload, "environment configuration")
+    if environment.get("name") != ENVIRONMENT:
+        fail("environment configuration", "must name stable-release")
+    if environment.get("can_admins_bypass") is not False:
+        fail("environment configuration", "admin bypass must be disabled")
+    rules = require_array(environment.get("protection_rules"), "protection rules")
+    reviewers = [rule for rule in rules if isinstance(rule, dict)
+                 and rule.get("type") == "required_reviewers"]
+    if len(reviewers) != 1 or reviewers[0].get("prevent_self_review") is not False:
+        fail("protection rules", "must allow designated maintainer self-review")
+    users = require_array(reviewers[0].get("reviewers"), "required reviewers")
+    if len(users) != 1:
+        fail("required reviewers", "must designate only yaseralnajjar")
+    user = require_object(users[0], "required reviewer")
+    identity = require_object(user.get("reviewer"), "required reviewer identity")
+    if (user.get("type") != "User" or identity.get("login") != MAINTAINER
+            or identity.get("id") != 10493809):
+        fail("required reviewers", "must designate only yaseralnajjar")
+
+
+def resolve_live_approval(
+    approvals: Any, *, configuration: Any, run: Any, repository: str,
+    operation: str, initiator: str, run_id: int, run_attempt: int,
+    evidence_sha256: str,
+) -> dict[str, Any]:
+    """Validate responses fetched from the exact current protected run.
+
+    The protected job is admitted by GitHub for each attempt. Its immutable
+    prepare summary binds the evidence shown before that approval. The CLI
+    fetches approval history itself; callers cannot supply another run's file.
+    """
+    if repository != REPOSITORY or operation not in OPERATIONS:
+        fail("publication approval", "unsupported repository or operation")
+    require_positive_int(run_id, "run ID")
+    require_positive_int(run_attempt, "run attempt")
+    require_sha256(evidence_sha256, "release evidence SHA-256")
+    validate_environment(configuration)
+    metadata = require_object(run, "GitHub run")
+    if metadata.get("id") != run_id or metadata.get("run_attempt") != run_attempt:
+        fail("GitHub run", "run ID or attempt does not match publication")
+    repo = require_object(metadata.get("repository"), "GitHub run repository")
+    actor = require_object(metadata.get("triggering_actor"), "GitHub run initiator")
+    if repo.get("full_name") != repository or actor.get("login") != initiator:
+        fail("GitHub run", "repository or initiator does not match publication")
+    if metadata.get("status") != "in_progress":
+        fail("GitHub run", "new publication requires the active run")
+    values = require_array(approvals, "GitHub approval history")
+    for raw in values:
+        review = require_object(raw, "GitHub approval")
+        if review.get("state") != "approved":
+            continue
+        environments = require_array(review.get("environments"), "approval environments")
+        if not any(isinstance(value, dict) and value.get("name") == ENVIRONMENT
+                   for value in environments):
+            continue
+        user = require_object(review.get("user"), "GitHub approver")
+        if user.get("login") == MAINTAINER and user.get("id") == 10493809:
+            return {
+                "approvers": [MAINTAINER],
+                "approval_policy": {"mode": SOLO_MAINTAINER, "waiver_sha256": "none"},
+            }
+    fail("GitHub approval history", "requires explicit approval by yaseralnajjar")

--- a/verification/areas/distribution_release/governance/approval_policy_selftest.py
+++ b/verification/areas/distribution_release/governance/approval_policy_selftest.py
@@ -1,0 +1,139 @@
+"""Positive and negative contracts for the one live approval policy."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from . import approval_live_cli
+from .approval_policy import OPERATIONS, resolve_live_approval
+from .common import GovernanceError, sha256_file
+
+
+def test_live_approval() -> None:
+    identity = {"login": "yaseralnajjar", "id": 10493809}
+    environment = {
+        "name": "stable-release", "can_admins_bypass": False,
+        "protection_rules": [{
+            "type": "required_reviewers", "prevent_self_review": False,
+            "reviewers": [{"type": "User", "reviewer": identity}],
+        }],
+    }
+    run = {
+        "id": 123, "run_attempt": 2, "status": "in_progress",
+        "repository": {"full_name": "sifr-lang/sifr"},
+        "triggering_actor": {"login": "yaseralnajjar"},
+    }
+    approval = {
+        "state": "approved", "user": identity,
+        "environments": [{"name": "stable-release"}],
+    }
+    arguments = dict(
+        configuration=environment, run=run, repository="sifr-lang/sifr",
+        operation="normal", initiator="yaseralnajjar", run_id=123,
+        run_attempt=2, evidence_sha256="a" * 64,
+    )
+    expected = {
+        "approvers": ["yaseralnajjar"],
+        "approval_policy": {"mode": "solo-maintainer", "waiver_sha256": "none"},
+    }
+    for operation in sorted(OPERATIONS):
+        assert resolve_live_approval([approval], **{**arguments, "operation": operation}) == expected
+    other_initiator = copy.deepcopy(run)
+    other_initiator["triggering_actor"]["login"] = "release-operator"
+    assert resolve_live_approval([approval], **{
+        **arguments, "run": other_initiator, "initiator": "release-operator",
+    }) == expected
+
+    def rejected(callback, label):
+        try:
+            callback()
+        except GovernanceError:
+            return
+        raise AssertionError(f"accepted invalid live approval: {label}")
+
+    for label, history in (
+        ("absent approval", []),
+        ("non-designated reviewer", [{**approval, "user": {"login": "other", "id": 7}}]),
+        ("wrong user ID", [{**approval, "user": {**identity, "id": 7}}]),
+        ("rejected review", [{**approval, "state": "rejected"}]),
+        ("other environment", [{**approval, "environments": [{"name": "preview-release"}]}]),
+    ):
+        rejected(lambda: resolve_live_approval(history, **arguments), label)
+    for label, field, value in (
+        ("different run", "run_id", 124),
+        ("different attempt", "run_attempt", 1),
+        ("different repository", "repository", "other/repo"),
+        ("different initiator", "initiator", "other"),
+        ("retired waiver operation", "operation", "single-maintainer-waiver"),
+        ("invalid evidence", "evidence_sha256", "none"),
+        ("completed run", "run", {**run, "status": "completed"}),
+    ):
+        rejected(lambda: resolve_live_approval([approval], **{**arguments, field: value}), label)
+    for label, mutate in (
+        ("admin bypass", lambda v: v.update(can_admins_bypass=True)),
+        ("missing bypass setting", lambda v: v.pop("can_admins_bypass")),
+        ("self-review forbidden", lambda v: v["protection_rules"][0].update(prevent_self_review=True)),
+        ("missing reviewer", lambda v: v["protection_rules"][0].update(reviewers=[])),
+        ("team reviewer", lambda v: v["protection_rules"][0]["reviewers"][0].update(type="Team")),
+        ("different reviewer", lambda v: v["protection_rules"][0]["reviewers"][0].update(
+            reviewer={"login": "other", "id": 7})),
+    ):
+        changed = copy.deepcopy(environment)
+        mutate(changed)
+        rejected(lambda: resolve_live_approval([approval], **{
+            **arguments, "configuration": changed,
+        }), label)
+
+    with tempfile.TemporaryDirectory() as raw:
+        evidence = Path(raw) / "summary.json"
+        evidence.write_text('{"release_evidence":"exact"}\n')
+        args = argparse.Namespace(
+            environment="stable-release", repository="sifr-lang/sifr",
+            run_id=123, run_attempt=2, operation="normal", initiator="yaseralnajjar",
+            evidence=str(evidence), expected_evidence_sha256=sha256_file(evidence),
+            include_policy=True,
+        )
+        runtime = {
+            "GITHUB_ACTIONS": "true", "GITHUB_REPOSITORY": "sifr-lang/sifr",
+            "GITHUB_RUN_ID": "123", "GITHUB_RUN_ATTEMPT": "2",
+            "GITHUB_TRIGGERING_ACTOR": "yaseralnajjar",
+        }
+        responses = {
+            "repos/sifr-lang/sifr/actions/runs/123/approvals": [approval],
+            "repos/sifr-lang/sifr/actions/runs/123": run,
+            "repos/sifr-lang/sifr/environments/stable-release": environment,
+        }
+        with patch.dict("os.environ", runtime, clear=True), patch.object(
+            approval_live_cli, "_github", side_effect=responses.__getitem__,
+        ) as fetch, patch("builtins.print") as output:
+            approval_live_cli.resolve_publication_approvers(args)
+            assert json.loads(output.call_args.args[0]) == expected
+            assert {call.args[0] for call in fetch.call_args_list} == set(responses)
+            evidence.write_text('{"release_evidence":"different"}\n')
+            fetch.reset_mock()
+            rejected(lambda: approval_live_cli.resolve_publication_approvers(args), "changed evidence")
+            fetch.assert_not_called()
+            args.expected_evidence_sha256 = sha256_file(evidence)
+            args.run_attempt = 1
+            rejected(lambda: approval_live_cli.resolve_publication_approvers(args), "stale current attempt")
+            fetch.assert_not_called()
+
+        root = Path(__file__).resolve().parents[4]
+        cli = root / "scripts/distribution/release_governance.py"
+        command = [
+            sys.executable, str(cli), "resolve-publication-approvers",
+            "--initiator", "yaseralnajjar", "--operation", "normal",
+            "--run-id", "123", "--run-attempt", "2",
+            "--evidence", str(evidence),
+            "--expected-evidence-sha256", sha256_file(evidence),
+        ]
+        for retired in ("--single-maintainer-waiver", "--expected-waiver-sha256", "--approvals"):
+            result = subprocess.run([*command, retired, "retired"], capture_output=True, text=True)
+            assert result.returncode == 2 and "unrecognized arguments" in result.stderr

--- a/verification/areas/distribution_release/governance/approval_waiver.py
+++ b/verification/areas/distribution_release/governance/approval_waiver.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+from .approval_policy import SOLO_MAINTAINER
+
 from .common import (
     fail,
     require_array,
@@ -17,7 +19,8 @@ from .common import (
 
 DISTINCT_REVIEWER = "distinct-reviewer"
 SINGLE_MAINTAINER_WAIVER = "single-maintainer-waiver"
-APPROVAL_MODES = {DISTINCT_REVIEWER, SINGLE_MAINTAINER_WAIVER}
+# Historical identities remain readable, but are never live authorization.
+APPROVAL_MODES = {DISTINCT_REVIEWER, SINGLE_MAINTAINER_WAIVER, SOLO_MAINTAINER}
 WAIVED_OPERATIONS = {"bootstrap-alpha", "bootstrap-index", "ga-activation"}
 CANONICAL_WAIVER_EXPIRY = "2026-08-27T00:00:00Z"
 
@@ -119,9 +122,9 @@ def validate_approval_policy(payload: Any, location: str) -> dict[str, str]:
     )
     mode = require_enum(policy["mode"], APPROVAL_MODES, f"{location}.mode")
     waiver_sha256 = policy["waiver_sha256"]
-    if mode == DISTINCT_REVIEWER:
+    if mode != SINGLE_MAINTAINER_WAIVER:
         if waiver_sha256 != "none":
-            fail(f"{location}.waiver_sha256", "must be none for distinct review")
+            fail(f"{location}.waiver_sha256", "must be none without a historical waiver")
     else:
         require_sha256(waiver_sha256, f"{location}.waiver_sha256")
     return {"mode": mode, "waiver_sha256": waiver_sha256}

--- a/verification/areas/distribution_release/governance/approval_waiver_selftest.py
+++ b/verification/areas/distribution_release/governance/approval_waiver_selftest.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from verification.json_schema_202012 import validate_instance
 
+from .approval_policy_selftest import test_live_approval
 from .approval_waiver import (
     CANONICAL_WAIVER_EXPIRY,
     WAIVED_OPERATIONS,
@@ -54,7 +55,10 @@ def validate_repository_waiver() -> None:
     assert waiver["owner_login"] == "yaseralnajjar"
     assert set(waiver["allowed_operations"]) == WAIVED_OPERATIONS
     assert waiver["expires_at"] == CANONICAL_WAIVER_EXPIRY
-    validate_repository_approval_waiver(waiver, require_unexpired=True)
+    validate_repository_approval_waiver(
+        waiver, require_unexpired=True,
+        now=datetime(2026, 7, 29, tzinfo=timezone.utc),
+    )
     for operation in sorted(WAIVED_OPERATIONS):
         validate_single_maintainer_waiver(
             waiver,
@@ -63,9 +67,10 @@ def validate_repository_waiver() -> None:
             operation=operation,
             initiator="yaseralnajjar",
             require_unexpired=True,
-            now=datetime.now(timezone.utc),
+            now=datetime(2026, 7, 29, tzinfo=timezone.utc),
         )
     validate_approval_cli(waiver)
+    test_live_approval()
 
 
 def validate_approval_cli(waiver: dict[str, Any]) -> None:
@@ -81,12 +86,18 @@ def validate_approval_cli(waiver: dict[str, Any]) -> None:
     }
     with tempfile.TemporaryDirectory() as raw:
         root = Path(raw)
+        original_run = root / "original-run.json"
+        write_canonical_json(original_run, {
+            "status": "completed", "updated_at": "2026-07-29T12:00:00Z",
+            "triggering_actor": {"login": waiver["owner_login"]},
+        }, refuse_existing=True)
         approvals = root / "approvals.json"
         write_canonical_json(approvals, [owner_approval], refuse_existing=True)
         base = [
             sys.executable,
             str(GOVERNANCE_CLI),
-            "resolve-publication-approvers",
+            "inspect-historical-publication-approval",
+            "--original-run", str(original_run),
             "--approvals",
             str(approvals),
             "--initiator",
@@ -163,6 +174,14 @@ def validate_approval_cli(waiver: dict[str, Any]) -> None:
             text=True,
             capture_output=True,
             check=False,
+        ).returncode == 2
+        original_run.write_text(json.dumps({
+            "status": "completed", "updated_at": "2026-09-08T12:00:00Z",
+            "triggering_actor": {"login": waiver["owner_login"]},
+        }))
+        assert subprocess.run(
+            [*base, "--operation", "bootstrap-index"], cwd=REPO_ROOT,
+            capture_output=True, check=False,
         ).returncode == 2
         subprocess.run(
             [

--- a/verification/areas/distribution_release/governance/release_plan.py
+++ b/verification/areas/distribution_release/governance/release_plan.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from .approval_waiver import validate_approval_policy
+from .approval_policy import MAINTAINER, SOLO_MAINTAINER
 from .common import (
     BUILDERS,
     TARGETS,
@@ -346,7 +347,9 @@ def validate_release_signoff(payload: Any) -> dict[str, Any]:
     for index, attempt in enumerate(signoff["attempts"]):
         approver = attempt["approver"]
         is_self = approver.casefold() == initiator.casefold()
-        if is_self != (policy["mode"] == "single-maintainer-waiver"):
+        accepted = (approver == MAINTAINER if policy["mode"] == SOLO_MAINTAINER
+                    else is_self == (policy["mode"] == "single-maintainer-waiver"))
+        if not accepted:
             fail(
                 f"$.attempts[{index}].approver",
                 "does not match the retained approval policy",

--- a/verification/areas/distribution_release/governance/release_signoff_selftest.py
+++ b/verification/areas/distribution_release/governance/release_signoff_selftest.py
@@ -19,6 +19,13 @@ COMMIT = "e" * 40
 def test_release_signoff_mutations() -> None:
     signoff = valid_release_signoff()
     validate_release_signoff(signoff)
+    solo = copy.deepcopy(signoff)
+    solo["initiator"] = "yaseralnajjar"
+    solo["attempts"][0]["approver"] = "yaseralnajjar"
+    solo["approval_policy"] = {"mode": "solo-maintainer", "waiver_sha256": "none"}
+    validate_release_signoff(solo)
+    expect_rejected(mutate(solo, lambda item: item["attempts"][0].update(approver="other")))
+    expect_rejected(mutate(solo, lambda item: item["approval_policy"].update(waiver_sha256=SHA_A)))
     waived = mutate(
         signoff,
         lambda item: (

--- a/verification/areas/distribution_release/governance/schema_bootstrap.py
+++ b/verification/areas/distribution_release/governance/schema_bootstrap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from .approval_policy import MAINTAINER, SOLO_MAINTAINER
 from .approval_waiver import (
     SINGLE_MAINTAINER_WAIVER,
     validate_approval_policy,
@@ -300,7 +301,7 @@ def _validate_approvers(
         normalized = approver.casefold()
         if (
             normalized == normalized_initiator
-            and approval_policy["mode"] != SINGLE_MAINTAINER_WAIVER
+            and approval_policy["mode"] not in {SINGLE_MAINTAINER_WAIVER, SOLO_MAINTAINER}
         ):
             fail(f"{location}[{index}]", "must differ from the workflow initiator")
         if normalized in seen:
@@ -311,6 +312,8 @@ def _validate_approvers(
         len(approvers) != 1 or approvers[0].casefold() != normalized_initiator
     ):
         fail(location, "single-maintainer waiver requires only the initiating owner")
+    if approval_policy["mode"] == SOLO_MAINTAINER and approvers != [MAINTAINER]:
+        fail(location, "solo-maintainer policy requires only yaseralnajjar")
     return approvers
 
 

--- a/verification/areas/distribution_release/governance/schema_bootstrap_selftest.py
+++ b/verification/areas/distribution_release/governance/schema_bootstrap_selftest.py
@@ -133,6 +133,13 @@ def main() -> int:
     assert validate_bootstrap_evidence(waived_evidence) == waived_evidence
     test_single_maintainer_waiver()
     validate_repository_waiver()
+    solo_evidence = valid_evidence()
+    solo_evidence["initiator"] = "yaseralnajjar"
+    solo_evidence["approvers"] = ["yaseralnajjar"]
+    solo_evidence["approval_policy"] = {"mode": "solo-maintainer", "waiver_sha256": "none"}
+    assert validate_bootstrap_evidence(solo_evidence) == solo_evidence
+    solo_evidence["approvers"] = ["other"]
+    expect_failure(lambda: validate_bootstrap_evidence(solo_evidence), "non-designated solo reviewer")
     expect_failure(
         lambda: build_preview_epoch(
             legacy_index_sha256="f" * 64,

--- a/verification/areas/distribution_release/governance/stable_orchestrator_selftest.py
+++ b/verification/areas/distribution_release/governance/stable_orchestrator_selftest.py
@@ -74,16 +74,6 @@ fi
             "1",
             "--initiator",
             "initiator",
-            "--approval-waiver",
-            str(
-                REPO_ROOT
-                / "plans/releases/single-maintainer-approval-waiver.json"
-            ),
-            "--expected-approval-waiver-sha256",
-            sha256_file(
-                REPO_ROOT
-                / "plans/releases/single-maintainer-approval-waiver.json"
-            ),
             "--site-repository",
             "sifr-lang/sifr-website",
             "--site-workflow",

--- a/verification/areas/distribution_release/schemas/schema_epoch_bootstrap_evidence.schema.json
+++ b/verification/areas/distribution_release/schemas/schema_epoch_bootstrap_evidence.schema.json
@@ -152,7 +152,7 @@
           "additionalProperties": false,
           "required": ["mode", "waiver_sha256"],
           "properties": {
-            "mode": {"const": "distinct-reviewer"},
+            "mode": {"enum": ["distinct-reviewer", "solo-maintainer"]},
             "waiver_sha256": {"const": "none"}
           }
         },

--- a/verification/areas/distribution_release/schemas/stable_release_signoff.schema.json
+++ b/verification/areas/distribution_release/schemas/stable_release_signoff.schema.json
@@ -73,7 +73,7 @@
           "additionalProperties": false,
           "required": ["mode", "waiver_sha256"],
           "properties": {
-            "mode": {"const": "distinct-reviewer"},
+            "mode": {"enum": ["distinct-reviewer", "solo-maintainer"]},
             "waiver_sha256": {"const": "none"}
           }
         },


### PR DESCRIPTION
Stable publication still selected an expired temporary waiver for self-approval. This change applies the approved permanent policy: explicit GitHub-recorded approval by `yaseralnajjar` for each protected run and its evidence, with self-review allowed and admin bypass disabled. Live governance executes from the workflow revision; retained waiver evidence remains immutable and historical inspection evaluates its original event time.

The approval resolver checks the live environment, current run/attempt and prepare-summary digest. Maintained publication and recovery entry points use the same policy; schemas, signoffs, owned contracts and current policy documentation follow it. Historical identities remain supported for evidence inspection only.

Item 65 only. All eight named distribution suites have attributable unchanged 11/11 passing evidence. On this candidate, readiness passed 4/4; workflow/submodule contracts, file-size and diff checks passed. One exact-SHA Opus review and one final-candidate merge gate remain before merge. No release job is approved or publication triggered.
