### PR TITLE
Add offline release evidence archive contract (70-F1B)

### DIFF
--- a/plans/issues/active/ad-hoc-latest-stable-item70-f1b-offline-archive.md
+++ b/plans/issues/active/ad-hoc-latest-stable-item70-f1b-offline-archive.md
@@ -1,0 +1,154 @@
+# Item 70-F1B: offline release evidence archive contract
+
+Implements the independently ready offline item registered by the merged
+[F1A assessment](ad-hoc-latest-stable-item70-f1a-backend-readiness.md).
+Owner: release/distribution, [issue #3775](https://github.com/sifr-lang/sifr/issues/3775).
+The [Item 70 disposition](ad-hoc-latest-stable-item70-evidence-recovery.md)
+remains INCOMPLETE/UNRECOVERED. Synthetic tests are new test identities and
+local bytes; they are neither historical recovery nor actual qualification.
+
+## Format and ownership
+
+The new [archive schema](../../../verification/areas/distribution_release/schemas/release_evidence_archive.schema.json)
+is version 1, separate from existing qualification/index/report schemas.
+[archive_manifest.py](../../../verification/areas/distribution_release/governance/archive_manifest.py)
+owns canonical construction, strict parsing, portable path checks and byte
+verification. [archive_bindings.py](../../../verification/areas/distribution_release/governance/archive_bindings.py)
+owns the required inventory and cross-links.
+[archive_store.py](../../../verification/areas/distribution_release/governance/archive_store.py)
+defines the provider interface and sealing/readback/receipt operations.
+No production store or filesystem fallback is supplied. The only store
+implementation is an in-memory double inside the named offline selftest.
+
+Input inventory has exactly `schema_version`, `identity`, `matrix`, and
+`artifacts`. Its identity binds repository, exact source SHA, qualification
+workflow path, run ID and attempt, canonical index digest, recursive submodule
+SHAs, lockfile digest, the four reported toolchain versions, and canonical
+release-profile manifest digest. The schema spells out every field.
+
+Each artifact has `role`, `path`, positive `size_bytes`, `sha256`, and
+`producer`. Producer fields repeat the enclosing repository/source/workflow/
+run/attempt association and name `job`, `execution` (`local` or `workflow`),
+plus the real upload `artifact_id` for transported payloads and ZIPs.
+For local capture, the run fields associate custody with the qualification
+bundle; `execution: local` does not claim that the workflow ran the local
+release profile or review. Source provenance and observed producer identities
+must be supplied by the later online integration; this offline format does
+not establish GitHub identity or authenticate a Git source tree on its own.
+
+The manifest adds `archive_root`, `inventory_sha256`, and each artifact's
+`key`. It sorts artifacts by unique logical role and matrix rows by target;
+duplicate roles are rejected even when their hashes agree. The inventory
+digest covers the exact normalized inventory without these derived fields.
+The manifest uses the existing `canonical_json_bytes` convention and SHA-256
+of those exact bytes. Root is `sifr/<S>/<R>/<A>/<index-sha256>/`, with
+`objects/sha256/<digest>` and `manifest.json` below it. Distinct logical roles
+may share a verified content object while retaining distinct portable input
+paths. Path aliases, duplicate/case-folded/prefix conflicts, traversal,
+absolute paths and symlinks are rejected before payload reads. Local reads
+walk directory descriptors without following any symlink, including root
+ancestors; pass a resolved owned root on systems where `/tmp` is a symlink.
+
+## Required inventory
+
+The role registry in `archive_bindings.py` requires all 20 indexed payload
+roles, the canonical index, seven original transport ZIPs and upload metadata,
+run metadata, workflow logs for all seven jobs, expanded release report and
+every bound result, standalone documentation result and summary, source and
+toolchain inventories, original lockfile and profile bytes, platform policy,
+support claims, candidate plan, release notes, and review evidence/raw log.
+
+The six-row matrix contains exactly four native rows and two Windows
+structured-skip rows. Skip reasons must match the archived platform policy;
+each skip has its own source-bound result. Every native report must bind its
+source, target, runner, archive/sidecar/sysroot bytes and native smoke result.
+Transport ZIPs bind API upload IDs and digests and contain exactly their
+indexed files (or the index itself), whose sizes and hashes are rechecked.
+There is no extraction or download.
+
+Dynamic roles are `result:<report-relative-path>`, `step-log:<step-name>`, and
+`case-log:<area>:<suite>:<case-id>`. The bound report defines their exact set;
+all selected suites must be represented, including areas beyond the older
+four-area minimum. The archived profile's selected areas, including the
+existing developer-tooling full-to-editor-release expansion, must exactly
+match the report. Missing classes, bytes, results or logs fail closed.
+Candidate/report/index/source/toolchain/documentation/review links are checked
+against actual retained bytes. These are custody checks, not a replacement
+for live qualification or release-plan validation.
+
+Only pre-publication roles are registered in this version. Future protected
+approval/sign-off/publication bytes require separately owned additive archive
+work after those actions actually occur. No successful approval receipt is
+invented to fill their current absence.
+
+## Offline entry points and store semantics
+
+The [CLI](../../../scripts/distribution/archive_release_evidence.py) implements
+the two registered commands:
+
+```text
+python3 scripts/distribution/archive_release_evidence.py plan --inventory <inventory.json> --payload-root <owned-input> --out <new-manifest.json>
+python3 scripts/distribution/archive_release_evidence.py verify-local --manifest <manifest.json> --manifest-sha256 <trusted-digest> --expected-source <S> --expected-run <R> --expected-attempt <A> --payload-root <separate-copy>
+```
+
+`plan` verifies complete local inventory and atomically creates a new manifest
+file without replacing an existing output. It does not upload/seal a backend.
+`verify-local` checks the externally supplied digest, source/run/attempt,
+inventory and every local byte. The trusted digest must be pinned outside
+the copy being verified; deriving it from an untrusted copy provides no trust.
+
+`ArchiveStore.create` must atomically refuse an existing key and never change
+its bytes; `read` must retrieve fresh exact bytes. `seal` verifies input and
+each created/reused content object, rechecks all stored bytes and links, then
+creates the root manifest exactly once. Existing identical content can be
+reused only after full readback; conflicting bytes and resealing fail.
+Interrupted object transfer leaves no sealed manifest. Provider-level atomic
+create and retention guarantees are prerequisites for a real adapter.
+
+`attest_readback` writes a separate append-only receipt only after every
+configured location has independently returned and verified its manifest and
+all objects against the same external digest. Copy receipts require at least
+two distinct location identities/handles; this does not prove physical or
+administrative independence. Receipts explicitly state
+`complete-byte-readback-only`, bind exact manifest and inventory digests, and
+never modify their own manifest. An interrupted/missing/mutated copy cannot
+produce success. If receipt replication itself interrupts, any already
+written receipt truthfully attests completed byte reads; the operation still
+raises and cannot report complete receipt replication. Event IDs are
+caller-owned and create-only, so retry with a reused receipt ID is rejected.
+
+Archive readback intentionally accepts expired custody bytes through the
+existing non-live index validation path. Calling the unchanged live validator
+with `require_unexpired=True` still rejects the same expired bytes and still
+requires exactly 30-day Actions retention. Durable custody is not renewed
+authorization, qualification, or publication approval.
+
+## Validation and closure boundary
+
+Only the registered checks run:
+
+```text
+python3 -m unittest verification.areas.distribution_release.governance.archive_offline_selftest
+git diff --check
+python3 scripts/check_file_size_guardrails.py
+```
+
+The seven required named tests cover all-class roundtrip and both CLI
+operations, schema enrollment, missing/mutated/truncated bytes, removed
+classes/results/logs, rehashed cross-link defects and ZIP entries, duplicate
+logical roles and producer identities, interrupted/immutable storage, full
+fresh copy readback, unchanged live freshness, unsafe paths/symlinks and
+untrusted digests. Tests use only inline synthetic data and temporary files.
+The new schema has one minimal entry in the existing exact-schema registry;
+the selftest verifies that enrollment. No broad test command, Cargo, native
+execution, provider, workflow, lockfile, tracked fixture file, or historical
+evidence changes are part of this item; no Sifr gate is required.
+
+Owned base `579770185d7c14c62e1b60bee7f740b077cac84e`, branch
+`codex/latest-stable-item70-f1b`, independent clone
+`/private/tmp/sifr-item70-f1b.qRSMYj/codebase`; external evidence root
+`/private/tmp/sifr-item70-f1b.qRSMYj`. Parent/predecessor stores remain read-only.
+One exact-SHA Opus review, at most one remediation. Record validation and
+review outside the reviewed tree, merge, update the phase record without a
+second review/gate, and stop. F1C provider/copy proof and F1D integration are
+later owners; neither is started by this item.

--- a/plans/issues/active/ad-hoc-latest-stable-item70-f1b-offline-archive.md
+++ b/plans/issues/active/ad-hoc-latest-stable-item70-f1b-offline-archive.md
@@ -139,8 +139,13 @@ classes/results/logs, rehashed cross-link defects and ZIP entries, duplicate
 logical roles and producer identities, interrupted/immutable storage, full
 fresh copy readback, unchanged live freshness, unsafe paths/symlinks and
 untrusted digests. Tests use only inline synthetic data and temporary files.
-The new schema has one minimal entry in the existing exact-schema registry;
-the selftest verifies that enrollment. No broad test command, Cargo, native
+The new schema has one entry in the existing exact-schema registry and one
+explicit independently versioned declaration in the two v2-epoch guards.
+Only the two archive modules owning v1 literals are exempted from the v2
+source sweep; existing schemas and source retain v2 enforcement. The runner's
+schema-count registration includes the new twentieth schema. The named
+selftest checks this enrollment and the preserved v2 rejection boundaries.
+No broad test command, Cargo, native
 execution, provider, workflow, lockfile, tracked fixture file, or historical
 evidence changes are part of this item; no Sifr gate is required.
 

--- a/scripts/distribution/archive_release_evidence.py
+++ b/scripts/distribution/archive_release_evidence.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Offline archive planning/readback only; no upload, provider, or qualification."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from verification.areas.distribution_release.governance.archive_manifest import (  # noqa: E402
+    plan, read_local, verify_local,
+)
+from verification.areas.distribution_release.governance.common import (  # noqa: E402
+    GovernanceError, canonical_json_bytes, load_json_bytes_strict, sha256_bytes,
+)
+
+
+def create_output(path: Path, raw: bytes) -> None:
+    """Install complete bytes atomically without clobbering an existing output."""
+    descriptor, temporary = tempfile.mkstemp(prefix=".archive-plan-", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(raw)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, path)
+    finally:
+        os.unlink(temporary)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    planning = commands.add_parser("plan")
+    planning.add_argument("--inventory", type=Path, required=True)
+    planning.add_argument("--payload-root", type=Path, required=True)
+    planning.add_argument("--out", type=Path, required=True)
+    verifying = commands.add_parser("verify-local")
+    verifying.add_argument("--manifest", type=Path, required=True)
+    verifying.add_argument("--manifest-sha256", required=True)
+    verifying.add_argument("--expected-source", required=True)
+    verifying.add_argument("--expected-run", type=int, required=True)
+    verifying.add_argument("--expected-attempt", type=int, required=True)
+    verifying.add_argument("--payload-root", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "plan":
+            inventory = load_json_bytes_strict(read_local(args.inventory.parent, args.inventory.name), source="inventory")
+            manifest = plan(inventory, args.payload_root)
+            raw = canonical_json_bytes(manifest)
+            create_output(args.out, raw)
+        else:
+            raw = read_local(args.manifest.parent, args.manifest.name)
+            manifest = verify_local(
+                raw, manifest_sha256=args.manifest_sha256, expected_source=args.expected_source,
+                expected_run=args.expected_run, expected_attempt=args.expected_attempt,
+                payload_root=args.payload_root,
+            )
+    except (GovernanceError, OSError) as exc:
+        print(f"archive-evidence: {exc}", file=sys.stderr)
+        return 2
+    print(f"archive {args.command} ok: sha256={sha256_bytes(raw)} objects={len(manifest['artifacts'])}; custody only")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/distribution_release/governance/archive_bindings.py
+++ b/verification/areas/distribution_release/governance/archive_bindings.py
@@ -1,0 +1,245 @@
+"""Archive inventory completeness and immutable cross-artifact identity links."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import PurePosixPath
+from typing import Any, Callable
+
+from .archive_manifest import SKIP_TARGETS, safe_path
+from .artifact_index import EXPECTED_ARTIFACT_IDS, validate_qualification_artifact_index
+from .common import (
+    BUILDERS, TARGETS, GovernanceError, canonical_json_bytes,
+    load_json_bytes_strict, require_object, sha256_bytes,
+)
+from .release_report import validate_release_profile_report
+
+UPLOAD_JOBS = (*TARGETS, "editor", "assemble", "index")
+SINGLETON_ROLES = {
+    "qualification-index", "run-metadata", "upload-metadata", "release-profile-report",
+    "documentation-result", "documentation-summary", "source-inventory", "lockfile",
+    "toolchain-inventory", "profile-manifest", "platform-policy", "support-claims",
+    "candidate-plan", "release-notes", "review-evidence", "review-log",
+}
+REQUIRED_ROLES = (
+    SINGLETON_ROLES | EXPECTED_ARTIFACT_IDS
+    | {f"transport-zip:{job}" for job in UPLOAD_JOBS}
+    | {f"workflow-log:{job}" for job in UPLOAD_JOBS}
+    | {f"structured-skip:{target}" for target in SKIP_TARGETS}
+)
+
+
+def equal(observed: Any, expected: Any, label: str) -> None:
+    if observed != expected:
+        raise GovernanceError(f"{label}: archive cross-link mismatch")
+
+
+def validate_required_roles(manifest: dict[str, Any]) -> None:
+    roles = {record["role"] for record in manifest["artifacts"]}
+    missing = REQUIRED_ROLES - roles
+    if missing:
+        raise GovernanceError(f"missing required producer classes: {sorted(missing)}")
+    # Later protected approval/publication needs a separately scoped additive manifest.
+    for role in roles - REQUIRED_ROLES:
+        if not role.startswith(("result:", "step-log:", "case-log:")):
+            raise GovernanceError(f"unregistered archive role: {role}")
+    matrix = manifest["matrix"]
+    equal([row["target"] for row in matrix], sorted((*TARGETS, *SKIP_TARGETS)), "complete platform matrix")
+    for row in matrix:
+        native = row["target"] in TARGETS
+        equal(row["mode"], "native" if native else "structured-skip", "platform mode")
+        if (native and row["reasons"]) or (not native and not row["reasons"]):
+            raise GovernanceError("native rows cannot skip; host-limited rows require reasons")
+        equal(row["reasons"], sorted(row["reasons"]), "ordered skip reasons")
+
+
+def verify_bindings(manifest: dict[str, Any], read: Callable[[dict[str, Any]], bytes]) -> None:
+    records = {record["role"]: record for record in manifest["artifacts"]}
+    identity = manifest["identity"]
+
+    def document(role: str) -> dict[str, Any]:
+        return require_object(load_json_bytes_strict(read(records[role]), source=role), role)
+
+    index_raw = read(records["qualification-index"])
+    index = validate_qualification_artifact_index(load_json_bytes_strict(
+        index_raw, source="qualification-index", require_canonical=True))
+    equal(records["qualification-index"]["sha256"], identity["index_sha256"], "index digest")
+    equal(index["source_commit"], identity["source_commit"], "index source")
+    equal(index["submodules"], identity["submodules"], "index submodules")
+    for key in ("repository", "run_id", "run_attempt"):
+        equal(index["workflow"][key], identity[key], f"index {key}")
+    run = document("run-metadata")
+    for key, field in (("id", "run_id"), ("run_attempt", "run_attempt"),
+                       ("head_sha", "source_commit"), ("path", "workflow_path")):
+        equal(run.get(key), identity[field], f"run {key}")
+    equal(run.get("repository", {}).get("full_name"), identity["repository"], "run repository")
+    equal(run.get("event"), "workflow_dispatch", "run event")
+    equal(document("source-inventory"), identity, "source inventory")
+    equal(document("toolchain-inventory"), identity["toolchain"], "toolchain inventory")
+    equal(records["lockfile"]["sha256"], identity["lock_sha256"], "lockfile")
+
+    for artifact in index["artifacts"]:
+        record = records[artifact["id"]]
+        equal(record["sha256"], artifact["sha256"], f"{artifact['id']} digest")
+        equal(record["size_bytes"], artifact["size_bytes"], f"{artifact['id']} size")
+        equal(PurePosixPath(record["path"]).name, artifact["name"], "transported filename")
+        equal(record["producer"].get("artifact_id"), artifact["workflow_artifact_id"], "upload identity")
+    verify_uploads(index, records, document("upload-metadata"), identity, read)
+    verify_report(records, document, identity)
+    verify_platforms(manifest, records, document, identity)
+    docs = document("documentation-summary")
+    equal(docs.get("source_commit"), identity["source_commit"], "documentation source")
+    equal(docs.get("result_sha256"), records["documentation-result"]["sha256"], "standalone documentation result")
+    candidate = document("candidate-plan")
+    equal(candidate.get("source_commit"), identity["source_commit"], "candidate source")
+    equal(candidate.get("submodules"), identity["submodules"], "candidate submodules")
+    equal(candidate.get("cargo_lock_sha256"), identity["lock_sha256"], "candidate lock")
+    for field, role in (("release_profile_report", "release-profile-report"),
+                        ("qualification_artifact_index", "qualification-index"),
+                        ("documentation_report", "documentation-summary")):
+        equal(candidate.get(field, {}).get("sha256"), records[role]["sha256"], f"candidate {field}")
+    equal(candidate.get("rust_interop", {}).get("stable_support_claims_sha256"),
+          records["support-claims"]["sha256"], "candidate support claims")
+    equal(candidate.get("release_notes_sha256"), records["release-notes"]["sha256"], "candidate release notes")
+    equal(candidate.get("toolchain"), {
+        "rustc": identity["toolchain"]["rustc"], "cargo": identity["toolchain"]["cargo"],
+        "profile_manifest_sha256": identity["profile_sha256"],
+    }, "candidate toolchain")
+    review = document("review-evidence")
+    equal(review.get("source_commit"), identity["source_commit"], "review source")
+    equal(review.get("log_sha256"), records["review-log"]["sha256"], "review log")
+    # Archive preserves the actual review outcome, with no fabricated approval requirement.
+
+
+def verify_uploads(index: dict[str, Any], records: dict[str, Any], metadata: dict[str, Any],
+                   identity: dict[str, Any], read: Callable[[dict[str, Any]], bytes]) -> None:
+    uploads = metadata.get("artifacts")
+    if not isinstance(uploads, list) or len(uploads) != len(UPLOAD_JOBS):
+        raise GovernanceError("must retain metadata for all seven original transport ZIPs")
+    ids: set[int] = set()
+    by_job: dict[str, Any] = {}
+    prefix = f"sifr-stable-candidate-{index['candidate_version']}-{identity['source_commit']}-"
+    for upload in uploads:
+        upload = require_object(upload, "upload")
+        upload_id = upload.get("id")
+        if type(upload_id) is not int or upload_id < 1 or upload_id in ids:
+            raise GovernanceError("duplicate or invalid upload identity")
+        ids.add(upload_id)
+        name = upload.get("name")
+        if not isinstance(name, str) or not name.startswith(prefix):
+            raise GovernanceError("wrong upload source/version name")
+        job = name[len(prefix):]
+        if job not in UPLOAD_JOBS or job in by_job:
+            raise GovernanceError("duplicate or unknown upload job")
+        by_job[job] = upload
+        equal(upload.get("workflow_run", {}).get("id"), identity["run_id"], "upload run")
+        transport = records[f"transport-zip:{job}"]
+        equal(transport["producer"].get("artifact_id"), upload_id, "ZIP upload identity")
+        equal(upload.get("digest"), "sha256:" + transport["sha256"], "original ZIP digest")
+        expected = {item["name"]: records[item["id"]] for item in index["artifacts"]
+                    if item["workflow_artifact_id"] == upload_id}
+        if job == "index":
+            expected = {"qualification-artifact-index.json": records["qualification-index"]}
+            owner = records["qualification-index"]["producer"]
+            equal(owner.get("artifact_id"), upload_id, "index upload identity")
+            equal(owner["job"], job, "index producer job")
+            equal(owner["execution"], "workflow", "index producer execution")
+        if not expected:
+            raise GovernanceError("ZIP does not bind any indexed payload")
+        for artifact in index["artifacts"]:
+            if artifact["workflow_artifact_id"] == upload_id:
+                equal(artifact["workflow_artifact_name"], name, "index upload name")
+                equal(records[artifact["id"]]["producer"]["job"], job, "payload producer job")
+                equal(records[artifact["id"]]["producer"]["execution"], "workflow", "payload execution")
+        equal(transport["producer"]["job"], job, "ZIP producer job")
+        equal(transport["producer"]["execution"], "workflow", "ZIP execution")
+        log = records[f"workflow-log:{job}"]
+        equal(log["producer"]["job"], job, "workflow log job")
+        equal(log["producer"]["execution"], "workflow", "workflow log execution")
+        try:
+            with zipfile.ZipFile(io.BytesIO(read(transport))) as archive:
+                entries = archive.infolist()
+                names = [safe_path(entry.filename) for entry in entries]
+                if len(names) != len(set(names)) or set(names) != set(expected):
+                    raise GovernanceError("ZIP must contain exactly its original payload inventory")
+                for entry in entries:
+                    if (entry.external_attr >> 16) & 0o170000 == 0o120000:
+                        raise GovernanceError("ZIP symlinks are forbidden")
+                    record = expected[entry.filename]
+                    equal(entry.file_size, record["size_bytes"], "ZIP entry size")
+                    equal(sha256_bytes(archive.read(entry)), record["sha256"], "ZIP entry digest")
+        except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+            raise GovernanceError(f"invalid original ZIP: {exc}") from exc
+
+
+def verify_report(records: dict[str, Any], document: Callable[[str], dict[str, Any]],
+                  identity: dict[str, Any]) -> None:
+    report = validate_release_profile_report(document("release-profile-report"),
+                                             expected_profile_sha256=identity["profile_sha256"])
+    equal(report["source"]["commit"], identity["source_commit"], "release report source")
+    equal(report["source"]["submodules"], identity["submodules"], "release report submodules")
+    equal(report["toolchain"], identity["toolchain"], "release report toolchain")
+    profile = document("profile-manifest")
+    equal(sha256_bytes(canonical_json_bytes(profile)), identity["profile_sha256"], "profile manifest digest")
+    equal(profile.get("name"), "release", "profile name")
+    expected: dict[str, set[str]] = {}
+    selections = profile.get("selected_areas")
+    if not isinstance(selections, list):
+        raise GovernanceError("profile selected_areas must be an array")
+    for selection in selections:
+        if not isinstance(selection, dict) or not isinstance(selection.get("suites"), list):
+            raise GovernanceError("invalid selected profile suites")
+        expected.setdefault(selection["area"], set()).update(selection["suites"])
+    if "full" in expected.get("developer_tooling", set()):
+        expected["developer_tooling"].add("editor-release")
+    equal({row["area"]: set(row["suites"]) for row in report["profile"]["expanded_selected_areas"]},
+          expected, "complete expanded release profile")
+    result_roles = set()
+    for artifact in report["result_artifacts"]:
+        role = "result:" + safe_path(artifact["path"])
+        result_roles.add(role)
+        if role not in records:
+            raise GovernanceError(f"missing bound result: {role}")
+        equal(records[role]["sha256"], artifact["sha256"], role)
+    log_roles = set()
+    observed: dict[str, set[str]] = {}
+    for step in report["steps"]:
+        log_roles.add("step-log:" + step["name"])
+        for suite in step["suite_results"]:
+            observed.setdefault(suite["area"], set()).add(suite["suite"])
+            for case in suite["case_ids"]:
+                log_roles.add(f"case-log:{suite['area']}:{suite['suite']}:{case}")
+    equal(observed, expected, "every selected suite executed")
+    equal({role for role in records if role.startswith("result:")}, result_roles, "exact bound results")
+    equal({role for role in records if role.startswith(("step-log:", "case-log:"))}, log_roles,
+          "complete raw step/case logs")
+
+
+def verify_platforms(manifest: dict[str, Any], records: dict[str, Any],
+                     document: Callable[[str], dict[str, Any]], identity: dict[str, Any]) -> None:
+    policy = document("platform-policy")
+    rows = policy.get("host_triples")
+    if not isinstance(rows, list) or len(rows) != 6:
+        raise GovernanceError("complete six-host platform policy required")
+    equal(sorted(row.get("triple", "") for row in rows), sorted((*TARGETS, *SKIP_TARGETS)), "platform policy")
+    for row in manifest["matrix"]:
+        target = row["target"]
+        declared = next(entry for entry in rows if entry["triple"] == target)
+        equal(declared.get("status"), "supported" if target in TARGETS else "host-limited", "declared platform status")
+        if target in TARGETS:
+            report = document(f"qualification-report-{target}")
+            for key, value in (("source_commit", identity["source_commit"]), ("target", target),
+                               ("builder", BUILDERS[target]), ("smoke_status", "pass")):
+                equal(report.get(key), value, f"target report {key}")
+            for field, role in (("archive_sha256", "binary-archive"), ("checksum_sha256", "checksum"),
+                                ("sysroot_bundle_sha256", "sysroot")):
+                equal(report.get(field), records[f"{role}-{target}"]["sha256"], f"target {field}")
+        else:
+            equal(row["reasons"], sorted(declared.get("allowed_skips", [])), "declared skip reasons")
+            skip = document(f"structured-skip:{target}")
+            equal(skip, {"source_commit": identity["source_commit"], "target": target,
+                         "status": "structured-skip", "reasons": row["reasons"]}, "structured skip evidence")
+    editor = document("editor-qualification-report")
+    equal(editor.get("source_commit"), identity["source_commit"], "editor source")
+    equal(editor.get("vsix_sha256"), records["vsix"]["sha256"], "editor VSIX")

--- a/verification/areas/distribution_release/governance/archive_manifest.py
+++ b/verification/areas/distribution_release/governance/archive_manifest.py
@@ -1,0 +1,193 @@
+"""Versioned, provider-independent release evidence archive contracts.
+
+An archive authenticates custody, never live qualification or publication approval.
+The manifest digest must be pinned outside the archive before readback.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import stat
+import unicodedata
+from pathlib import Path
+from typing import Any, Callable
+
+from verification.json_schema_202012 import JsonSchemaError, validate_instance
+
+from .common import (
+    GovernanceError, canonical_json_bytes, load_json_bytes_strict,
+    require_commit, require_exact_keys, require_object, require_sha256, sha256_bytes,
+)
+
+SCHEMA = Path(__file__).resolve().parents[1] / "schemas/release_evidence_archive.schema.json"
+WORKFLOW = ".github/workflows/release-qualification.yml"
+SKIP_TARGETS = ("x86_64-pc-windows-msvc", "x86_64-pc-windows-gnu")
+
+
+def safe_path(value: str) -> str:
+    """Use one portable spelling; reject aliases before touching payload bytes."""
+    if (not isinstance(value, str) or not value or value.startswith("/")
+            or "\\" in value or ":" in value
+            or any(ord(char) < 32 for char in value)
+            or unicodedata.normalize("NFC", value) != value
+            or any(part in {"", ".", ".."} or part.endswith((".", " "))
+                   for part in value.split("/"))):
+        raise GovernanceError(f"unsafe archive path: {value!r}")
+    return value
+
+
+def check_paths(paths: list[str]) -> None:
+    seen: set[str] = set()
+    for path in paths:
+        normalized = safe_path(path).casefold()
+        if normalized in seen:
+            raise GovernanceError(f"conflicting normalized path: {path}")
+        seen.add(normalized)
+    for path in seen:
+        parts = path.split("/")
+        if any("/".join(parts[:i]) in seen for i in range(1, len(parts))):
+            raise GovernanceError(f"file/directory path conflict: {path}")
+
+
+def read_local(root: Path, relative: str) -> bytes:
+    """Descriptor-relative no-follow traversal, including all root ancestors."""
+    safe_path(relative)
+    root = Path(os.path.abspath(root))
+    descriptors: list[int] = []
+    try:
+        descriptor = os.open(root.anchor, os.O_RDONLY | os.O_DIRECTORY)
+        descriptors.append(descriptor)
+        for part in (*root.parts[1:], *relative.split("/")[:-1]):
+            descriptor = os.open(
+                part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=descriptor
+            )
+            descriptors.append(descriptor)
+        descriptor = os.open(
+            relative.split("/")[-1], os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+            dir_fd=descriptor,
+        )
+        descriptors.append(descriptor)
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise GovernanceError(f"not a regular archive file: {relative}")
+        with os.fdopen(os.dup(descriptor), "rb") as stream:
+            return stream.read()
+    except OSError as exc:
+        raise GovernanceError(f"cannot safely read {relative}: {exc}") from exc
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def archive_root(identity: dict[str, Any]) -> str:
+    return (f"sifr/{identity['source_commit']}/{identity['run_id']}/"
+            f"{identity['run_attempt']}/{identity['index_sha256']}/")
+
+
+def inventory_of(manifest: dict[str, Any]) -> dict[str, Any]:
+    inventory = copy.deepcopy({key: manifest[key] for key in ("schema_version", "identity", "matrix", "artifacts")})
+    for artifact in inventory["artifacts"]:
+        artifact.pop("key")
+    return inventory
+
+
+def construct_manifest(inventory: Any) -> dict[str, Any]:
+    inventory = require_object(inventory, "inventory")
+    require_exact_keys(inventory, required={"schema_version", "identity", "matrix", "artifacts"},
+                       location="inventory")
+    manifest = copy.deepcopy(inventory)
+    if not isinstance(manifest["artifacts"], list) or not isinstance(manifest["matrix"], list):
+        raise GovernanceError("inventory artifacts and matrix must be arrays")
+    for record in manifest["artifacts"]:
+        require_exact_keys(require_object(record, "artifact"),
+                           required={"role", "path", "size_bytes", "sha256", "producer"},
+                           location="artifact")
+    identity = require_object(manifest["identity"], "identity")
+    if not {"source_commit", "run_id", "run_attempt", "index_sha256"} <= identity.keys():
+        raise GovernanceError("incomplete archive identity")
+    manifest["archive_root"] = archive_root(identity)
+    for record in manifest["artifacts"]:
+        record["key"] = manifest["archive_root"] + f"objects/sha256/{record['sha256']}"
+    try:
+        manifest["artifacts"].sort(key=lambda record: record["role"])
+        manifest["matrix"].sort(key=lambda row: row["target"])
+    except (KeyError, TypeError) as exc:
+        raise GovernanceError("invalid logical artifact or matrix identity") from exc
+    manifest["inventory_sha256"] = sha256_bytes(canonical_json_bytes(inventory_of(manifest)))
+    return validate_manifest(manifest)
+
+
+def validate_manifest(manifest: Any) -> dict[str, Any]:
+    try:
+        validate_instance(manifest, SCHEMA)
+    except JsonSchemaError as exc:
+        raise GovernanceError(str(exc)) from exc
+    identity = manifest["identity"]
+    require_commit(identity["source_commit"], "archive source")
+    for commit in identity["submodules"].values():
+        require_commit(commit, "archive submodule")
+    for field in ("index_sha256", "lock_sha256", "profile_sha256"):
+        require_sha256(identity[field], field)
+    check_paths(list(identity["submodules"]))
+    root = archive_root(identity)
+    if manifest["archive_root"] != root:
+        raise GovernanceError("archive root identity mismatch")
+    roles = [record["role"] for record in manifest["artifacts"]]
+    if roles != sorted(set(roles)):
+        raise GovernanceError("duplicate or unordered logical artifact records")
+    check_paths([record["path"] for record in manifest["artifacts"]])
+    for record in manifest["artifacts"]:
+        require_sha256(record["sha256"], "artifact digest")
+        if record["key"] != root + f"objects/sha256/{record['sha256']}":
+            raise GovernanceError("content-addressed key mismatch")
+        for field in ("repository", "source_commit", "workflow_path", "run_id", "run_attempt"):
+            if record["producer"][field] != identity[field]:
+                raise GovernanceError(f"{record['role']}: wrong producer {field}")
+    if manifest["inventory_sha256"] != sha256_bytes(canonical_json_bytes(inventory_of(manifest))):
+        raise GovernanceError("exact inventory digest mismatch")
+    from .archive_bindings import validate_required_roles
+    validate_required_roles(manifest)
+    return manifest
+
+
+def parse_manifest(raw: bytes, *, manifest_sha256: str, expected_source: str,
+                   expected_run: int, expected_attempt: int) -> dict[str, Any]:
+    require_sha256(manifest_sha256, "external manifest digest")
+    if sha256_bytes(raw) != manifest_sha256:
+        raise GovernanceError("untrusted manifest digest")
+    manifest = validate_manifest(load_json_bytes_strict(raw, source="archive manifest", require_canonical=True))
+    identity = manifest["identity"]
+    if (type(expected_run) is not int or type(expected_attempt) is not int
+            or (identity["source_commit"], identity["run_id"], identity["run_attempt"])
+            != (expected_source, expected_run, expected_attempt)):
+        raise GovernanceError("wrong expected source/run/attempt")
+    return manifest
+
+
+def verify_bytes(record: dict[str, Any], raw: bytes) -> bytes:
+    if not isinstance(raw, bytes) or len(raw) != record["size_bytes"] or sha256_bytes(raw) != record["sha256"]:
+        raise GovernanceError(f"{record['role']}: missing, mutated or truncated bytes")
+    return raw
+
+
+def verify_payloads(manifest: dict[str, Any], read: Callable[[dict[str, Any]], bytes]) -> None:
+    validate_manifest(manifest)
+    for record in manifest["artifacts"]:
+        verify_bytes(record, read(record))
+    from .archive_bindings import verify_bindings
+    try:
+        verify_bindings(manifest, lambda record: verify_bytes(record, read(record)))
+    except (KeyError, TypeError, AttributeError) as exc:
+        raise GovernanceError(f"malformed bound archive document: {exc}") from exc
+
+
+def plan(inventory: Any, payload_root: Path) -> dict[str, Any]:
+    manifest = construct_manifest(inventory)
+    verify_payloads(manifest, lambda record: read_local(payload_root, record["path"]))
+    return manifest
+
+
+def verify_local(raw: bytes, *, payload_root: Path, **expectations: Any) -> dict[str, Any]:
+    manifest = parse_manifest(raw, **expectations)
+    verify_payloads(manifest, lambda record: read_local(payload_root, record["path"]))
+    return manifest

--- a/verification/areas/distribution_release/governance/archive_offline_selftest.py
+++ b/verification/areas/distribution_release/governance/archive_offline_selftest.py
@@ -225,11 +225,28 @@ class ArchiveOfflineTests(unittest.TestCase):
 
     def test_complete_all_class_roundtrip(self):
         from verification.json_schema_202012 import validate_instance
+        from verification.runner.sifr_verify.selftest import GOVERNANCE_SCHEMA_COUNT
+        from . import schema_epoch
         from .schema_contracts import schema_fixtures
         validate_instance(self.manifest, SCHEMA)
         registered = schema_fixtures()
         self.assertEqual(set(registered), {path.name for path in SCHEMA.parent.glob("*.schema.json")})
         self.assertEqual(registered[SCHEMA.name], self.manifest)
+        self.assertEqual(len(registered), GOVERNANCE_SCHEMA_COUNT)
+        declaration = json.loads(SCHEMA.read_bytes())
+        schema_epoch.check_schema_declaration(SCHEMA, declaration)
+        with self.assertRaises(ValueError):
+            schema_epoch.check_schema_declaration(SCHEMA.with_name("release_index.schema.json"), declaration)
+        changed_declaration = copy.deepcopy(declaration)
+        changed_declaration["properties"]["schema_version"] = {"const": 2}
+        with self.assertRaises(ValueError):
+            schema_epoch.check_schema_declaration(SCHEMA, changed_declaration)
+        schema_epoch.check_schema_declaration(SCHEMA.with_name("release_index.schema.json"), changed_declaration)
+        expected_exclusions = {Path(__file__), Path(__file__).with_name("archive_store.py")}
+        self.assertEqual(schema_epoch.ARCHIVE_SOURCE_EXCLUSIONS, expected_exclusions)
+        self.assertTrue(expected_exclusions.isdisjoint(schema_epoch.governed_sources()))
+        with self.assertRaises(ValueError):
+            schema_epoch.check_source_text(Path("existing-release-owner.py"), '{"schema_version": 1}')
         roles = {row["role"] for row in self.manifest["artifacts"]}
         self.assertTrue(REQUIRED_ROLES <= roles)
         self.assertEqual(len(self.manifest["matrix"]), 6)

--- a/verification/areas/distribution_release/governance/archive_offline_selftest.py
+++ b/verification/areas/distribution_release/governance/archive_offline_selftest.py
@@ -1,0 +1,471 @@
+"""Synthetic archive contracts only: no network, native build, or real custody."""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from .archive_bindings import REQUIRED_ROLES, UPLOAD_JOBS
+from .archive_manifest import (
+    SCHEMA, SKIP_TARGETS, WORKFLOW, construct_manifest, inventory_of, parse_manifest,
+    plan, read_local, verify_local, verify_payloads,
+)
+from .archive_store import attest_readback, manifest_key, readback, seal
+from .artifact_index import validate_qualification_artifact_index
+from .common import (
+    BUILDERS, TARGETS, GovernanceError, canonical_json_bytes, sha256_bytes,
+)
+
+SOURCE = "123456789abcdef0" * 2 + "12345678"
+RUN = 987654321
+ATTEMPT = 3
+SUBMODULES = {"editor_integrations": "23456789abcdef01" * 2 + "23456789"}
+
+
+class MemoryStore:
+    """Intentionally a test double, never imported by the offline CLI."""
+
+    def __init__(self, location="test-memory:primary"):
+        self.location = location
+        self.objects = {}
+        self.reads = []
+        self.fail_after = None
+        self.creates = 0
+
+    def create(self, key, content):
+        if self.fail_after is not None and self.creates >= self.fail_after:
+            raise GovernanceError("synthetic interrupted create")
+        self.creates += 1
+        if key in self.objects:
+            return False
+        self.objects[key] = content
+        return True
+
+    def read(self, key):
+        self.reads.append(key)
+        if key not in self.objects:
+            raise GovernanceError("synthetic missing object")
+        return self.objects[key]
+
+
+def synthetic_bundle():
+    """All-class fresh identities; older generic fixtures supply shapes only."""
+    from .schema_contracts import qualification_index, release_report
+    index = qualification_index()
+    index.update(source_commit=SOURCE, submodules=SUBMODULES)
+    index["workflow"].update(run_id=RUN, run_attempt=ATTEMPT, expires_at="2000-01-31T00:00:00Z")
+    prefix = f"sifr-stable-candidate-0.1.0-{SOURCE}-"
+    report = release_report()
+    report["source"].update(commit=SOURCE, submodules=SUBMODULES)
+    # An extra synthetic area proves expanded coverage is not the old four-area list.
+    report["profile"]["expanded_selected_areas"].append({"area": "new_area", "suites": ["extra"]})
+    report["steps"].append({"name": "new_area", "status": "pass", "elapsed_ms": 1,
+                            "suite_results": [{"area": "new_area", "suite": "extra", "status": "pass",
+                                               "case_ids": ["fresh-case"], "result_artifact_sha256": "a" * 64}]})
+    profile = {"schema_version": 2, "name": "release",
+               "selected_areas": report["profile"]["expanded_selected_areas"]}
+    identity = {"repository": "sifr-lang/sifr", "source_commit": SOURCE, "workflow_path": WORKFLOW,
+                "run_id": RUN, "run_attempt": ATTEMPT, "index_sha256": "a" * 64,
+                "submodules": SUBMODULES, "lock_sha256": sha256_bytes(b"synthetic lock\n"),
+                "toolchain": report["toolchain"], "profile_sha256": sha256_bytes(canonical_json_bytes(profile))}
+    producer = {key: identity[key] for key in ("repository", "source_commit", "workflow_path", "run_id", "run_attempt")}
+    rows = {}
+    payloads = {}
+
+    def add(role, data, *, path=None, job="local-release-profile", execution="local", artifact_id=None):
+        raw = data if isinstance(data, bytes) else canonical_json_bytes(data)
+        path = path or "payload/" + role.replace(":", "_").replace("/", "_") + ".data"
+        owner = {**producer, "job": job, "execution": execution}
+        if artifact_id is not None:
+            owner["artifact_id"] = artifact_id
+        rows[role] = {"role": role, "path": path, "size_bytes": len(raw), "sha256": sha256_bytes(raw), "producer": owner}
+        payloads[path] = raw
+
+    # Create the native bytes before their JSON reports and the index that binds them.
+    for artifact in index["artifacts"]:
+        job = artifact["workflow_artifact_name"].rsplit("-", 1)[-1]
+        job = next((target for target in TARGETS if artifact["id"].endswith(target)), job)
+        artifact["workflow_artifact_name"] = prefix + job
+        artifact["expires_at"] = "2000-01-31T00:00:00Z"
+        add(artifact["id"], f"synthetic:{artifact['id']}\n".encode(), path=f"native/{job}/{artifact['name']}",
+            job=job, execution="workflow", artifact_id=artifact["workflow_artifact_id"])
+    for target in TARGETS:
+        role = f"qualification-report-{target}"
+        add(role, {"source_commit": SOURCE, "target": target, "builder": BUILDERS[target], "smoke_status": "pass",
+                   "archive_sha256": rows[f"binary-archive-{target}"]["sha256"],
+                   "checksum_sha256": rows[f"checksum-{target}"]["sha256"],
+                   "sysroot_bundle_sha256": rows[f"sysroot-{target}"]["sha256"]},
+            path=rows[role]["path"], job=target, execution="workflow", artifact_id=rows[role]["producer"]["artifact_id"])
+    add("editor-qualification-report", {"source_commit": SOURCE, "vsix_sha256": rows["vsix"]["sha256"]},
+        path=rows["editor-qualification-report"]["path"], job="editor", execution="workflow", artifact_id=11)
+    for artifact in index["artifacts"]:
+        artifact.update({key: rows[artifact["id"]][key] for key in ("size_bytes", "sha256")})
+    add("qualification-index", index, path="payload/qualification-artifact-index.json", job="index", execution="workflow", artifact_id=12)
+    identity["index_sha256"] = rows["qualification-index"]["sha256"]
+    uploads = []
+    for job in UPLOAD_JOBS:
+        artifacts = [artifact for artifact in index["artifacts"] if artifact["workflow_artifact_name"] == prefix + job]
+        upload_id = 12 if job == "index" else artifacts[0]["workflow_artifact_id"]
+        content = {artifact["name"]: payloads[rows[artifact["id"]]["path"]] for artifact in artifacts}
+        if job == "index":
+            content = {"qualification-artifact-index.json": payloads[rows["qualification-index"]["path"]]}
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as archive:
+            for name, raw in sorted(content.items()):
+                archive.writestr(zipfile.ZipInfo(name, date_time=(2000, 1, 1, 0, 0, 0)), raw)
+        add(f"transport-zip:{job}", buffer.getvalue(), job=job, execution="workflow", artifact_id=upload_id)
+        uploads.append({"id": upload_id, "name": prefix + job, "workflow_run": {"id": RUN},
+                        "digest": "sha256:" + rows[f"transport-zip:{job}"]["sha256"]})
+        add(f"workflow-log:{job}", f"synthetic workflow log {job}\n".encode(), job=job, execution="workflow")
+    add("upload-metadata", {"artifacts": uploads})
+    add("run-metadata", {"id": RUN, "run_attempt": ATTEMPT, "head_sha": SOURCE, "path": WORKFLOW,
+                         "event": "workflow_dispatch", "repository": {"full_name": "sifr-lang/sifr"}})
+    add("profile-manifest", profile)
+    add("lockfile", b"synthetic lock\n")
+    add("toolchain-inventory", identity["toolchain"])
+    add("source-inventory", identity)
+    report["profile"]["manifest_sha256"] = identity["profile_sha256"]
+    report["result_artifacts"] = []
+    for step in report["steps"]:
+        area = step["suite_results"][0]["area"]
+        result_path = f"target/verification/{area}-results.json"
+        role = "result:" + result_path
+        add(role, {"area": area, "status": "pass", "synthetic": True})
+        report["result_artifacts"].append({"path": result_path, "sha256": rows[role]["sha256"]})
+        add("step-log:" + step["name"], b"synthetic shared log\n")
+        for suite in step["suite_results"]:
+            suite["result_artifact_sha256"] = rows[role]["sha256"]
+            for case in suite["case_ids"]:
+                add(f"case-log:{suite['area']}:{suite['suite']}:{case}", b"synthetic shared log\n")
+    add("release-profile-report", report)
+    matrix = []
+    policy_rows = []
+    for target in (*TARGETS, *SKIP_TARGETS):
+        reasons = [] if target in TARGETS else ["synthetic declared host restriction"]
+        matrix.append({"target": target, "mode": "native" if target in TARGETS else "structured-skip", "reasons": reasons})
+        policy_rows.append({"triple": target, "status": "supported" if target in TARGETS else "host-limited", "allowed_skips": reasons})
+        if target in SKIP_TARGETS:
+            add(f"structured-skip:{target}", {"source_commit": SOURCE, "target": target, "status": "structured-skip", "reasons": reasons})
+    add("platform-policy", {"host_triples": policy_rows})
+    add("documentation-result", {"synthetic": True, "status": "pass"})
+    add("documentation-summary", {"source_commit": SOURCE, "result_sha256": rows["documentation-result"]["sha256"]})
+    add("support-claims", {"claims": ["synthetic"]})
+    add("release-notes", b"Synthetic release notes\n")
+    add("review-log", b"Synthetic offline review; no real approval\n")
+    add("review-evidence", {"source_commit": SOURCE, "log_sha256": rows["review-log"]["sha256"], "verdict": "synthetic"})
+    add("candidate-plan", {
+        "source_commit": SOURCE, "submodules": SUBMODULES, "cargo_lock_sha256": identity["lock_sha256"],
+        "toolchain": {"rustc": identity["toolchain"]["rustc"], "cargo": identity["toolchain"]["cargo"],
+                      "profile_manifest_sha256": identity["profile_sha256"]},
+        "release_profile_report": {"sha256": rows["release-profile-report"]["sha256"]},
+        "qualification_artifact_index": {"sha256": rows["qualification-index"]["sha256"]},
+        "documentation_report": {"sha256": rows["documentation-summary"]["sha256"]},
+        "rust_interop": {"stable_support_claims_sha256": rows["support-claims"]["sha256"]},
+        "release_notes_sha256": rows["release-notes"]["sha256"],
+    })
+    return {"schema_version": 1, "identity": identity, "matrix": matrix, "artifacts": list(rows.values())}, payloads
+
+
+def archive_schema_example():
+    inventory, _ = synthetic_bundle()
+    return construct_manifest(inventory)
+
+
+class ArchiveOfflineTests(unittest.TestCase):
+    def setUp(self):
+        self.inventory, self.payloads = synthetic_bundle()
+        self.manifest = construct_manifest(self.inventory)
+        self.raw = canonical_json_bytes(self.manifest)
+        self.pin = sha256_bytes(self.raw)
+        self.expected = dict(manifest_sha256=self.pin, expected_source=SOURCE, expected_run=RUN, expected_attempt=ATTEMPT)
+
+    def read(self, record):
+        if record["path"] not in self.payloads:
+            raise GovernanceError("synthetic missing payload")
+        return self.payloads[record["path"]]
+
+    def verify(self):
+        verify_payloads(self.manifest, self.read)
+
+    def write_payloads(self, root):
+        for path, raw in self.payloads.items():
+            destination = root / path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(raw)
+
+    def rewrite(self, role, update):
+        """Rehash a changed assertion so negative tests reach cross-link validation."""
+        row = next(row for row in self.manifest["artifacts"] if row["role"] == role)
+        document = json.loads(self.payloads[row["path"]])
+        update(document)
+        raw = canonical_json_bytes(document)
+        self.payloads[row["path"]] = raw
+        inventory = inventory_of(self.manifest)
+        target = next(row for row in inventory["artifacts"] if row["role"] == role)
+        target.update(sha256=sha256_bytes(raw), size_bytes=len(raw))
+        self.manifest = construct_manifest(inventory)
+
+    def replace_zip(self, raw):
+        role = f"transport-zip:{TARGETS[0]}"
+        inventory = inventory_of(self.manifest)
+        row = next(row for row in inventory["artifacts"] if row["role"] == role)
+        row.update(sha256=sha256_bytes(raw), size_bytes=len(raw))
+        self.payloads[row["path"]] = raw
+        self.manifest = construct_manifest(inventory)
+        self.rewrite("upload-metadata", lambda doc: doc["artifacts"][0].update(digest="sha256:" + sha256_bytes(raw)))
+
+    def test_complete_all_class_roundtrip(self):
+        from verification.json_schema_202012 import validate_instance
+        from .schema_contracts import schema_fixtures
+        validate_instance(self.manifest, SCHEMA)
+        registered = schema_fixtures()
+        self.assertEqual(set(registered), {path.name for path in SCHEMA.parent.glob("*.schema.json")})
+        self.assertEqual(registered[SCHEMA.name], self.manifest)
+        roles = {row["role"] for row in self.manifest["artifacts"]}
+        self.assertTrue(REQUIRED_ROLES <= roles)
+        self.assertEqual(len(self.manifest["matrix"]), 6)
+        shuffled = copy.deepcopy(self.inventory)
+        shuffled["artifacts"].reverse()
+        shuffled["matrix"].reverse()
+        self.assertEqual(canonical_json_bytes(construct_manifest(shuffled)), self.raw)
+        self.verify()
+        store = MemoryStore()
+        self.assertEqual(seal(store, self.manifest, self.read), self.pin)
+        self.assertEqual(readback(store, key=manifest_key(self.manifest), **self.expected), self.manifest)
+        # Distinct logical roles deliberately share identical content bytes.
+        unique = {row["key"] for row in self.manifest["artifacts"]}
+        self.assertLess(len(unique), len(roles))
+        self.assertEqual(len(store.objects), len(unique) + 1)
+        with tempfile.TemporaryDirectory(prefix="sifr-archive-test-") as temporary:
+            root = Path(temporary).resolve()
+            self.write_payloads(root / "input")
+            self.write_payloads(root / "copy")
+            self.assertEqual(plan(self.inventory, root / "input"), self.manifest)
+            self.assertEqual(verify_local(self.raw, payload_root=root / "copy", **self.expected), self.manifest)
+            entry = Path(__file__).resolve().parents[4] / "scripts/distribution/archive_release_evidence.py"
+            spec = importlib.util.spec_from_file_location("archive_cli_test", entry)
+            cli = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(cli)
+            (root / "inventory.json").write_bytes(canonical_json_bytes(self.inventory))
+            planning = ["plan", "--inventory", str(root / "inventory.json"), "--payload-root", str(root / "input"), "--out", str(root / "manifest.json")]
+            verifying = ["verify-local", "--manifest", str(root / "manifest.json"), "--manifest-sha256", self.pin,
+                         "--expected-source", SOURCE, "--expected-run", str(RUN), "--expected-attempt", str(ATTEMPT),
+                         "--payload-root", str(root / "copy")]
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(cli.main(planning), 0)
+                self.assertEqual(cli.main(verifying), 0)
+                self.assertEqual(cli.main(planning), 2)
+                self.assertEqual((root / "manifest.json").read_bytes(), self.raw)
+                with patch.object(cli.os, "link", side_effect=OSError("synthetic interrupted install")):
+                    self.assertEqual(cli.main(planning[:-1] + [str(root / "interrupted.json")]), 2)
+                self.assertFalse((root / "interrupted.json").exists())
+                self.assertFalse(list(root.glob(".archive-plan-*")))
+
+    def test_missing_mutated_truncated_bytes(self):
+        for row in self.manifest["artifacts"]:
+            original = self.payloads[row["path"]]
+            for mutation in (None, b"X" * len(original), original[:-1]):
+                with self.subTest(role=row["role"], mutation="missing" if mutation is None else len(mutation)):
+                    if mutation is None:
+                        del self.payloads[row["path"]]
+                    else:
+                        self.payloads[row["path"]] = mutation
+                    with self.assertRaises(GovernanceError):
+                        self.verify()
+                    self.payloads[row["path"]] = original
+        for role in REQUIRED_ROLES:
+            inventory = copy.deepcopy(self.inventory)
+            inventory["artifacts"] = [row for row in inventory["artifacts"] if row["role"] != role]
+            with self.subTest(missing_role=role), self.assertRaises(GovernanceError):
+                construct_manifest(inventory)
+        result = next(row for row in self.inventory["artifacts"] if row["role"].startswith("result:"))
+        inventory = copy.deepcopy(self.inventory)
+        inventory["artifacts"] = [row for row in inventory["artifacts"] if row["role"] != result["role"]]
+        with self.assertRaisesRegex(GovernanceError, "missing bound result"):
+            verify_payloads(construct_manifest(inventory), self.read)
+        for role in ("step-log:area_rust_interop", "case-log:new_area:extra:fresh-case"):
+            inventory = copy.deepcopy(self.inventory)
+            inventory["artifacts"] = [row for row in inventory["artifacts"] if row["role"] != role]
+            with self.assertRaisesRegex(GovernanceError, "raw step/case logs"):
+                verify_payloads(construct_manifest(inventory), self.read)
+        for role, update in (
+            ("release-profile-report", lambda doc: doc["result_artifacts"][0].update(sha256="b" * 64)),
+            ("release-profile-report", lambda doc: doc["profile"]["expanded_selected_areas"].pop()),
+            ("documentation-summary", lambda doc: doc.update(result_sha256="b" * 64)),
+            ("candidate-plan", lambda doc: doc.update(cargo_lock_sha256="b" * 64)),
+            ("review-evidence", lambda doc: doc.update(log_sha256="b" * 64)),
+            ("upload-metadata", lambda doc: doc["artifacts"][0].update(digest="sha256:" + "b" * 64)),
+        ):
+            with self.subTest(rehashed_cross_link=role):
+                self.setUp()
+                self.rewrite(role, update)
+                with self.assertRaises(GovernanceError):
+                    self.verify()
+        # Rehash a syntactically valid ZIP and its API digest to reach entry checks.
+        for change in ("duplicate", "mutated-entry", "symlink"):
+            self.setUp()
+            row = next(row for row in self.manifest["artifacts"] if row["role"] == f"transport-zip:{TARGETS[0]}")
+            output = io.BytesIO()
+            with zipfile.ZipFile(io.BytesIO(self.read(row))) as original, zipfile.ZipFile(output, "w") as changed:
+                for number, entry in enumerate(original.infolist()):
+                    content = original.read(entry)
+                    if number == 0 and change == "mutated-entry":
+                        content = b"X" * len(content)
+                    if number == 0 and change == "symlink":
+                        entry.external_attr = 0o120777 << 16
+                    changed.writestr(entry, content)
+                    if number == 0 and change == "duplicate":
+                        with self.assertWarns(UserWarning):
+                            changed.writestr(entry, content)
+            self.replace_zip(output.getvalue())
+            with self.subTest(zip=change), self.assertRaises(GovernanceError):
+                self.verify()
+
+    def test_duplicate_logical_records_and_wrong_source_run_attempt(self):
+        duplicate = copy.deepcopy(self.inventory)
+        duplicate["artifacts"].append(copy.deepcopy(duplicate["artifacts"][0]))
+        with self.assertRaisesRegex(GovernanceError, "duplicate"):
+            construct_manifest(duplicate)
+        for key, value in (("source_commit", "c" * 40), ("run_id", RUN + 1), ("run_attempt", ATTEMPT + 1),
+                           ("repository", "other/repo"), ("workflow_path", "other.yml")):
+            inventory = copy.deepcopy(self.inventory)
+            inventory["artifacts"][0]["producer"][key] = value
+            with self.subTest(producer=key), self.assertRaises(GovernanceError):
+                construct_manifest(inventory)
+        for key, value in (("expected_source", "c" * 40), ("expected_run", RUN + 1), ("expected_attempt", ATTEMPT + 1)):
+            with self.subTest(expected=key), self.assertRaises(GovernanceError):
+                parse_manifest(self.raw, **{**self.expected, key: value})
+        for field, value in (("head_sha", "c" * 40), ("id", RUN + 1), ("run_attempt", ATTEMPT + 1)):
+            self.setUp()
+            self.rewrite("run-metadata", lambda doc: doc.update({field: value}))
+            with self.subTest(metadata=field), self.assertRaises(GovernanceError):
+                self.verify()
+        for mutation in (lambda inv: inv["matrix"].pop(), lambda inv: inv["matrix"].append(inv["matrix"][0]),
+                         lambda inv: inv["matrix"][0].update(mode="structured-skip", reasons=["fake skip"])):
+            inventory = copy.deepcopy(self.inventory)
+            mutation(inventory)
+            with self.assertRaises(GovernanceError):
+                construct_manifest(inventory)
+        duplicate_json = self.raw.replace(b'"schema_version":1', b'"schema_version":1,"schema_version":1', 1)
+        with self.assertRaisesRegex(GovernanceError, "duplicate object key"):
+            parse_manifest(duplicate_json, **{**self.expected, "manifest_sha256": sha256_bytes(duplicate_json)})
+        noncanonical = b" " + self.raw
+        with self.assertRaisesRegex(GovernanceError, "canonical"):
+            parse_manifest(noncanonical, **{**self.expected, "manifest_sha256": sha256_bytes(noncanonical)})
+
+    def test_create_only_conflict_and_interrupted_manifest(self):
+        first = self.manifest["artifacts"][0]
+        store = MemoryStore()
+        store.objects[first["key"]] = b"conflicting existing object"
+        with self.assertRaises(GovernanceError):
+            seal(store, self.manifest, self.read)
+        self.assertEqual(store.objects[first["key"]], b"conflicting existing object")
+        self.assertNotIn(manifest_key(self.manifest), store.objects)
+        for boundary in (0, 3, len(self.manifest["artifacts"])):
+            store = MemoryStore()
+            store.fail_after = boundary
+            with self.subTest(interruption=boundary), self.assertRaises(GovernanceError):
+                seal(store, self.manifest, self.read)
+            self.assertNotIn(manifest_key(self.manifest), store.objects)
+            store.fail_after = None
+            self.assertEqual(seal(store, self.manifest, self.read), self.pin)
+            before = dict(store.objects)
+            with self.assertRaisesRegex(GovernanceError, "already sealed"):
+                seal(store, self.manifest, self.read)
+            self.assertEqual(store.objects, before)
+        incomplete = copy.deepcopy(self.manifest)
+        incomplete["artifacts"].pop()
+        store = MemoryStore()
+        with self.assertRaises(GovernanceError):
+            seal(store, incomplete, self.read)
+        self.assertFalse(store.objects)
+
+    def test_independent_copy_requires_complete_verified_readback(self):
+        primary, secondary = MemoryStore(), MemoryStore("test-memory:separate-copy")
+        seal(primary, self.manifest, self.read)
+        seal(secondary, self.manifest, self.read)
+        key = manifest_key(self.manifest)
+        before = primary.objects[key]
+        row = self.manifest["artifacts"][0]
+        secondary.objects.pop(row["key"])
+        for locations in ([primary], [primary, primary], [primary, secondary]):
+            with self.assertRaises(GovernanceError):
+                attest_readback(locations, key=key, receipt_id="copy-001", kind="copy", **self.expected)
+            self.assertFalse(any("/receipts/" in path for path in primary.objects))
+        secondary.objects[row["key"]] = self.read(row)
+        primary.reads.clear()
+        secondary.reads.clear()
+        receipt = attest_readback([primary, secondary], key=key, receipt_id="copy-001", kind="copy", **self.expected)
+        self.assertEqual(receipt["assurance"], "complete-byte-readback-only")
+        self.assertEqual(receipt["manifest_sha256"], self.pin)
+        self.assertEqual(primary.objects[key], before)
+        for store in (primary, secondary):
+            self.assertTrue({record["key"] for record in self.manifest["artifacts"]} <= set(store.reads))
+        with self.assertRaisesRegex(GovernanceError, "already exists"):
+            attest_readback([primary, secondary], key=key, receipt_id="copy-001", kind="copy", **self.expected)
+        attest_readback([secondary], key=key, receipt_id="read-002", kind="readback", **self.expected)
+        self.assertEqual(primary.objects[key], before)
+        secondary.objects[key] = b"changed manifest"
+        with self.assertRaises(GovernanceError):
+            attest_readback([primary, secondary], key=key, receipt_id="copy-003", kind="copy", **self.expected)
+
+    def test_archive_read_does_not_relax_live_freshness(self):
+        row = next(row for row in self.inventory["artifacts"] if row["role"] == "qualification-index")
+        raw = self.payloads[row["path"]]
+        index = json.loads(raw)
+        now = datetime(2026, 9, 8, tzinfo=timezone.utc)
+        with self.assertRaisesRegex(GovernanceError, "expired"):
+            validate_qualification_artifact_index(index, require_unexpired=True, now=now)
+        self.verify()
+        seal(MemoryStore(), self.manifest, self.read)
+        self.assertEqual(self.payloads[row["path"]], raw)
+        with self.assertRaisesRegex(GovernanceError, "expired"):
+            validate_qualification_artifact_index(index, require_unexpired=True, now=now)
+        wrong_retention = copy.deepcopy(index)
+        wrong_retention["workflow"]["retention_days"] = 365
+        with self.assertRaises(GovernanceError):
+            validate_qualification_artifact_index(wrong_retention)
+
+    def test_unsafe_paths_symlinks_and_untrusted_manifest_digest(self):
+        for path in ("/absolute", "../escape", "a/../b", "a//b", "./name", "C:/file", "a\\b", "a/./b", "a/", "a\x00b", "a/space "):
+            inventory = copy.deepcopy(self.inventory)
+            inventory["artifacts"][0]["path"] = path
+            with self.subTest(path=path), self.assertRaises(GovernanceError):
+                construct_manifest(inventory)
+        for second in ("DATA", "data/file"):
+            inventory = copy.deepcopy(self.inventory)
+            inventory["artifacts"][0]["path"] = "data"
+            inventory["artifacts"][1]["path"] = second
+            with self.assertRaisesRegex(GovernanceError, "conflict"):
+                construct_manifest(inventory)
+        with self.assertRaisesRegex(GovernanceError, "untrusted"):
+            parse_manifest(self.raw, **{**self.expected, "manifest_sha256": "b" * 64})
+        with tempfile.TemporaryDirectory(prefix="sifr-archive-path-test-") as temporary:
+            root = Path(temporary).resolve()
+            self.write_payloads(root / "input")
+            row = self.manifest["artifacts"][0]
+            path = root / "input" / row["path"]
+            path.unlink()
+            (root / "outside").write_bytes(self.read(row))
+            path.symlink_to(root / "outside")
+            with self.assertRaises(GovernanceError):
+                verify_local(self.raw, payload_root=root / "input", **self.expected)
+            (root / "linked-root").symlink_to(root / "input", target_is_directory=True)
+            with self.assertRaises(GovernanceError):
+                read_local(root / "linked-root", row["path"])
+            (root / "linked-parent").symlink_to(root, target_is_directory=True)
+            with self.assertRaises(GovernanceError):
+                read_local(root / "linked-parent" / "input", row["path"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verification/areas/distribution_release/governance/archive_store.py
+++ b/verification/areas/distribution_release/governance/archive_store.py
@@ -1,0 +1,100 @@
+"""Create-only archive transport interface, sealing and append-only readback receipts.
+
+There is deliberately no filesystem/cloud store implementation here. A provider
+must implement atomic create-only writes and fresh exact-byte reads. Test doubles
+prove logic only; provider retention, permissions and independent custody belong
+to the subsequent online item.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol
+
+from .archive_manifest import parse_manifest, validate_manifest, verify_bytes, verify_payloads
+from .common import GovernanceError, canonical_json_bytes, require_nonempty_string, sha256_bytes
+
+
+class ArchiveStore(Protocol):
+    @property
+    def location(self) -> str:
+        """Provider-qualified custody identity, not a claim of independence."""
+        ...
+
+    def create(self, key: str, content: bytes) -> bool:
+        """Atomically create; return False if key exists, never replace any bytes."""
+        ...
+
+    def read(self, key: str) -> bytes:
+        """Fresh read of the exact key; missing/unavailable reads must raise."""
+        ...
+
+
+def manifest_key(manifest: dict[str, Any]) -> str:
+    return manifest["archive_root"] + "manifest.json"
+
+
+def seal(store: ArchiveStore, manifest: dict[str, Any],
+         read: Callable[[dict[str, Any]], bytes]) -> str:
+    """Verify input, copy/reuse verified objects, then create the root once."""
+    validate_manifest(manifest)
+    verify_payloads(manifest, read)
+    for record in manifest["artifacts"]:
+        content = verify_bytes(record, read(record))
+        # False only permits reuse of identical, fully read-back content objects.
+        store.create(record["key"], content)
+        verify_bytes(record, store.read(record["key"]))
+    verify_payloads(manifest, lambda record: store.read(record["key"]))
+    raw = canonical_json_bytes(manifest)
+    if not store.create(manifest_key(manifest), raw):
+        raise GovernanceError("root manifest already sealed; no overwrite or reseal")
+    if store.read(manifest_key(manifest)) != raw:
+        raise GovernanceError("manifest readback mismatch")
+    return sha256_bytes(raw)
+
+
+def readback(store: ArchiveStore, *, key: str, manifest_sha256: str,
+             expected_source: str, expected_run: int, expected_attempt: int) -> dict[str, Any]:
+    manifest = parse_manifest(store.read(key), manifest_sha256=manifest_sha256,
+                              expected_source=expected_source, expected_run=expected_run,
+                              expected_attempt=expected_attempt)
+    if key != manifest_key(manifest):
+        raise GovernanceError("manifest key mismatch")
+    verify_payloads(manifest, lambda record: store.read(record["key"]))
+    return manifest
+
+
+def attest_readback(stores: list[ArchiveStore], *, key: str, receipt_id: str,
+                    kind: str, manifest_sha256: str, expected_source: str,
+                    expected_run: int, expected_attempt: int) -> dict[str, Any]:
+    """Append a receipt only after fresh complete reads of every custody location.
+
+    Names cannot establish physical independence. The bytes-only assurance is
+    explicit; the online owner must independently authenticate those locations.
+    Receipt IDs are unique caller-owned audit-event identifiers. A partially
+    written receipt set raises; each extant receipt truthfully covers completed
+    readbacks and never rewrites the sealed manifest.
+    """
+    require_nonempty_string(receipt_id, "receipt id")
+    if kind not in {"copy", "readback"} or not stores or (kind == "copy" and len(stores) < 2):
+        raise GovernanceError("copy requires at least two configured custody locations")
+    locations = [require_nonempty_string(store.location, "store location") for store in stores]
+    if len(set(locations)) != len(locations) or len({id(store) for store in stores}) != len(stores):
+        raise GovernanceError("duplicate custody location")
+    manifests = [readback(store, key=key, manifest_sha256=manifest_sha256,
+                          expected_source=expected_source, expected_run=expected_run,
+                          expected_attempt=expected_attempt) for store in stores]
+    receipt = {
+        "schema_version": 1, "kind": kind, "receipt_id": receipt_id,
+        "manifest_sha256": manifest_sha256,
+        "inventory_sha256": manifests[0]["inventory_sha256"],
+        "source_commit": expected_source, "run_id": expected_run, "run_attempt": expected_attempt,
+        "locations": sorted(locations), "assurance": "complete-byte-readback-only",
+    }
+    raw = canonical_json_bytes(receipt)
+    receipt_key = manifests[0]["archive_root"] + "receipts/" + sha256_bytes(receipt_id.encode()) + ".json"
+    for store in stores:
+        if not store.create(receipt_key, raw):
+            raise GovernanceError("append-only receipt identity already exists")
+        if store.read(receipt_key) != raw:
+            raise GovernanceError("receipt readback mismatch")
+    return receipt

--- a/verification/areas/distribution_release/governance/schema_contracts.py
+++ b/verification/areas/distribution_release/governance/schema_contracts.py
@@ -171,8 +171,11 @@ def validate_schema_contracts() -> None:
 
 
 def schema_fixtures() -> dict[str, Any]:
+    from .archive_offline_selftest import archive_schema_example
+
     index = preview_index()
     return {
+        "release_evidence_archive.schema.json": archive_schema_example(),
         "qualification_artifact_index.schema.json": qualification_index(),
         "protected_release_drill_evidence.schema.json": protected_drill_evidence(),
         "release_index.schema.json": index,

--- a/verification/areas/distribution_release/governance/schema_epoch.py
+++ b/verification/areas/distribution_release/governance/schema_epoch.py
@@ -23,6 +23,12 @@ GOVERNED_GLOBS = (
     ("verification/areas/distribution_release/governance", "*.py"),
 )
 SCAN_EXCLUSIONS = {"schema_epoch.py", "selftest.py", "schema_contracts.py"}
+# The archive/receipt contract starts its own version history, outside the v2
+# release-index cutover. Keep this exemption limited to its two literal owners.
+ARCHIVE_SOURCE_EXCLUSIONS = {
+    AREA_ROOT / "governance" / "archive_store.py",
+    AREA_ROOT / "governance" / "archive_offline_selftest.py",
+}
 V1_PATTERNS = (
     re.compile(r'"schema_version"\s*:\s*1(?:\D|$)'),
     re.compile(r"(?<![A-Za-z0-9_])schema_version\s+must\s+be\s+1\b"),
@@ -33,16 +39,23 @@ V1_PATTERNS = (
 def check_schema_epoch() -> None:
     for path in sorted((AREA_ROOT / "schemas").glob("*.schema.json")):
         schema = json.loads(path.read_text(encoding="utf-8"))
-        if "schema_version" not in schema.get("required", []):
-            raise ValueError(f"{path}: schema_version is not required")
-        if schema.get("properties", {}).get("schema_version") != {"const": 2}:
-            raise ValueError(f"{path}: schema_version must be exact integer 2")
-        if "default" in json.dumps(schema.get("properties", {}).get("schema_version")):
-            raise ValueError(f"{path}: schema_version must not have a default")
+        check_schema_declaration(path, schema)
     for path in governed_sources():
         check_source_text(path, path.read_text(encoding="utf-8"))
     if (REPO_ROOT / "scripts" / "distribution" / "bootstrap_channel_metadata.py").exists():
         raise ValueError("schema-v1 bootstrap producer must not exist")
+
+
+def check_schema_declaration(path: Path, schema: dict) -> None:
+    expected = {"const": 2}
+    if path == AREA_ROOT / "schemas" / "release_evidence_archive.schema.json":
+        expected = {"const": 1, "type": "integer"}
+    if "schema_version" not in schema.get("required", []):
+        raise ValueError(f"{path}: schema_version is not required")
+    if schema.get("properties", {}).get("schema_version") != expected:
+        raise ValueError(f"{path}: schema_version must be exactly {expected}")
+    if "default" in json.dumps(schema.get("properties", {}).get("schema_version")):
+        raise ValueError(f"{path}: schema_version must not have a default")
 
 
 def governed_sources() -> list[Path]:
@@ -53,6 +66,7 @@ def governed_sources() -> list[Path]:
             path
             for path in root.glob(pattern)
             if path.is_file() and path.name not in SCAN_EXCLUSIONS
+            and path not in ARCHIVE_SOURCE_EXCLUSIONS
         )
     required = {
         REPO_ROOT / "crates" / "sifr" / "src" / "self_update_receipt.rs",

--- a/verification/areas/distribution_release/governance/selftest.py
+++ b/verification/areas/distribution_release/governance/selftest.py
@@ -362,6 +362,8 @@ def mutate(
 
 
 def test_schemas_use_epoch_two() -> None:
+    from .schema_epoch import check_schema_declaration
+
     def contains_default_keyword(value: Any) -> bool:
         if isinstance(value, dict):
             return "default" in value or any(
@@ -375,8 +377,7 @@ def test_schemas_use_epoch_two() -> None:
     assert schema_paths
     for path in schema_paths:
         schema = json.loads(path.read_text(encoding="utf-8"))
-        assert "schema_version" in schema["required"], path
-        assert schema["properties"]["schema_version"] == {"const": 2}, path
+        check_schema_declaration(path, schema)
         assert not contains_default_keyword(schema), path
         assert '"rc"' not in path.read_text(encoding="utf-8"), path
     validate_schema_contracts()

--- a/verification/areas/distribution_release/schemas/release_evidence_archive.schema.json
+++ b/verification/areas/distribution_release/schemas/release_evidence_archive.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Release evidence archive v1 (custody only, no authorization)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "identity", "matrix", "artifacts", "archive_root", "inventory_sha256"],
+  "properties": {
+    "schema_version": {"const": 1, "type": "integer"},
+    "identity": {"$ref": "#/$defs/identity"},
+    "archive_root": {"type": "string", "minLength": 1},
+    "inventory_sha256": {"$ref": "#/$defs/digest"},
+    "matrix": {
+      "type": "array", "minItems": 6, "maxItems": 6,
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": ["target", "mode", "reasons"],
+        "properties": {
+          "target": {"type": "string", "minLength": 1},
+          "mode": {"enum": ["native", "structured-skip"]},
+          "reasons": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array", "minItems": 1,
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": ["role", "path", "size_bytes", "sha256", "key", "producer"],
+        "properties": {
+          "role": {"type": "string", "minLength": 1},
+          "path": {"type": "string", "minLength": 1},
+          "size_bytes": {"type": "integer", "minimum": 1},
+          "sha256": {"$ref": "#/$defs/digest"},
+          "key": {"type": "string", "minLength": 1},
+          "producer": {
+            "type": "object", "additionalProperties": false,
+            "required": ["repository", "source_commit", "workflow_path", "run_id", "run_attempt", "job", "execution"],
+            "properties": {
+              "repository": {"const": "sifr-lang/sifr"},
+              "source_commit": {"$ref": "#/$defs/commit"},
+              "workflow_path": {"const": ".github/workflows/release-qualification.yml"},
+              "run_id": {"type": "integer", "minimum": 1},
+              "run_attempt": {"type": "integer", "minimum": 1},
+              "job": {"type": "string", "minLength": 1},
+              "execution": {"enum": ["workflow", "local"]},
+              "artifact_id": {"type": "integer", "minimum": 1}
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$", "not": {"const": "0000000000000000000000000000000000000000000000000000000000000000"}},
+    "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$", "not": {"const": "0000000000000000000000000000000000000000"}},
+    "identity": {
+      "type": "object", "additionalProperties": false,
+      "required": ["repository", "source_commit", "workflow_path", "run_id", "run_attempt", "index_sha256", "submodules", "lock_sha256", "toolchain", "profile_sha256"],
+      "properties": {
+        "repository": {"const": "sifr-lang/sifr"},
+        "source_commit": {"$ref": "#/$defs/commit"},
+        "workflow_path": {"const": ".github/workflows/release-qualification.yml"},
+        "run_id": {"type": "integer", "minimum": 1},
+        "run_attempt": {"type": "integer", "minimum": 1},
+        "index_sha256": {"$ref": "#/$defs/digest"},
+        "submodules": {"type": "object", "minProperties": 1, "additionalProperties": {"$ref": "#/$defs/commit"}},
+        "lock_sha256": {"$ref": "#/$defs/digest"},
+        "profile_sha256": {"$ref": "#/$defs/digest"},
+        "toolchain": {
+          "type": "object", "additionalProperties": false,
+          "required": ["rustc", "cargo", "uv", "python"],
+          "properties": {
+            "rustc": {"type": "string", "minLength": 1},
+            "cargo": {"type": "string", "minLength": 1},
+            "uv": {"type": "string", "minLength": 1},
+            "python": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    }
+  }
+}

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -46,6 +46,8 @@ from .schemas import (
 )
 from .step_budgets import run_self_test as step_budget_self_test
 
+GOVERNANCE_SCHEMA_COUNT = 20
+
 
 def run_all() -> list[str]:
     checks = [
@@ -92,7 +94,7 @@ def _schema_self_test() -> None:
         Path(__file__).resolve().parents[3] / "verification" / "areas" / "distribution_release" / "schemas"
     )
     governed = [lint_schema(path) for path in sorted(governance_schemas.glob("*.schema.json"))]
-    if len(governed) != 19:
+    if len(governed) != GOVERNANCE_SCHEMA_COUNT:
         raise AssertionError("release-governance schema lint registration drifted")
     try:
         validate_schema_requirement({"type": "object", "oneOf": []}, Path("bad.schema.json"))


### PR DESCRIPTION
Expired Actions artifacts previously left release qualification without retained payload bytes. Item 70-F1B adds a provider-independent, canonical archive manifest, complete inventory and byte/cross-link verification, create-only store/sealing and append-only readback/copy receipts, plus offline `plan` and `verify-local` commands.

The offline contract retains the 20 indexed payloads, seven original ZIPs, complete native/structured-skip matrix, expanded release report and every bound result, producer logs, source/toolchain/profile inventory and candidate/support/review records. No provider, workflow, lockfile, compiler, fixture file, historical evidence or live freshness policy changes. Local test doubles establish byte logic only; actual backend custody/independence belongs to later F1C, integration to F1D.

The independently versioned archive schema is explicitly enrolled in the existing schema registry, v2 epoch guards and runner schema count; existing v2 enforcement remains strict.

Validation on exact candidate `d85d2008572090f62e7d6d8d900a8bb42e92e5b9`:

- `python3 -m unittest verification.areas.distribution_release.governance.archive_offline_selftest`: seven named tests passed, including CLI, schema enrollment and negative subcases.
- `git diff --check` and exact base/candidate diff check: passed.
- `python3 scripts/check_file_size_guardrails.py`: passed.

The initial exact-SHA Opus review found only schema-enrollment regressions, corrected in one batch. The single remediation review returned SATISFIED with no blockers on final SHA `d85d2008572090f62e7d6d8d900a8bb42e92e5b9`. Validation and both reviews are published in PR comments, outside the reviewed tree. No Sifr gates apply to these offline source/schema/docs paths under the item's explicit gate rule. Owner: release/distribution, issue #3775. This PR closes only 70-F1B; it does not close the historical recovery issue or start the next item.
