### PR TITLE
Require delivery coverage for non-live Python suites

### DIFF
--- a/verification/areas/coverage_matrix/checks/coverage_matrix_readiness_self_test.py
+++ b/verification/areas/coverage_matrix/checks/coverage_matrix_readiness_self_test.py
@@ -4,16 +4,18 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 import tempfile
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import date
+from functools import partial
 from io import StringIO
 from pathlib import Path
 from typing import Any, Callable
 
 import coverage_matrix
 import profile_assignment_matrix
-from sifr_verify.profiles import compare_plans
+from sifr_verify.profiles import ProfileError, compare_plans, validate_python_delivery_coverage
 
 
 OWNERS = {
@@ -65,6 +67,8 @@ def main() -> int:
         ("missing SQL test target", missing_sql_test_target, "target lacks classification: test:runtime_types"),
     ]
     failed: list[str] = []
+    python_delivery_tests = python_delivery_coverage_tests()
+    tests.extend(python_delivery_tests)
     for name, func, expected in tests:
         errors = func()
         if not any(expected in error for error in errors):
@@ -73,8 +77,81 @@ def main() -> int:
         for failure in failed:
             print(f"coverage matrix self-test: {failure}")
         return 1
-    print(f"coverage matrix readiness self-tests ok: cases={len(tests)}")
+    print(
+        f"coverage matrix readiness self-tests ok: cases={len(tests)} "
+        f"python-delivery-mutations={len(python_delivery_tests)}"
+    )
     return 0
+
+
+def python_delivery_coverage_tests() -> list[tuple[str, Callable[[], list[str]], str]]:
+    manifest = json.loads(
+        (profile_assignment_matrix.AREA_ROOTS / "python_interop" / "manifest.json").read_text()
+    )
+    errors: list[str] = []
+    profiles = {
+        name: profile_assignment_matrix.load_profile(name, errors)
+        for name in profile_assignment_matrix.PROFILE_NAMES
+    }
+    if errors:
+        raise AssertionError(errors)
+    validate_python_delivery_coverage(profiles, manifest)
+    # Discover mutations from the manifest, independently of assignment data.
+    non_live = [
+        suite["name"]
+        for suite in manifest["suites"]
+        if suite.get("network_mode", manifest["network_mode"]) != "live"
+    ]
+    tests = []
+    for suite in non_live:
+        removed = deepcopy(profiles)
+        for profile in removed.values():
+            for selection in profile.get("selected_areas", []):
+                if selection.get("area") == "python_interop":
+                    selection["suites"] = [name for name in selection["suites"] if name != suite]
+        # The opt-in live profile cannot supply delivery coverage.
+        removed["python-interop-live"] = {
+            "selected_areas": [{"area": "python_interop", "suites": [suite]}]
+        }
+        tests.append((
+            f"unassigned Python suite {suite}",
+            partial(python_delivery_errors, removed, manifest),
+            f"no delivery profile assignment: {suite}",
+        ))
+    extended = deepcopy(manifest)
+    extended["suites"].append({"name": "new-unassigned-suite", "network_mode": "offline"})
+    tests.append((
+        "new unassigned Python manifest suite",
+        partial(python_delivery_errors, profiles, extended),
+        "no delivery profile assignment: new-unassigned-suite",
+    ))
+    # One assignment is sufficient, including an offline override in a live area.
+    boundary_manifest = {
+        "name": "python_interop",
+        "network_mode": "live",
+        "suites": [
+            {"name": "offline-override", "network_mode": "offline"},
+            {"name": "inherited-live"},
+            {"name": "explicit-live", "network_mode": "live"},
+        ],
+    }
+    for name in profile_assignment_matrix.PROFILE_NAMES:
+        one_profile = {
+            name: {"selected_areas": [{"area": "python_interop", "suites": ["offline-override"]}]}
+        }
+        if validate_python_delivery_coverage(one_profile, boundary_manifest) != 1:
+            raise AssertionError("Python delivery suite count did not follow network policy")
+    return tests
+
+
+def python_delivery_errors(
+    profiles: dict[str, dict[str, Any]], manifest: dict[str, Any]
+) -> list[str]:
+    try:
+        validate_python_delivery_coverage(profiles, manifest)
+    except ProfileError as error:
+        return [str(error)]
+    return []
 
 
 def stable_guarantee_without_matrix_row() -> list[str]:

