### PR TITLE
Align HTTPX2 protocol documentation and verification ownership

### DIFF
--- a/internal_docs/python_interop_architecture.md
+++ b/internal_docs/python_interop_architecture.md
@@ -13,6 +13,9 @@ certified Arrow C Data Interface declarations are active. Declaration-first
 DLPack tensor and stream acquisition, validation, and one-shot transfer are
 active as well. Read-only Python plan inspection and deterministic doctor
 suggestions are active on the same package/driver path used by compilation.
+The [protocol architecture](./python_interop_protocol_architecture.md) defines
+the async, context, callback, and zero-copy rules, including the maintained
+HTTPX2 coroutine example.
 
 ## Ownership Boundary
 
@@ -215,6 +218,7 @@ The public examples in `docs/python-interop.mdx` are intentionally backed by che
 | biip / schwifty package calls | `library-examples` runs `simple_import/biip_schwifty_full_example.sifr`; Tier 1a package matrix entries and `simple_import` contract coverage remain inventory evidence. |
 | installed package-local biip bridge | `package_bridge_archive/package_bridge_evidence.json` records the archive/unpack/build/run proof; the package bridge showcase runs the compiled fixture after checkout and installed bridge-source removal. |
 | FastAPI app construction | `library-examples` runs `fastapi_app/fastapi_pydantic_full_example.sifr`; `fastapi_app_contract.json` remains the contract inventory. |
+| HTTPX2 async client | `async-declaration-examples` runs `async_declaration/httpx2_client.sifr` with an offline ASGI transport, typed bridge response, shared application loop, and consuming async close. The `coroutine-declaration` row in `declaration_capabilities.json` binds the current report, case, source, and marker. |
 | Pydantic / pydantic-core validation | `library-examples` runs `fastapi_app/fastapi_pydantic_full_example.sifr`; `pydantic_models_contract.json` remains the contract inventory. |
 | pandas / pyarrow / polars Arrow bridge | `arrow-examples` creates and read-only rechecks exact environment-bound certifications, then compiles and runs `pyarrow_capsule/arrow_declaration_compiled.sifr` against all three producers with zero residual resources. The lower-level dataframe/library examples remain dynamic API evidence. |
 | PyTorch DLPack | `dlpack-examples` compiles and runs the declaration-first PyTorch transfer and checks stable data pointers, exact one-shot cleanup, and zero residual resources. `ml-examples` retains the lower-level raw PyTorch example. |

