### PR TITLE
B23: reap timed benchmark process groups before the next sample

### DIFF
--- a/plans/issues/active/ad-hoc-emitted-rust-excellence.md
+++ b/plans/issues/active/ad-hoc-emitted-rust-excellence.md
@@ -2,6 +2,62 @@
 
 Status: active
 
+## Item12K-B23: timed subprocess group ownership (2026-09-08)
+
+Bounded implementation awaiting its named validation and exact-SHA review.
+Base: `16a97d07327c3c3b0f153acb3662bd2bd89925a3`; independent owner root
+`/private/tmp/sifr-b23.inohbu`, branch `codex/item12k-b23-timeout-lifecycle`.
+The parent and every predecessor clone, index, target and reference are read-only.
+Owned launch environment uses sibling `tmp` and `evidence`, with
+`CARGO_TARGET_DIR` unset. No historical parent ledger is copied into this record.
+
+Scope follows the dispatched B23 registration and the merged
+[B26 assessment](ad-hoc-joint-emitted-rust-delivery-assessment.md#existing-b23-timeout-descendant-lifecycle).
+Only `run_benchmarks.py`'s timed process boundary and its registered
+`benchmark_process.py` helper change. The helper owns each command's new session
+and process group, terminates descendants on timeout, drains output, reaps the
+leader and waits for the group to disappear before returning. Resistant members
+receive SIGKILL after a bounded TERM grace. Failure to drain or finish reaping
+raises a benchmark error, preventing another sample. Ordinary success/error
+status and output survive; timeout output is text and unavailable metrics remain
+unavailable. Background descendants left by an exited leader are cleaned too.
+POSIX descendants inherit this group; deliberate session/group escape is outside
+this benchmark-command contract. Orphan reaping belongs to the OS adopter, and
+failure to reap is a blocking error rather than an overlapping next sample.
+
+All deterministic tests are implemented before execution: ordinary exit0/7;
+ready-handshaken cooperative and TERM-resistant child/grandchild trees;
+leader-exit with inherited pipes; closed-pipe background descendants; UTF-8
+stdout/stderr retention; PID/group disappearance and a following sample proving
+no overlap; simulated failure to reap must fail closed. These checks are called
+by the existing benchmark `--self-test`, with no compiler or benchmark workload.
+
+Named validation only:
+
+- `python3 verification/areas/performance/run_benchmarks.py --self-test`
+- `python3 verification/areas/performance/check_budgets.py --self-test`
+- `git diff --check <exact-base> <exact-candidate>`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- `python3 scripts/check_file_size_guardrails.py`
+
+One initial exact-SHA Opus review and at most one remediation belong to this new
+mechanism. No compiler/lock/fixture/workflow changes, builds, Cargo/Clippy,
+benchmark acquisitions, create-pr or merge-profile gates are authorized here.
+This independent Python prerequisite may merge main after these checks/review.
+
+Authenticated B20 terminal SHA256
+`0b4fe5b32beb604527091fdfbeab9ff3b4b7dbd6d4d194e27ebb17d3260999dc` and stopped-group
+receipt SHA256 `bb8cfafa105efc55b06bf83acd4a9d198756e92d5d6110142924d2c00d79a06e`
+show orphan85215 overlapping3862, both launches of the same first case in
+PGID84008. B20 wrapper blob `7dc3270d0226f68ead596c347d15c38cc21fa33b` differs from
+main blob `95ff6b6d8fb58223396cbf91b5f67b4c244fee88` only by diagnostic sample
+recording imports/call/self-test; the timed subprocess function is identical.
+Preserve main's current evidence contracts without importing B19/B20 code.
+This fix does not explain the first120s timeout or original formatter CV.
+Private TMPDIR is independently required for future launchers. B24 owns causal
+and controlled qualification; B27 owns later joint delivery. All predecessor
+review/gate counts remain unchanged. After merge and record update, stop.
+
 ## Item12K-B26: joint-delivery assessment (2026-09-08)
 
 **B26 MERGED / COMPLETE — ASSESSMENT ONLY.** Documentation

--- a/verification/areas/performance/benchmark_process.py
+++ b/verification/areas/performance/benchmark_process.py
@@ -1,0 +1,233 @@
+"""Own a timed command's POSIX process group through output drain and cleanup."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Callable
+from unittest.mock import Mock, patch
+
+from benchmark_manifest import BenchmarkError
+
+TERMINATE_GRACE_SECONDS = 1.0
+REAP_TIMEOUT_SECONDS = 5.0
+
+
+def group_exists(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def signal_group(pgid: int, signum: int) -> None:
+    try:
+        os.killpg(pgid, signum)
+    except ProcessLookupError:
+        pass
+
+
+def finish_group(process: subprocess.Popen[str]) -> tuple[str, str]:
+    """Drain/reap the leader and require the entire owned group to disappear.
+
+    Descendants inherit the session leader's group, including /usr/bin/time's
+    children. Give parents a chance to reap their children, then kill resistant
+    members. Orphans are reaped by the OS's adopter; never start another sample
+    while even a zombie remains in this group. A broken adopter fails closed.
+    """
+    signal_group(process.pid, signal.SIGTERM)
+    try:
+        process.communicate(timeout=TERMINATE_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        pass
+    deadline = time.monotonic() + TERMINATE_GRACE_SECONDS
+    while group_exists(process.pid) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    signal_group(process.pid, signal.SIGKILL)
+    try:
+        output = process.communicate(timeout=REAP_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as error:
+        raise BenchmarkError(
+            f"benchmark process group {process.pid} did not close its output pipes"
+        ) from error
+    deadline = time.monotonic() + REAP_TIMEOUT_SECONDS
+    while group_exists(process.pid):
+        if time.monotonic() >= deadline:
+            raise BenchmarkError(
+                f"benchmark process group {process.pid} was not fully reaped; "
+                "refusing to start another sample"
+            )
+        time.sleep(0.01)
+    return output
+
+
+def run_owned_process(
+    command: list[str], cwd: Path, timeout_seconds: float
+) -> tuple[subprocess.CompletedProcess[str], bool]:
+    # The timing wrapper itself is the session/group leader. Never signal the
+    # caller's group, and do not rely on killing just the wrapper process.
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        text=True,
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    timed_out = False
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        stdout, stderr = finish_group(process)
+    except BaseException:
+        finish_group(process)
+        raise
+    else:
+        # A leader can exit while a descendant with redirected output survives.
+        # Preserve the leader's status/output, but close that ownership too.
+        if group_exists(process.pid):
+            finish_group(process)
+    return subprocess.CompletedProcess(command, process.returncode, stdout, stderr), timed_out
+
+
+_TREE_PROGRAM = r'''
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+root, depth, mode = Path(sys.argv[1]), int(sys.argv[2]), sys.argv[3]
+child = None
+def terminate(signum, frame):
+    if child is not None:
+        child.wait()
+    sys.exit(0)
+signal.signal(signal.SIGTERM, terminate)
+if mode == "resistant":
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+if depth:
+    child = subprocess.Popen(
+        [sys.executable, __file__, str(root), str(depth - 1), mode],
+        stdout=subprocess.DEVNULL if mode == "closed-pipes" else None,
+        stderr=subprocess.DEVNULL if mode == "closed-pipes" else None,
+    )
+    while not (root / f"ready-{depth - 1}").exists():
+        time.sleep(0.01)
+(root / f"pid-{depth}").write_text(str(os.getpid()))
+if depth == 2:
+    print("timeout stdout: café", flush=True)
+    print("timeout stderr: café", file=sys.stderr, flush=True)
+(root / f"ready-{depth}").touch()
+if depth == 2 and mode in ("leader-exit", "closed-pipes"):
+    sys.exit(0)
+while True:
+    signal.pause()
+'''
+
+
+def run_self_test(run_sample: Callable[[list[str], int], dict[str, Any]]) -> None:
+    """Exercise the public result shape with real child/grandchild groups.
+
+    The test-only launch handshake ensures the whole tree is ready before
+    communicate starts its short timeout; correctness never depends on a
+    guessed Python startup delay. No compiler or benchmark input is executed.
+    """
+    for exit_code in (0, 7):
+        result = run_sample(
+            [sys.executable, "-c", "import sys; print('ordinary stdout'); "
+             "print('ordinary stderr', file=sys.stderr); "
+             f"sys.exit({exit_code})"],
+            10000,
+        )
+        assert result["exit_code"] == exit_code and not result["timed_out"], result
+        assert result["stdout"] == "ordinary stdout\n", result
+        assert "ordinary stderr\n" in result["stderr_tail"], result
+        assert result["duration_ms"] > 0 and result["peak_rss_bytes"] is not None
+        print(f"benchmark process: ordinary exit {exit_code} passed")
+
+    # Even an unreaped orphan must block the caller rather than yield a normal
+    # timed-out sample. Simulate only this OS failure, without leaking a process.
+    fake_process = Mock(pid=123, communicate=Mock(return_value=("", "")))
+    with (
+        patch("benchmark_process.signal_group"),
+        patch("benchmark_process.group_exists", return_value=True),
+        patch("benchmark_process.time.monotonic", side_effect=[0, 2, 3, 9]),
+    ):
+        try:
+            finish_group(fake_process)
+        except BenchmarkError as error:
+            assert "refusing to start another sample" in str(error), error
+        else:
+            raise AssertionError("unreaped process group did not block sampling")
+    print("benchmark process: unreaped group fails closed passed")
+
+    real_popen = subprocess.Popen
+    for mode in ("cooperative", "resistant", "leader-exit", "closed-pipes"):
+        with TemporaryDirectory(prefix="sifr-benchmark-process-") as raw:
+            root = Path(raw)
+            script = root / "tree.py"
+            script.write_text(_TREE_PROGRAM, encoding="utf-8")
+            owned: list[subprocess.Popen[str]] = []
+
+            def launch_ready(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+                process = real_popen(*args, **kwargs)
+                owned.append(process)
+                deadline = time.monotonic() + 10.0
+                while not (root / "ready-2").exists():
+                    if time.monotonic() >= deadline:
+                        finish_group(process)
+                        raise AssertionError("process tree did not become ready")
+                    time.sleep(0.01)
+                return process
+
+            try:
+                with patch("benchmark_process.subprocess.Popen", launch_ready):
+                    result = run_sample(
+                        [sys.executable, str(script), str(root), "2", mode], 100
+                    )
+                assert len(owned) == 1
+                assert owned[0].pid != os.getpgrp()
+                assert owned[0].returncode is not None
+                assert not group_exists(owned[0].pid), "owned process group survived"
+                pids = [int((root / f"pid-{depth}").read_text()) for depth in range(3)]
+                # Verify PID disappearance inside the NEXT sample as well as
+                # here, so a return-before-cleanup regression cannot overlap it.
+                next_sample = run_sample(
+                    [sys.executable, "-c",
+                     "import os, sys\n"
+                     "for pid in map(int, sys.argv[1:]):\n"
+                     "    try: os.kill(pid, 0)\n"
+                     "    except ProcessLookupError: continue\n"
+                     "    raise SystemExit('previous sample still exists')\n"
+                     "print('no overlap')\n", *map(str, pids)],
+                    10000,
+                )
+                assert next_sample["exit_code"] == 0, next_sample
+                assert next_sample["stdout"] == "no overlap\n", next_sample
+                assert result["stdout"] == "timeout stdout: café\n", result
+                assert "timeout stderr: café\n" in result["stderr_tail"], result
+                assert isinstance(result["stdout"], str)
+                assert isinstance(result["stderr_tail"], str)
+                if mode == "closed-pipes":
+                    assert result["exit_code"] == 0 and not result["timed_out"], result
+                else:
+                    assert result["timed_out"] and result["exit_code"] is None, result
+                    for key in ("peak_rss_bytes", "retired_instructions",
+                                "cycles_elapsed", "cpu_time_ms"):
+                        assert result[key] is None, result
+                    assert result["work_counter_source"] == "unavailable", result
+                print(f"benchmark process: {mode} tree cleanup and no-overlap passed")
+            finally:
+                for process in owned:
+                    if process.poll() is None or group_exists(process.pid):
+                        finish_group(process)

--- a/verification/areas/performance/run_benchmarks.py
+++ b/verification/areas/performance/run_benchmarks.py
@@ -30,6 +30,8 @@ from benchmark_manifest import (
     select_cases,
     validate_manifest,
 )
+from benchmark_process import run_owned_process
+from benchmark_process import run_self_test as run_benchmark_process_self_test
 from controlled_sampling import (
     run_controlled_case,
 )
@@ -600,16 +602,10 @@ def collect_build_size_metrics(output_dir: Path) -> dict[str, int | None]:
 def run_subprocess(command: list[str], timeout_ms: int) -> dict[str, Any]:
     started = time.perf_counter()
     rss_before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
-    try:
-        completed = subprocess.run(
-            timed_command(command),
-            cwd=REPO_ROOT,
-            text=True,
-            capture_output=True,
-            timeout=timeout_ms / 1000.0,
-            check=False,
-        )
-    except subprocess.TimeoutExpired as error:
+    completed, timed_out = run_owned_process(
+        timed_command(command), REPO_ROOT, timeout_ms / 1000.0
+    )
+    if timed_out:
         return {
             "duration_ms": (time.perf_counter() - started) * 1000.0,
             "peak_rss_bytes": None,
@@ -619,8 +615,8 @@ def run_subprocess(command: list[str], timeout_ms: int) -> dict[str, Any]:
             "work_counter_source": "unavailable",
             "exit_code": None,
             "timed_out": True,
-            "stdout": error.stdout or "",
-            "stderr_tail": tail(error.stderr or ""),
+            "stdout": completed.stdout,
+            "stderr_tail": tail(completed.stderr),
         }
     rss_after = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
     process_data = parse_process_metrics(completed.stderr)
@@ -703,6 +699,7 @@ def invalidate_output(path: Path) -> None:
 
 
 def run_self_test() -> None:
+    run_benchmark_process_self_test(run_subprocess)
     run_benchmark_baseline_self_test()
     run_process_metrics_self_test()
     run_query_processes_self_test()


### PR DESCRIPTION
Timed benchmark wrapper timeouts previously killed only the wrapper, allowing its descendants to overlap the next sample. Each timed command now owns a new process group; cleanup terminates and reaps it before returning, escalates resistant members to SIGKILL, and fails closed if the group or output pipes remain. Success/nonzero status and captured text remain available.

12K-B23 only. The registered helper keeps process ownership and its deterministic tests together under the file-size limit. This does not establish the cause of the original120s timeout or formatter CV; B24 owns that qualification.

Validation on exact candidate `1af54249499ebdf42dcbb42c1fe3272810d9ee3a`, base `16a97d07327c3c3b0f153acb3662bd2bd89925a3`: both named benchmark/budget Python self-tests, exact diff hygiene, HIR maintainability and file-size guardrails PASS. Real child/grandchild tests cover cooperative/resistant timeout, exited leaders, closed pipes, retained UTF-8 output and a following sample checking old PIDs are gone; unreaped-group failure is also locked.

Only two Python harness files and the scoped phase record change. Per explicit B23 dispatch, no compiler tests/builds, benchmark acquisitions, create-pr or merge-profile gates. One initial exact-SHA Opus review SATISFIED, no blockers, zero remediation/retries. Review SHA256 `62889dd3be376f38ea9b7e268cb9f06ec4811e09f27cb3fbd4b013bc55fe84ab`; full response published in the PR. Five nonblocking follow-ups are deferred to the record-only update, with no next-item implementation.

External receipts: `/private/tmp/sifr-b23.inohbu/evidence/validation.1af54249499ebdf42dcbb42c1fe3272810d9ee3a.json`, SHA256 `0dbbbccfae532dcbd3942cf36bb9ff9d72262a88793be696ec10d9bedabad4fa`.