--- a/verification/areas/coverage_matrix/checks/profile_assignment_matrix.py
+++ b/verification/areas/coverage_matrix/checks/profile_assignment_matrix.py
@@ -8,13 +8,19 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from sifr_verify.profiles import (
+    DELIVERY_PROFILE_NAMES,
+    ProfileError,
+    validate_python_delivery_coverage,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[4]
 AREA_ROOT = REPO_ROOT / "verification" / "areas" / "coverage_matrix"
 MATRIX_PATH = AREA_ROOT / "profile_assignment_matrix.json"
 SURFACE_MATRIX_PATH = AREA_ROOT / "compiler_surface_matrix.json"
 PROFILES_DIR = REPO_ROOT / "verification" / "profiles"
 AREA_ROOTS = REPO_ROOT / "verification" / "areas"
-PROFILE_NAMES = ("create-pr", "merge", "nightly", "release")
+PROFILE_NAMES = DELIVERY_PROFILE_NAMES
 
 
 def main() -> int:
@@ -29,6 +35,12 @@ def main() -> int:
     area_suites = load_area_suites(errors)
     release_suites = load_release_surface_suites(area_suites, errors)
     profiles = {profile: load_profile(profile, errors) for profile in PROFILE_NAMES}
+    python_manifest = load_json(AREA_ROOTS / "python_interop" / "manifest.json", errors)
+    python_delivery_suites = 0
+    try:
+        python_delivery_suites = validate_python_delivery_coverage(profiles, python_manifest)
+    except ProfileError as error:
+        errors.append(str(error))
     profile_suites = {
         profile: selected_area_suite_tokens(payload)
         for profile, payload in profiles.items()
@@ -86,7 +98,10 @@ def main() -> int:
         for error in errors:
             print(f"profile-assignment-matrix error: {error}", file=sys.stderr)
         return 1
-    print(f"profile assignment matrix ok: rows={len(rows)}")
+    print(
+        f"profile assignment matrix ok: rows={len(rows)} "
+        f"python-delivery-suites={python_delivery_suites}"
+    )
     return 0
 
 

--- a/verification/runner/sifr_verify/profiles.py
+++ b/verification/runner/sifr_verify/profiles.py
@@ -19,6 +19,7 @@ class ProfileError(VerificationError):
 
 
 _WORKSPACE_PACKAGE_NAMES: set[str] | None = None
+DELIVERY_PROFILE_NAMES = ("create-pr", "merge", "nightly", "release")
 E2E_PASS_FIXTURE_DIR = REPO_ROOT / "crates" / "sifr" / "tests" / "e2e" / "pass"
 PYTHON_INTEROP_CAPABILITY_MATRIX = (
     REPO_ROOT / "verification" / "areas" / "python_interop" / "declaration_capabilities.json"
@@ -114,6 +115,39 @@ def selected_suites_for_area(profile: dict[str, Any], area_name: str) -> list[st
         if isinstance(raw_suites, list):
             suites.extend(str(suite) for suite in raw_suites)
     return suites
+
+
+def validate_python_delivery_coverage(
+    profiles: dict[str, dict[str, Any]], manifest: dict[str, Any]
+) -> int:
+    """Require each non-live manifest suite in at least one delivery profile."""
+    suites = manifest.get("suites")
+    if manifest.get("name") != "python_interop" or not isinstance(suites, list) or not suites:
+        raise ProfileError("Python interop manifest must declare non-empty suites")
+    declared: set[str] = set()
+    required: set[str] = set()
+    for suite in suites:
+        name = suite.get("name") if isinstance(suite, dict) else None
+        if not isinstance(name, str) or not name or name in declared:
+            raise ProfileError("Python interop manifest has invalid or duplicate suites")
+        declared.add(name)
+        network_mode = suite.get("network_mode", manifest.get("network_mode"))
+        if network_mode not in {"offline", "live"}:
+            raise ProfileError(f"Python interop suite {name} has invalid network_mode")
+        if network_mode != "live":
+            required.add(name)
+    assigned = {
+        suite
+        for name in DELIVERY_PROFILE_NAMES
+        for suite in selected_suites_for_area(profiles.get(name, {}), "python_interop")
+    }
+    missing = sorted(required - assigned)
+    if missing:
+        raise ProfileError(
+            "non-live Python interop suites have no delivery profile assignment: "
+            + ", ".join(missing)
+        )
+    return len(required)
 
 
 def validate_selected_area_suites(profile: dict[str, Any]) -> None:


### PR DESCRIPTION
Every non-live Python manifest suite must occur in at least one delivery profile. Readiness now checks the manifest against the union of create-pr, merge, nightly, and release assignments, so removing a suite from all profiles fails even when the assignment matrix does not mention it. The opt-in live profile cannot satisfy this invariant.

The current 30 non-live suites are already covered. Manifest-derived mutations remove each suite's delivery assignments and add a new unassigned suite, with derived counts (31 mutations, 57 total readiness cases). Boundary checks accept one delivery assignment and honor inherited and overridden network policy. Item 55's derived Schwifty counts are retained.

Validation covers candidate `d5d966128032e350dfad5c30a580f526df64e6dc` (the tested bytes were committed unchanged):

- `area coverage_matrix: readiness`: 4/4 variants passed; 30 covered suites, 31 delivery mutations.
- `area python_interop: self-test, minor-train-features`: 2/2 variants passed; Schwifty 8 countries and 32 checksums.
- `git diff --check` and `python3 scripts/check_file_size_guardrails.py`: passed (3,761 files; 900-line limit).

Item 53 only in `plans/issues/active/ad-hoc-latest-stable-release-convergence.md`. Three runner/check Python paths change. No compiler, fixture, lockfile, workflow, profile, or custody edits; no create-pr or merge gate applies under the item's explicit runner-only rule. Readiness used read-only Cargo metadata; no native compilation or performance measurement ran.

One exact-SHA Opus review returned `SATISFIED` with no blocking findings. No remediation review was needed. Validation and review evidence are retained in PR comments keyed to the candidate SHA.
