### PR TITLE
B22: defer formatter ignore loading past explicit-file bypass

### DIFF
--- a/crates/sifr/src/check_and_package_commands.rs
+++ b/crates/sifr/src/check_and_package_commands.rs
@@ -579,11 +579,9 @@ pub(super) fn fmt_entrypoint(
         args.paths.clone()
     };
     let mut diagnostics = Vec::new();
-    let gitignore = FormatterGitignore::load(&cwd, config.respect_gitignore, &mut provider)?;
+    let mut gitignore = None;
     for target in targets {
-        let explicit_target = provider.is_file(&target);
-        let files =
-            select_formatter_files(&target, &config, &gitignore, explicit_target, &mut provider)?;
+        let files = select_formatter_files(&target, &config, &cwd, &mut gitignore, &mut provider)?;
         for file in files {
             if args.check {
                 diagnostics.extend(sifr_format::check_path_with_options(
@@ -697,16 +695,29 @@ fn flag_override(enable: bool, disable: bool) -> Option<bool> {
 fn select_formatter_files(
     target: &Path,
     config: &EffectiveFormatConfig,
-    gitignore: &FormatterGitignore,
-    explicit_target: bool,
+    cwd: &Path,
+    gitignore: &mut Option<FormatterGitignore>,
     provider: &mut impl SourceProvider,
 ) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
+    // Explicit files bypass exclusion entirely, including reading and parsing
+    // ignore rules. Load once when a directory or --force-exclude needs them.
+    if provider.is_file(target) && !config.force_exclude {
+        return sifr_format::collect_sifr_files(target, provider);
+    }
+    let gitignore = match gitignore {
+        Some(gitignore) => gitignore,
+        None => gitignore.insert(FormatterGitignore::load(
+            cwd,
+            config.respect_gitignore,
+            provider,
+        )?),
+    };
     let files = sifr_format::collect_sifr_files(target, provider)?;
     let mut selected = Vec::new();
     for file in files {
         let excluded =
             pattern_matches(&file, &config.exclude) || gitignore.is_ignored(&file, provider)?;
-        if excluded && (!explicit_target || config.force_exclude) {
+        if excluded {
             continue;
         }
         selected.push(file);

--- a/crates/sifr/src/formatter_discovery.rs
+++ b/crates/sifr/src/formatter_discovery.rs
@@ -239,6 +239,43 @@ mod tests {
     }
 
     #[test]
+    fn formatter_discovery_malformed_rules_keep_source_line_diagnostics() {
+        let dir = tempfile::tempdir().unwrap();
+        for rule in ["{a,b", "[z-a]", "\\"] {
+            std::fs::write(
+                dir.path().join(".gitignore"),
+                format!("# rules\n\n{rule}\n"),
+            )
+            .unwrap();
+            let result = FormatterGitignore::load(dir.path(), true, &mut DiskSourceProvider::new());
+            let Err(diagnostics) = result else {
+                panic!("malformed rule {rule:?} must retain its diagnostic");
+            };
+            assert_eq!(diagnostics.len(), 1);
+            assert_eq!(diagnostics[0].code, "SIFR-FMT-0001");
+            assert!(
+                diagnostics[0]
+                    .message
+                    .contains("invalid formatter gitignore")
+            );
+            assert!(diagnostics[0].message.contains(".gitignore:3:"));
+        }
+    }
+
+    #[test]
+    fn formatter_discovery_disabled_ignores_do_not_parse_malformed_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        for rule in ["{a,b", "[z-a]", "\\"] {
+            let ignore = matcher(dir.path(), &format!("*.sifr\n{rule}\n"), false);
+            assert!(
+                !ignore
+                    .matches_resolved_path(Path::new("nested/main.sifr"))
+                    .unwrap()
+            );
+        }
+    }
+
+    #[test]
     fn formatter_discovery_literal_filter_agrees_with_complete_engine() {
         let dir = tempfile::tempdir().unwrap();
         let rules = "/tmp/\n*.sifr\n!keep.sifr\nfoo/**/bar\n[ab].txt\n\\#name\n{one,two}.rs\né?*.log\nspace\\ \n";

--- a/crates/sifr/tests/formatter_discovery.rs
+++ b/crates/sifr/tests/formatter_discovery.rs
@@ -47,3 +47,89 @@ fn formatter_discovery_preserves_explicit_file_and_exclusion_controls() {
         assert_eq!(result.status.code(), Some(expected), "{result:?}");
     }
 }
+
+#[test]
+fn formatter_discovery_explicit_files_bypass_malformed_ignore_rules() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("main.sifr"), "def main():\n    pass\n").unwrap();
+    std::fs::write(root.join("drift.sifr"), "def main( ):\n    pass\n").unwrap();
+    for rule in ["{a,b", "[z-a]", "\\"] {
+        std::fs::write(root.join(".gitignore"), format!("*.sifr\n{rule}\n")).unwrap();
+        for (name, expected) in [("main.sifr", 0), ("drift.sifr", 1)] {
+            for target in [root.join(name), name.into()] {
+                let result = check(root, &target, &[]);
+                assert_eq!(result.status.code(), Some(expected), "{rule:?}: {result:?}");
+                let stderr = String::from_utf8_lossy(&result.stderr);
+                assert!(!stderr.contains("gitignore"), "{stderr}");
+                if expected == 1 {
+                    assert!(stderr.contains("SIFR-FMT-0001"), "{stderr}");
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn formatter_discovery_directory_and_forced_files_report_malformed_ignore_rules() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::create_dir(root.join("empty")).unwrap();
+    std::fs::write(root.join("main.sifr"), "def main():\n    pass\n").unwrap();
+    for rule in ["{a,b", "[z-a]", "\\"] {
+        std::fs::write(root.join(".gitignore"), format!("# rules\n\n{rule}\n")).unwrap();
+        for (target, args) in [
+            (Path::new("."), vec![]),
+            (Path::new("empty"), vec![]),
+            (Path::new("main.sifr"), vec!["--force-exclude"]),
+        ] {
+            let result = check(root, target, &args);
+            assert_eq!(result.status.code(), Some(1), "{rule:?}: {result:?}");
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            assert!(stderr.contains("SIFR-FMT-0001"), "{stderr}");
+            assert!(stderr.contains("invalid formatter gitignore"), "{stderr}");
+            assert!(stderr.contains(".gitignore:3:"), "{stderr}");
+        }
+    }
+}
+
+#[test]
+fn formatter_discovery_no_respect_gitignore_bypasses_malformed_rules() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("main.sifr"), "def main( ):\n    pass\n").unwrap();
+    for rule in ["{a,b", "[z-a]", "\\"] {
+        std::fs::write(root.join(".gitignore"), format!("*.sifr\n{rule}\n")).unwrap();
+        for target in [Path::new("."), Path::new("main.sifr")] {
+            let result = check(root, target, &["--force-exclude", "--no-respect-gitignore"]);
+            assert_eq!(result.status.code(), Some(1), "{rule:?}: {result:?}");
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            assert!(stderr.contains("SIFR-FMT-0001"), "{stderr}");
+            assert!(!stderr.contains("gitignore"), "{stderr}");
+        }
+    }
+}
+
+#[test]
+fn formatter_discovery_mixed_targets_load_rules_at_directory_selection() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::create_dir(root.join("empty")).unwrap();
+    std::fs::write(root.join(".gitignore"), "{a,b\n").unwrap();
+    for name in ["first.sifr", "second.sifr"] {
+        std::fs::write(root.join(name), "def main( ):\n    pass\n").unwrap();
+    }
+    let result = Command::new(env!("CARGO_BIN_EXE_sifr"))
+        .current_dir(root)
+        .args(["fmt", "--no-cache", "first.sifr", "second.sifr", "empty"])
+        .output()
+        .unwrap();
+    assert_eq!(result.status.code(), Some(1), "{result:?}");
+    assert!(String::from_utf8_lossy(&result.stderr).contains("invalid formatter gitignore"));
+    for name in ["first.sifr", "second.sifr"] {
+        assert_eq!(
+            std::fs::read_to_string(root.join(name)).unwrap(),
+            "def main():\n    pass\n"
+        );
+    }
+}


### PR DESCRIPTION
Malformed `.gitignore` rules aborted explicit-file formatting before exclusion
bypass could apply. Load ignore rules once, on demand, when a directory or
`--force-exclude` target needs them. Explicit files bypass loading and matching;
directory diagnostics and rooted glob/component/negation behavior are preserved.

This is item **12K-B22 only**, staged against an independently owned branch at
B20 candidate `ac4c277b30c6cac046ab1746fe4020c04df7eaf1`. It does not target main
or qualify B20's unresolved performance acceptance. The predecessor PR3783 and
its branches remain unchanged. B27 owns eventual full qualification/delivery,
after B24 and the concretely registered integration allowance.

Candidate: `77d9976d868d9c0d4a1ead1c5ed321489e8359f9`.
All implementation and negative cases were complete before validation.

Validation on this exact candidate:
- `cargo test -p sifr --bin sifr formatter_discovery`: 6 passed.
- `cargo test -p sifr --test formatter_discovery`: 6 passed.
- `cargo fmt --check`: passed.
- `git diff --check ac4c277b30c6cac046ab1746fe4020c04df7eaf1 77d9976d868d9c0d4a1ead1c5ed321489e8359f9`: passed.
- Both HIR maintainability and file-size guardrails: passed.

Negative cases cover malformed alternates, ranges and escapes; clean/drifting
explicit absolute/relative files; populated/empty directory diagnostics with
source lines; forced exclusion; ignore disabling; and actual formatting of
explicit files before a later mixed directory target reports malformed rules.

Evidence is retained outside the reviewed tree at
`/private/tmp/sifr-b22.gWLgQ9/evidence/validation.77d9976d868d9c0d4a1ead1c5ed321489e8359f9.json`,
with exact commands, log paths and SHA256 hashes. Private TMPDIR and Cargo target;
CARGO_TARGET_DIR unset. No broad tests, performance acquisition or Sifr gate,
as explicitly required by the current B22 dispatch.

B20's initial NOT SATISFIED review remains consumed and attributable:
https://github.com/sifr-lang/sifr/pull/3783#issuecomment-5577108250.
Only its one remaining remediation review is authorized for this candidate.
Review evidence will be published here outside the approved commit. The old
causal/qualification failures and invalid acquisition remain open under B24/3776;
timeout descendant cleanup remains B23. No claim of discovery explaining CV.
