### PR TITLE
docs: align public Python interop examples with HTTPX2

### DIFF
--- a/docs/packages/dependencies.mdx
+++ b/docs/packages/dependencies.mdx
@@ -105,7 +105,7 @@ Sifr does not resolve Python dependencies. Python packages are installed by the 
 
 ```toml
 [python]
-requires-imports = ["pydantic", "httpx"]
+requires-imports = ["pydantic", "httpx2"]
 ```
 
 For normal uv layout, Sifr discovers the root project's `pyproject.toml`,

--- a/docs/python-interop.mdx
+++ b/docs/python-interop.mdx
@@ -16,7 +16,7 @@ The root application owns the Python environment. Sifr verifies and consumes it;
 
 ```toml
 [trust]
-python = ["pandas", "pyarrow", "torch", "httpx"]
+python = ["pandas", "pyarrow", "torch", "httpx2"]
 python-native = ["numpy", "pyarrow", "torch"]
 ```
 
@@ -194,12 +194,12 @@ Every public `sifr.python` operation is `@blocking_io`. Direct Python calls in a
 ```python
 from sifr.python import PythonError
 
-@python.opaque(type=httpx.Response, cleanup=drop)
+@python.opaque(type=httpx2.Response, cleanup=drop)
 class Response:
     @python.attr(Self.status_code)
     def status_code(self) -> Result[int, PythonError]: ...
 
-@python(httpx.get)
+@python(httpx2.get)
 def get(url: str) -> Result[Response, PythonError]: ...
 
 async def fetch_status() -> Result[int, PythonError]:
@@ -220,7 +220,7 @@ Libraries with genuine coroutine APIs use typed async declarations. The generate
 ```python
 from sifr.python import PythonError
 
-@python.opaque(type=httpx.AsyncClient, cleanup=async_close)
+@python.opaque(type=httpx2.AsyncClient, cleanup=async_close)
 class AsyncClient:
     @python.coroutine(Self.aclose)
     async def aclose(own self) -> Result[None, PythonError]: ...


### PR DESCRIPTION
Five current public Python interop examples still use the retired `httpx` import root while the maintained environment uses HTTPX2. Update the trust list, `Response` and `AsyncClient` opaque identities, `get` decorator, and dependency `requires-imports` example to `httpx2`.

Scope is Item 69 / #3793: only `docs/python-interop.mdx` and `docs/packages/dependencies.mdx`. Historical evidence and implementation inputs are unchanged.

Validation on candidate `54e4528f3f82b2dce31cb42ded8e52254f5b817d`:

- Documentation `structure` suite passed 1/1, including the GA documentation mutation harness. Exact-SHA Opus review will be attached before merge.
- `git diff --check`, file-size guard (3,761 files), and all 21 local documentation links passed.
- No create-pr or merge-profile gate applies to this documentation-only item under the explicit file-category rule.

The initial structure attempts lacked the pinned editor submodule and its nested VS Code submodule. They were initialized at existing gitlinks `d202b8c60240b6d2897c9deeda59be899bf47e24` and `732bcdc3ae2a494753025710dd138aa23a39b6e4` before the completed-input run of the same named check passed; no tracked input changed.
