### PR TITLE
Record item 70 recovery assessment closure

### DIFF
--- a/plans/issues/active/ad-hoc-latest-stable-item70-evidence-recovery.md
+++ b/plans/issues/active/ad-hoc-latest-stable-item70-evidence-recovery.md
@@ -1,7 +1,8 @@
 # Item 70: original-evidence recovery and prospective disposition
 
-State: bounded recovery assessment complete, 2026-09-08; pending exact-SHA
-review and merge. This is the authorized current disposition, not qualification.
+State: bounded recovery assessment complete and merged, 2026-09-08, via
+[PR #3810](https://github.com/sifr-lang/sifr/pull/3810). This is the authorized
+current disposition, not qualification.
 Owner: release/distribution, [issue #3775](https://github.com/sifr-lang/sifr/issues/3775).
 Source of scope: Item 70 in the coordinator's read-only convergence ledger,
 relaying the user's authorization to take recommended decisions on their behalf.
@@ -288,10 +289,22 @@ identities, the six-row matrix and all selected-read evidence identities.
 No custody suite, Cargo, native execution, Sifr gate or package update is
 authorized or needed for this documentation-only assessment.
 
-Item 70 assessment blocker: none. Missing historical custody and external
-compiler/policy/durable-custody delivery still block qualification; they are
-preserved as later work, not satisfied by this assessment. Exact next action:
-complete the named checks and one exact-SHA Opus review, merge this assessment,
-update phase records and stop. Do not start 70-F1 or another item. Final
-candidate, validation, review and merge receipts are recorded outside the
-reviewed tree and in the subsequent record-only phase update.
+Reviewed candidate: `d9d23149f8a59579f5e399bbb2239912198b524e`.
+Merge: `df093dab01b27484b684060443d1129d9898df04`.
+All named checks passed on that exact candidate. The first and only Opus
+review returned SATISFIED with no blocking findings; no remediation review
+or Sifr gate ran. The
+[validation/review receipt](https://github.com/sifr-lang/sifr/pull/3810#issuecomment-5581186433)
+and [full review](https://github.com/sifr-lang/sifr/pull/3810#issuecomment-5581186774)
+are published outside the approved tree. Raw response SHA-256:
+`922ca904484ed50badb0330ab4fb21dccb8048694753ba99af37f0fb6288e682`.
+
+Item 70 assessment blocker: none. Items 59/64 remain unqualified; historical
+custody is still INCOMPLETE/UNRECOVERED. Their prospective replacement depends
+on separately owned compiler/policy delivery and later 70-F1 durable custody
+and qualification work. These are later prerequisites, not satisfied by this
+assessment. Review follow-ups are settled by this current-status update or
+retained under issue #3775/70-F1, including the impermanence of host-local raw
+scan evidence. Exact next action: finish this record-only update and return
+the handoff, then stop. Do not start 70-F1 or another item. No new review or
+gate is required for this record-only update.

--- a/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
+++ b/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
@@ -1,12 +1,12 @@
 # Ad Hoc Phase: Latest Stable Release Convergence
 
-Status: active on 2026-09-08. Items 0–30, 36–39, 53–55, 58, 60, 66–67 and 69 are complete. Item 39 closed
+Status: active on 2026-09-08. Items 0–30, 36–39, 53–55, 58, 60, 66–67 and 69–70 are complete. Item 39 closed
 the runner dependency/API invariants; independent work can proceed under the continuation
 ledger while Kafka and gate-bearing items retain explicit prerequisites.
 
 ## Objective
 
-### Item 70 — bounded recovery assessment / authorized disposition
+### Item 70 — merged bounded recovery assessment / authorized disposition
 
 The current historical evidence disposition is INCOMPLETE/UNRECOVERED.
 The user-authorized direction is a prospective replacement qualification
@@ -24,11 +24,31 @@ read-only. After B37's explicit release, metadata/reflog inspection passed in
 covered 99,567 small blobs / 2,269,583,001 bytes; 6,058 exact-size/JSON candidates
 were hashed. Only the already-retained Rust result matched; no missing original
 was newly recovered. Scan capacity is released. Assessment scope is complete
-and pending exact-SHA review/merge; Items 59/64 remain unqualified and the phase
-is not closed. No Sifr gate is needed for these three Markdown files.
-Later work 70-F1 registers durable all-byte evidence retention only; it is not
-implemented or dispatched. Next action: named checks, one exact-SHA Opus review,
-merge and phase-record update, then stop. No repeated Git-pointer request.
+via [PR #3810](https://github.com/sifr-lang/sifr/pull/3810), reviewed candidate
+`d9d23149f8a59579f5e399bbb2239912198b524e`, merge
+`df093dab01b27484b684060443d1129d9898df04`.
+
+Named exact-candidate checks passed: five retained identities/sizes, all 20
+index rows, seven local links, six-row matrix, 59-store and selected-read
+evidence consistency, authenticated retained Rust match, diff whitespace and
+file-size guard (3,762 files, 900-line limit). One Opus review returned
+SATISFIED with no blockers; no remediation or Sifr gate ran for these three
+Markdown files. External
+[validation/review evidence](https://github.com/sifr-lang/sifr/pull/3810#issuecomment-5581186433)
+and [full response](https://github.com/sifr-lang/sifr/pull/3810#issuecomment-5581186774)
+cover the same candidate. Raw response SHA-256:
+`922ca904484ed50badb0330ab4fb21dccb8048694753ba99af37f0fb6288e682`.
+
+Items 59/64 remain unqualified and the phase is not closed. The authorized
+INCOMPLETE/UNRECOVERED disposition removes the repeated Git-pointer decision;
+it does not make the original evidence complete. Prospective replacement
+qualification remains dependent on separately owned compiler/policy delivery
+and later 70-F1 durable custody/qualification work. Raw host-local evidence
+impermanence is also retained with that later work under #3775. No 70-F1 or
+other implementation is started. Item 70 blocker: none. This record-only
+update settles the review's pending-status follow-up, reuses its evidence,
+and needs no new review or gate. Next action: finish records, return this
+completed handoff and stop.
 
 ### Item 69 — public HTTPX2 documentation closure
 

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -11,6 +11,12 @@ A NEW source/run/evidence qualification
 is the adopted future direction, conditional on compiler/policy delivery and
 durable custody. No qualification, waiver renewal or publication is authorized
 by this status. Recovery ownership remains [issue #3775](https://github.com/sifr-lang/sifr/issues/3775).
+Item 70's assessment/disposition merged through
+[PR #3810](https://github.com/sifr-lang/sifr/pull/3810), reviewed candidate
+`d9d23149f8a59579f5e399bbb2239912198b524e`; this leaves Items 59/64 unqualified.
+Later 70-F1 custody/qualification work and compiler/policy delivery remain
+prerequisites for the prospective replacement; no repeated Git-pointer
+decision or retrospective success is required or claimed.
 
 ## Status
 


### PR DESCRIPTION
Record Item 70's completed assessment/disposition after PR #3810 merged. Settle pending-review wording and retain the exact approved candidate, merge, named validation, external review evidence, and later prerequisites.

Items 59/64 remain unqualified and historical evidence INCOMPLETE/UNRECOVERED. No further Git-pointer decision is required; prospective replacement qualification still depends on compiler/policy delivery and later 70-F1 custody work. No later-item implementation is included.

Record-only changes in the same three Markdown files. Local documentation/identity checks and `git diff --check` passed; unchanged first-party file-size evidence is reused (3,762 files / 900). The phase-closure workflow requires no new Opus review or Sifr gate for this post-merge record update. Prior implementation evidence: https://github.com/sifr-lang/sifr/pull/3810#issuecomment-5581186433 .
