### PR TITLE
docs(release): record item 70-F1A closure

### DIFF
--- a/plans/issues/active/ad-hoc-latest-stable-item70-f1a-backend-readiness.md
+++ b/plans/issues/active/ad-hoc-latest-stable-item70-f1a-backend-readiness.md
@@ -1,6 +1,7 @@
 # Item 70-F1A: durable backend capability and implementation readiness
 
-Assessment complete, 2026-09-08. Owner: release/distribution,
+Assessment complete and merged, 2026-09-08, via
+[PR #3812](https://github.com/sifr-lang/sifr/pull/3812). Owner: release/distribution,
 [issue #3775](https://github.com/sifr-lang/sifr/issues/3775).
 This docs-only unit implements the coordinator's Item 70-F1A registration.
 It makes no resource, credential, permission, upload, qualification or
@@ -234,3 +235,24 @@ historical search, create-PR gate, merge gate, qualification or publication.
 One exact-SHA Opus assessment review, at most one remediation; publish review
 and validation outside the reviewed tree. Merge assessment, then update the
 phase record without another review or Sifr gate, and stop.
+
+Reviewed candidate `e74ea1dc366edea5d324b25da4a52be571337bc5`, merge
+`546c0f3b22438aeaf2d6b012264744356777032f`. Named checks passed on unchanged
+candidate bytes: file-size guardrail 3,762 files, diff/local paths, 14 API
+collection identities/counts, two metadata hashes and five base-tree blobs.
+The ONE Opus review returned SATISFIED/no blockers; zero remediation, zero
+Sifr gates. [Validation receipt](https://github.com/sifr-lang/sifr/pull/3812#issuecomment-5581503394),
+[full sanitized metadata](https://github.com/sifr-lang/sifr/pull/3812#issuecomment-5581503738),
+[supplemental metadata](https://github.com/sifr-lang/sifr/pull/3812#issuecomment-5581503975),
+and [full review](https://github.com/sifr-lang/sifr/pull/3812#issuecomment-5581510828)
+are published outside the reviewed Git tree. Raw review response SHA-256:
+`638dbca68aa76961e7f0139ff6c110c0b2a46f4b33427a5c006cc8e588538303`.
+
+Nonblocking review follow-ups belong to later F1C: recheck pricing when an
+actual provider is selected; use full timestamps for future metadata receipts;
+evaluate storage-role separation with observed environment protection metadata.
+Existing environment rules are not an in-scope defect or authorization to add
+approval requirements. These do not change F1B's offline boundary.
+F1A blocker: none. This record-only update needs no second review or Sifr
+gate. After its merge, release the owned session and stop; no later item,
+provider action, qualification or publication is executed here.

--- a/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
+++ b/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
@@ -8,7 +8,9 @@ ledger while Kafka and gate-bearing items retain explicit prerequisites.
 
 ### Item 70-F1A — durable backend capability and implementation readiness
 
-Assessment complete; exact-SHA review and merge pending. The coordinator
+Assessment COMPLETE via [PR #3812](https://github.com/sifr-lang/sifr/pull/3812).
+Reviewed candidate `e74ea1dc366edea5d324b25da4a52be571337bc5`, merge
+`546c0f3b22438aeaf2d6b012264744356777032f`. The coordinator
 authorized this read-only metadata/docs unit independently of compiler/policy
 delivery. The [assessment](ad-hoc-latest-stable-item70-f1a-backend-readiness.md)
 records scoped repository/org/four-environment API identities, secret names
@@ -32,6 +34,21 @@ diff, file-size guardrail, local links/paths and exact source/API metadata
 identities. No Cargo, native execution, historical search, Sifr gate or
 qualification. One Opus review, at most one remediation; merge assessment,
 record evidence without another review/gate, then stop.
+
+All named checks passed, including the 3,762-file size guardrail; ONE exact-SHA
+Opus review returned SATISFIED/no blockers. Zero remediation and zero Sifr
+gates. [Validation](https://github.com/sifr-lang/sifr/pull/3812#issuecomment-5581503394),
+[sanitized metadata](https://github.com/sifr-lang/sifr/pull/3812#issuecomment-5581503738),
+[supplemental metadata](https://github.com/sifr-lang/sifr/pull/3812#issuecomment-5581503975),
+[review](https://github.com/sifr-lang/sifr/pull/3812#issuecomment-5581510828).
+Review SHA-256 `638dbca68aa76961e7f0139ff6c110c0b2a46f4b33427a5c006cc8e588538303`.
+F1C follow-ups: refresh provider pricing at actual selection; capture full
+timestamps for future API receipts; evaluate actual storage access separation
+without inferring a new environment-approval requirement from existing rules.
+Assessment blocker: none. Online access/copy proof remains a later prerequisite.
+Record-only branch `codex/latest-stable-item70-f1a-record`; after this record
+merges, stop and return terminal. F1B is merely registered for a future sole
+child; this session starts no next item.
 
 ### Item 70 — merged bounded recovery assessment / authorized disposition
 


### PR DESCRIPTION
Record merged Item 70-F1A assessment PR #3812, exact reviewed candidate e74ea1dc366edea5d324b25da4a52be571337bc5 and merge 546c0f3b22438aeaf2d6b012264744356777032f, named validation, sanitized metadata and SATISFIED Opus evidence. Preserve bounded later F1C follow-ups and the assessment's no-blocker terminal state.

Two Markdown files only. Diff and changed-document local-link/evidence-identity checks pass; unchanged file-size evidence (3,762 files) is reused. This post-merge record update requires no second review or Sifr gate. No later item is started.