--- a/internal_docs/python_interop_protocol_architecture.md
+++ b/internal_docs/python_interop_protocol_architecture.md
@@ -36,7 +36,7 @@ hermetic, and the root application owns environment and trust decisions.
 Python coroutine targets use `@python.coroutine(path)` on `async def` declarations:
 
 ```sifr
-@python.opaque(type=httpx.AsyncClient, cleanup=async_close)
+@python.opaque(type=httpx2.AsyncClient, cleanup=async_close)
 class AsyncClient:
     @python.coroutine(Self.get)
     async def get(
@@ -54,6 +54,15 @@ class AsyncClient:
 item, buffer, Arrow, and DLPack declarations are synchronous `blocking_io`
 operations. Async context and callback declarations have their own explicit
 forms below.
+
+The maintained HTTPX2 example is
+[`httpx2_client.sifr`](../verification/areas/python_interop/fixtures/async_declaration/httpx2_client.sifr).
+Its [package-local bridge](../verification/areas/python_interop/fixtures/async_declaration/python_bridges/client.py)
+creates an `httpx2.AsyncClient` with `httpx2.ASGITransport`, adapts the response
+to a typed Sifr record, and exercises consuming async close on the owned loop.
+The `async-declaration-examples` suite owns this compiled offline ASGI evidence;
+the declaration above illustrates the protocol shape rather than a complete
+package.
 
 ### Event-Loop Ownership
 

--- a/verification/areas/coverage_matrix/README.md
+++ b/verification/areas/coverage_matrix/README.md
@@ -1,0 +1,41 @@
+# Coverage Matrix And Taxonomy Ownership
+
+The `compiler-verification` owner maintains this area's
+[manifest](manifest.json), shipped guarantees, compiler surfaces, profile
+assignments, and naming checks. The executable `readiness` suite is the source
+of current readiness; dated reports under `reports/` retain their original
+observations.
+
+| Registry or check | Owned paths and meaning |
+| --- | --- |
+| [Shipped guarantees](shipped_guarantees.json) and [compiler surfaces](compiler_surface_matrix.json) | Guarantee and surface identities refer to owners in [the owner registry](../../owners.json) and executable area/suite tokens. |
+| [Profile assignments](profile_assignment_matrix.json) | The [assignment checker](checks/profile_assignment_matrix.py) compares the four delivery profiles in [profiles](../../profiles/) with area manifests. Python delivery coverage is also derived directly from the [Python manifest](../python_interop/manifest.json). |
+| [Cargo classification](data/cargo_metadata_classification.json) | Package names are checked against offline, locked `cargo metadata --no-deps`; classification does not run package tests. |
+| [Taxonomy checker](checks/verification_taxonomy.py) | Scans the active source, documentation, verification, script, workflow, and editor roots declared in `ACTIVE_ROOTS`. It owns naming checks, not runtime suite selection or fixture execution. |
+| [Python evidence topology](../python_interop/README.md) | `runtime/python-interop` owns package matrices, declaration ledgers, fixture-relative source paths, repository-relative generated reports, and the compiled HTTPX2 client. |
+
+Python delivery coverage is enforced by
+[`sifr_verify.profiles`](../../runner/sifr_verify/profiles.py): every non-live
+suite in the Python area manifest must be selected by at least one of
+`create-pr`, `merge`, `nightly`, or `release`. Effective `network_mode` comes
+from the suite or its area default; live suites are outside that requirement.
+The opt-in live-service profile does not count as delivery-profile coverage.
+This readiness check establishes profile reachability, not that the selected
+Python suites have executed in the current run.
+
+Runtime-generated artifacts live below repository-relative `target/` paths.
+Taxonomy excludes `target`, `.venv`, `__pycache__`, `node_modules`, `third_party`,
+`vendor`, `.git`, and `skills` directories according to the checker. Historical
+issue and review records under `plans/` are outside its active roots. These
+boundaries preserve recorded environments and upstream ownership; active
+documentation still uses current API identities and actual repository paths.
+
+Run the named readiness suite with:
+
+```bash
+uv run --project verification --locked python -m sifr_verify areas run --area coverage_matrix --suite readiness
+```
+
+The area emits `target/verification/areas/coverage-matrix-results.json`.
+This report is generated run evidence and does not replace any Python area's
+compiled-example report or retained performance measurement.

--- a/verification/areas/python_interop/README.md
+++ b/verification/areas/python_interop/README.md
@@ -9,6 +9,45 @@ The single maintained interpreter is GIL-enabled CPython 3.14.7. The area
 project pins it exactly; there is no older compatibility project or fallback
 interpreter lane.
 
+## HTTP Client Evidence And Retained Names
+
+The maintained project uses `httpx2` and `httpcore2`. The
+[dependency audit](runner/dependency_versions.py) rejects the retired `httpx`
+and `httpcore` distributions in the owned project manifests and locks. The
+[protocol guide](../../../internal_docs/python_interop_protocol_architecture.md)
+uses the current `httpx2.AsyncClient` identity.
+
+The [tier-two matrix](packages/tier2.toml) retains the distribution name
+`pytest-httpx` and import root `pytest_httpx` as deterministic inventory. Its
+matrix `certified` label describes checked-in package metadata; it provides no
+installation, live-import, or HTTPX2 compatibility evidence. This package is
+absent from the maintained area's project and lock. It is not a replacement
+for the compiled HTTPX2 client suite, and the name must not be mechanically
+rewritten to a different distribution.
+
+Historical issue/review records and captured performance environments retain
+the HTTPX names and versions actually used by those runs. They are provenance,
+not current dependency guidance or qualification of the maintained environment.
+Third-party source and its own locks retain their upstream ownership.
+
+## Verification Path Ownership
+
+Paths in the package and declaration ledgers have distinct bases:
+
+| Input or artifact | Owner and path interpretation |
+| --- | --- |
+| [Package matrices](packages/tier1.toml), [async packages](packages/async.toml), and [tier-two packages](packages/tier2.toml) | `runtime/python-interop` owns inventory. Import roots are Python module identities, not repository paths. |
+| [Area manifest](manifest.json) | Suite `entry` paths are repository-relative; the outer [area runner](runner.py) selects the owned suite. |
+| [Declaration ledger](declaration_capabilities.json) | `compiled_evidence.sifr_source` is relative to `fixtures/`; `report` is repository-relative under `target/verification/areas/python_interop/`. |
+| [Async example registry](runner/async_declaration_examples.py) | Case `httpx2-client` resolves `async_declaration/httpx2_client.sifr` under `fixtures/`, with its adjacent `python_bridges/client.py` packaged hermetically. |
+| [Coverage and taxonomy checks](../coverage_matrix/README.md) | `compiler-verification` owns profile reachability and naming checks; the Python area owns fixture meaning and generated suite evidence. |
+
+The HTTPX2 ledger entry consumes
+`target/verification/areas/python_interop/async-declaration-examples.latest.json`
+for the current selected run. The outer area result is
+`target/verification/areas/python-interop-results.json`; these paths are generated
+outputs, not checked-in evidence to relabel when a dependency changes.
+
 The canonical entrypoint is:
 
 ```bash

--- a/verification/areas/python_interop/packages/tier2.toml
+++ b/verification/areas/python_interop/packages/tier2.toml
@@ -123,6 +123,8 @@ groups = ["imports"]
 import-roots = ["requests_mock"]
 
 [[packages]]
+# Retained package identity for deterministic matrix inventory only. This row
+# does not certify installation or HTTPX2 support; see ../README.md.
 name = "pytest-httpx"
 tier = "tier2"
 groups = ["imports"]


### PR DESCRIPTION
Current protocol documentation still identifies the retired HTTPX client even though the maintained compiled example uses HTTPX2. Update the opaque client identity and connect the architecture guide to the actual offline ASGI bridge, shared-loop behavior, and consuming close evidence.

Document the ownership and path bases for package matrices, declaration fixtures, profile checks, taxonomy, and generated reports. Classify `pytest-httpx` as retained deterministic inventory without claiming installation or HTTPX2 compatibility; preserve historical performance environments and upstream records. Its TOML change is comments only.

Scope: latest-stable convergence item 58. The separate public-guide references are assigned to later item 69 and are unchanged.

Validation at `d592713207f12acc2b16ae4dedf0e73bc006ea1d`:

- `documentation:structure`: 1/1 passed.
- `coverage_matrix:readiness`: 4/4 passed; 13 guarantees, 34 surfaces, 19 assignment rows, 30 non-live Python delivery suites, 57 negative tests including 31 delivery mutations, and taxonomy.
- 28 local links and three HTTPX2 topology paths passed; parsed tier-two metadata unchanged.
- `git diff --check` and file-size guard passed (3,761 files, 900-line limit).

Only Markdown and TOML comments change. No compiler, lockfile, runtime fixture, or workflow changes, so no create-pr or merge-profile gate applies under the explicit item rule. Exact-SHA Opus review pending.
