### PR TITLE
Implement offline R2 archive adapter and admission (70-F1C1)

### DIFF
--- a/plans/issues/active/ad-hoc-latest-stable-item70-f1c0-r2-plan.md
+++ b/plans/issues/active/ad-hoc-latest-stable-item70-f1c0-r2-plan.md
@@ -222,7 +222,7 @@ starting the later offline F1C1 item in a fresh session.
 ## Registered later items; not implemented here
 
 **70-F1C1 — offline R2 adapter and admission contract**, release/distribution.
-Ready after F1C0 merges; no live account, compiler/policy, credential or SDK
+Implemented pending exact-SHA review/merge; no live account, compiler/policy, credential or SDK
 installation prerequisite. Exact new implementation paths:
 
 - `verification/areas/distribution_release/governance/archive_r2_store.py`:
@@ -275,6 +275,46 @@ retention/error precedence, credential rights or custody independence.
 Use one exact-SHA Opus review plus at most one remediation; only source
 inspection in review. Apply actual changed-path gate rules; the registered
 source/docs-only F1C1 paths require no Sifr gate. Merge, record, and stop.
+
+F1C1 implementation: `R2Target` is immutable and validates the canonical
+manifest against an externally supplied digest and source/run/attempt before
+deriving the root. Clients expose standard SDK `meta.endpoint_url` and
+`meta.config` fields; admission requires region `auto`, path addressing,
+one total request attempt and required-only checksum negotiation. The same
+binding is rechecked before every operation. Successful PUT requires 200 and
+a nonempty ETag, used only as response completeness metadata. GET requires
+200, exact ContentLength and explicit STANDARD, reads through EOF and closes
+the body, rejecting range/encoding/expiration indicators. The ETag never
+establishes byte integrity. Missing Standard metadata is a fail-closed online
+compatibility question, not an inferred Standard default.
+
+`PolicyObservation` holds immutable UTF-8 JSON envelope bytes. Its exact fields
+are `account`, `jurisdiction`, `bucket`, `archive_root`, `source_commit`,
+`run_id`, `run_attempt`, `endpoint`, `method`, `path`, `operation`, `headers`,
+`observed_at`, `status`, `request_id`, `authority_ref`, `raw_response` and
+`response_sha256`. `raw_response` preserves the provider JSON text whose
+UTF-8 bytes the digest identifies. Operations are `metadata`, `locks` and
+`lifecycle`; paths and jurisdiction headers follow the contract above.
+Lifecycle observations serialize the SDK response shape with ResponseMetadata,
+Rules or the explicit 404/NoSuchLifecycleConfiguration error. All JSON layers
+reject duplicate keys; policy shapes admit only supported fields and filters.
+The admission result retains all three observations and says
+`supplied-policy-observations-only`. This format is an offline consumption
+boundary, not a network transport, authentication claim or live freshness check.
+The later owner must capture and preserve before/after observations.
+
+`R2ArchiveReader` exposes only reads. `R2ReadbackStore` composes it with a
+separate `R2ArchiveStore` receipt writer with matching location/root/digest
+and distinct client/reference; only receipt keys may be written. Every read,
+including receipt verification, stays on the dedicated reader. Local labels
+do not prove the actual credential rights or administrative independence.
+Only the three registered Python modules and this plan/phase record change;
+the F1B manifest, schema, store, CLI and synthetic builder remain unchanged.
+Owned clone `/private/tmp/sifr-item70-f1c1.fDMx42/codebase`, branch
+`codex/latest-stable-item70-f1c1`, base
+`5614f06c8ff49411dd8d0b8107e6479e4274ec96`; sibling private evidence root.
+No SDK installation, factory, real service call, fixture, workflow, lock,
+Cargo, native run, historical recovery, F1C2/D work or qualification occurs.
 
 **70-F1C2 — real SDK/configuration/access and independent-copy proof**,
 release/distribution with the existing storage/copy owners. Not ready for

--- a/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
+++ b/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
@@ -6,6 +6,33 @@ ledger while Kafka and gate-bearing items retain explicit prerequisites.
 
 ## Objective
 
+### Item 70-F1C1 — offline R2 adapter and admission contract
+
+IMPLEMENTED pending exact-SHA review/merge under the merged
+[F1C0 scope and nine-test table](ad-hoc-latest-stable-item70-f1c0-r2-plan.md).
+Only the registered `archive_r2_store.py`, `archive_r2_config.py` and
+`archive_r2_selftest.py` source modules plus plan/phase records change.
+Immutable manifest-bound target, canonical endpoint/location/key checks,
+explicit SDK metadata binding, one conditional PUT, fresh full GET with body
+cleanup and sanitized errors, strict supplied lock/lifecycle/Standard
+observations, and dedicated reader/separate receipt-writer composition.
+F1B source/schema/CLI remain unchanged; tests import its synthetic inventory.
+Mocks prove logic only; live SDK/retention/error precedence and separately
+controlled full-byte copy remain F1C2 prerequisites, with no readiness claim.
+
+Named checks only: Python 3.14.7
+`python3 -m unittest verification.areas.distribution_release.governance.archive_r2_selftest`,
+`git diff --check`, `python3 scripts/check_file_size_guardrails.py`.
+One exact-SHA Opus review plus at most one remediation, Read/Grep/Glob only;
+no reviewer command/test execution. Registered source/docs paths require no
+Sifr gate. No SDK install, credential/resource, transport/factory, workflow,
+lockfile, fixture, compiler/native, historical or qualification work.
+Owned clone `/private/tmp/sifr-item70-f1c1.fDMx42/codebase`, branch
+`codex/latest-stable-item70-f1c1`, base
+`5614f06c8ff49411dd8d0b8107e6479e4274ec96`; sibling external evidence root.
+Parent/predecessor stores remain read-only. Blocker: none. Merge, record and
+stop; do not start F1C2/D or any next item.
+
 ### Item 70-F1C0 — selected R2 contract and offline implementation plan
 
 COMPLETE via [PR #3816](https://github.com/sifr-lang/sifr/pull/3816), merged

--- a/verification/areas/distribution_release/governance/archive_r2_config.py
+++ b/verification/areas/distribution_release/governance/archive_r2_config.py
@@ -1,0 +1,264 @@
+"""Pure R2 target and observed-policy admission; no credentials or network.
+
+An accepted observation records supplied bytes, not authenticated live access.
+The online owner must obtain these observations and prove their custody/freshness.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from .archive_manifest import parse_manifest
+from .common import GovernanceError, load_json_bytes_strict, sha256_bytes
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise GovernanceError(message)
+
+
+def _shape(value: Any, required: set[str], optional: set[str] = frozenset()) -> dict:
+    _require(isinstance(value, dict), "invalid R2 observation object")
+    _require(required <= value.keys() <= required | optional, "unknown or missing R2 policy fields")
+    return value
+
+
+def _label(value: Any) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}", value) is not None
+
+
+@dataclass(frozen=True)
+class R2Target:
+    account: str
+    jurisdiction: str
+    bucket: str
+    credential_ref: str
+    manifest_bytes: bytes = field(repr=False)
+    manifest_sha256: str
+    expected_source: str
+    expected_run: int
+    expected_attempt: int
+    storage_class: str = "STANDARD"
+    root: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        _require(isinstance(self.account, str) and re.fullmatch(r"[0-9a-f]{32}", self.account) is not None,
+                 "invalid R2 account")
+        _require(self.jurisdiction in ("default", "eu", "us", "fedramp"), "invalid R2 jurisdiction")
+        _require(isinstance(self.bucket, str) and re.fullmatch(r"[a-z0-9][a-z0-9-]{1,61}[a-z0-9]", self.bucket) is not None,
+                 "invalid R2 bucket")
+        try:
+            ipaddress.ip_address(self.bucket)
+        except ValueError:
+            pass
+        else:
+            raise GovernanceError("IP bucket alias is forbidden")
+        _require(not self.bucket.startswith(("xn--", "sthree-", "amzn-s3-demo-"))
+                 and not self.bucket.endswith(("-s3alias", "--ol-s3", "--x-s3", "--table-s3")),
+                 "reserved bucket alias")
+        _require(_label(self.credential_ref), "invalid nonsecret credential reference")
+        _require(self.storage_class == "STANDARD", "R2 archive requires STANDARD")
+        _require(type(self.manifest_bytes) is bytes, "manifest must be exact bytes")
+        manifest = parse_manifest(self.manifest_bytes, manifest_sha256=self.manifest_sha256,
+                                  expected_source=self.expected_source, expected_run=self.expected_run,
+                                  expected_attempt=self.expected_attempt)
+        object.__setattr__(self, "root", manifest["archive_root"])
+
+    @property
+    def endpoint(self) -> str:
+        jurisdiction = "" if self.jurisdiction == "default" else self.jurisdiction + "."
+        return f"https://{self.account}.{jurisdiction}r2.cloudflarestorage.com"
+
+    @property
+    def location(self) -> str:
+        return f"r2://{self.account}/{self.jurisdiction}/{self.bucket}"
+
+    @property
+    def binding(self) -> tuple:
+        return (self.location, self.root, self.manifest_sha256, self.storage_class)
+
+    def validate_key(self, key: str, *, receipt_only: bool = False) -> None:
+        _require(isinstance(key, str) and key.isascii() and len(key) <= 1024
+                 and key.startswith(self.root), "key does not match bound archive root")
+        suffix = key[len(self.root):]
+        pattern = r"receipts/[0-9a-f]{64}\.json"
+        if not receipt_only:
+            pattern = rf"(?:{pattern}|objects/sha256/[0-9a-f]{{64}}|manifest\.json)"
+        _require(re.fullmatch(pattern, suffix) is not None, "unsafe or unsupported archive key")
+
+
+@dataclass(frozen=True)
+class PolicyObservation:
+    """Exact sanitized transport envelope and strict raw JSON response bytes."""
+
+    envelope: bytes
+
+    def parse(self, target: R2Target, operation: str) -> dict:
+        value = _shape(load_json_bytes_strict(self.envelope, source="R2 observation"), {
+            "account", "jurisdiction", "bucket", "archive_root", "source_commit", "run_id",
+            "run_attempt", "endpoint", "method", "path", "operation", "headers", "observed_at",
+            "status", "request_id", "authority_ref", "raw_response", "response_sha256",
+        })
+        bucket_path = f"/accounts/{target.account}/r2/buckets/{target.bucket}"
+        paths = {"metadata": bucket_path, "locks": bucket_path + "/lock",
+                 "lifecycle": f"/{target.bucket}?lifecycle"}
+        _require(operation in paths, "unsupported configuration observation")
+        expected = {
+            "account": target.account, "jurisdiction": target.jurisdiction, "bucket": target.bucket,
+            "archive_root": target.root, "source_commit": target.expected_source,
+            "run_id": target.expected_run, "run_attempt": target.expected_attempt,
+            "endpoint": target.endpoint if operation == "lifecycle" else "https://api.cloudflare.com/client/v4",
+            "method": "GET", "path": paths[operation], "operation": operation,
+            "headers": ({"cf-r2-jurisdiction": target.jurisdiction}
+                        if operation != "lifecycle" and target.jurisdiction != "default" else {}),
+        }
+        _require(all(type(value[k]) is type(v) and value[k] == v for k, v in expected.items()),
+                 "configuration observation target/request mismatch")
+        _require(_label(value["authority_ref"]) and value["authority_ref"] != target.credential_ref,
+                 "configuration authority must be separate from producer reference")
+        _require(value["request_id"] is None or _label(value["request_id"]), "invalid request identity")
+        try:
+            timestamp = value["observed_at"]
+            _require(isinstance(timestamp, str) and timestamp.endswith("Z"), "observation requires UTC time")
+            datetime.fromisoformat(timestamp)
+        except ValueError:
+            raise GovernanceError("invalid observation UTC time") from None
+        _require(type(value["status"]) is int and value["status"] in (200, 404), "observation request failed")
+        _require(isinstance(value["raw_response"], str), "missing raw response bytes")
+        raw = value["raw_response"].encode("utf-8")
+        _require(sha256_bytes(raw) == value["response_sha256"], "observation response digest mismatch")
+        response = load_json_bytes_strict(raw, source="R2 policy response")
+        if operation == "lifecycle":
+            response = _shape(response, {"ResponseMetadata"}, {"Rules", "Error"})
+            metadata = _shape(response["ResponseMetadata"], {"HTTPStatusCode"}, {"RequestId", "HTTPHeaders", "RetryAttempts"})
+            _require(type(metadata["HTTPStatusCode"]) is int and metadata["HTTPStatusCode"] == value["status"],
+                     "lifecycle status mismatch")
+            _require(metadata.get("RequestId") == value["request_id"], "lifecycle request identity mismatch")
+            if value["status"] == 404:
+                error = _shape(response.get("Error"), {"Code"}, {"Message"})
+                _require(error["Code"] == "NoSuchLifecycleConfiguration" and "Rules" not in response,
+                         "lifecycle is unavailable, not empty")
+                return {"Rules": []}
+            _require("Error" not in response and "Rules" in response, "missing lifecycle rules")
+            return response
+        _require(value["status"] == 200, "control-plane request failed")
+        response = _shape(response, {"success", "errors", "messages", "result"}, {"result_info"})
+        _require(response["success"] is True and response["errors"] == [] and isinstance(response["messages"], list),
+                 "control-plane observation failed")
+        return response["result"]
+
+
+def _prefix(value: Any) -> str:
+    _require(isinstance(value, str) and value.isascii() and len(value) <= 1024
+             and "\\" not in value and "%" not in value and not value.startswith("/")
+             and all(ord(c) >= 32 for c in value)
+             and all(p not in (".", "..") for p in value.split("/")), "unsupported policy prefix")
+    return value
+
+
+def _locks(result: Any, root: str) -> None:
+    result = _shape(result, {"rules"})
+    _require(isinstance(result["rules"], list), "missing lock rules")
+    covered = False
+    seen = set()
+    for rule in result["rules"]:
+        rule = _shape(rule, {"id", "enabled", "condition"}, {"prefix"})
+        _require(_label(rule["id"]) and rule["id"] not in seen and type(rule["enabled"]) is bool,
+                 "invalid lock identity/enabled state")
+        seen.add(rule["id"])
+        prefix = _prefix(rule.get("prefix", ""))
+        condition = _shape(rule["condition"], {"type"}, {"maxAgeSeconds", "date"})
+        kind = condition["type"]
+        if kind == "Indefinite":
+            _shape(condition, {"type"})
+        elif kind == "Age":
+            _shape(condition, {"type", "maxAgeSeconds"})
+            _require(type(condition["maxAgeSeconds"]) is int and condition["maxAgeSeconds"] > 0, "invalid lock age")
+        elif kind == "Date":
+            _shape(condition, {"type", "date"})
+            _require(isinstance(condition["date"], str), "invalid lock date")
+            try:
+                datetime.fromisoformat(condition["date"])
+            except ValueError:
+                raise GovernanceError("invalid lock date") from None
+        else:
+            raise GovernanceError("unknown lock condition")
+        covered |= rule["enabled"] and kind == "Indefinite" and root.startswith(prefix)
+    _require(covered, "indefinite lock does not cover complete archive root")
+
+
+def _lifecycle(result: dict, root: str) -> None:
+    rules = result["Rules"]
+    _require(isinstance(rules, list), "invalid lifecycle rules")
+    actions = {"Expiration", "Transitions", "NoncurrentVersionExpiration", "NoncurrentVersionTransitions"}
+    seen = set()
+    for rule in rules:
+        rule = _shape(rule, {"Status"}, {"ID", "Prefix", "Filter", "AbortIncompleteMultipartUpload"} | actions)
+        _require(rule["Status"] in ("Enabled", "Disabled"), "unknown lifecycle status")
+        if "ID" in rule:
+            _require(_label(rule["ID"]) and rule["ID"] not in seen, "invalid lifecycle identity")
+            seen.add(rule["ID"])
+        _require(("Prefix" in rule) != ("Filter" in rule), "missing or ambiguous lifecycle filter")
+        if "Filter" in rule:
+            filter_value = _shape(rule["Filter"], set(), {"Prefix"})
+            prefix = _prefix(filter_value.get("Prefix", ""))
+        else:
+            prefix = _prefix(rule["Prefix"])
+        _require(bool(actions.intersection(rule) or "AbortIncompleteMultipartUpload" in rule), "missing lifecycle action")
+        if "AbortIncompleteMultipartUpload" in rule:
+            abort = _shape(rule["AbortIncompleteMultipartUpload"], {"DaysAfterInitiation"})
+            _require(type(abort["DaysAfterInitiation"]) is int and abort["DaysAfterInitiation"] > 0,
+                     "invalid multipart-abort lifecycle")
+        for action in actions.intersection(rule):
+            records = rule[action] if action.endswith("Transitions") else [rule[action]]
+            _require(isinstance(records, list) and bool(records), "invalid lifecycle action")
+            for record in records:
+                if action.startswith("Noncurrent"):
+                    required = {"NoncurrentDays"} | ({"StorageClass"} if action.endswith("Transitions") else set())
+                    record = _shape(record, required)
+                    _require(type(record["NoncurrentDays"]) is int and record["NoncurrentDays"] >= 0,
+                             "invalid noncurrent lifecycle age")
+                else:
+                    record = _shape(record, set(), {"Days", "Date", "StorageClass"})
+                    _require(("Days" in record) != ("Date" in record), "missing lifecycle age/date")
+                    _require(("StorageClass" in record) == action.endswith("Transitions"), "invalid lifecycle class action")
+                    if "Days" in record:
+                        _require(type(record["Days"]) is int and record["Days"] >= 0, "invalid lifecycle age")
+                    else:
+                        _require(isinstance(record["Date"], str), "invalid lifecycle date")
+                        try:
+                            datetime.fromisoformat(record["Date"])
+                        except ValueError:
+                            raise GovernanceError("invalid lifecycle date") from None
+                if "StorageClass" in record:
+                    _require(record["StorageClass"] in ("STANDARD", "STANDARD_IA"), "unknown lifecycle class")
+        overlap = root.startswith(prefix) or prefix.startswith(root)
+        _require(not (rule["Status"] == "Enabled" and overlap and actions.intersection(rule)),
+                 "completed archive objects have active expiry or class transition")
+
+
+@dataclass(frozen=True)
+class R2Admission:
+    target_binding: tuple
+    observations: tuple[PolicyObservation, PolicyObservation, PolicyObservation]
+    assurance: str = "supplied-policy-observations-only"
+
+
+def admit_configuration(target: R2Target, *, metadata: PolicyObservation,
+                        locks: PolicyObservation, lifecycle: PolicyObservation) -> R2Admission:
+    """Admit exact supplied observations, never assert live protection or custody."""
+    result = _shape(metadata.parse(target, "metadata"), {"name", "jurisdiction", "storageClass", "creationDate"})
+    _require(result["name"] == target.bucket and result["jurisdiction"] == target.jurisdiction
+             and result["storageClass"] == "Standard", "bucket metadata/Standard selection mismatch")
+    _require(isinstance(result["creationDate"], str), "missing bucket creation date")
+    try:
+        datetime.fromisoformat(result["creationDate"])
+    except ValueError:
+        raise GovernanceError("invalid bucket creation date") from None
+    _locks(locks.parse(target, "locks"), target.root)
+    _lifecycle(lifecycle.parse(target, "lifecycle"), target.root)
+    return R2Admission(target.binding, (metadata, locks, lifecycle))

--- a/verification/areas/distribution_release/governance/archive_r2_selftest.py
+++ b/verification/areas/distribution_release/governance/archive_r2_selftest.py
@@ -1,0 +1,496 @@
+"""Nine offline R2 contracts. Doubles prove logic, never live custody/access."""
+
+from __future__ import annotations
+
+import copy
+import io
+import json
+import socket
+import subprocess
+import unittest
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from .archive_manifest import construct_manifest
+from .archive_offline_selftest import ATTEMPT, RUN, SOURCE, synthetic_bundle
+from .archive_r2_config import PolicyObservation, R2Target, admit_configuration
+from .archive_r2_store import (
+    MAX_SINGLE_PART_BYTES, R2ArchiveReader, R2ArchiveStore, R2ReadbackStore,
+)
+from .archive_store import attest_readback, manifest_key, readback, seal
+from .common import GovernanceError, canonical_json_bytes, sha256_bytes
+
+
+class SDKError(Exception):
+    def __init__(self, status, code):
+        super().__init__("secret-value https://private.example/?token=never-print")
+        self.response = {"ResponseMetadata": {"HTTPStatusCode": status}, "Error": {"Code": code}}
+
+
+class Body(io.BytesIO):
+    def __init__(self, content, *, fail=False, close_fail=False):
+        super().__init__(content)
+        self.fail = fail
+        self.close_fail = close_fail
+        self.eof = False
+        self.read_calls = 0
+
+    def read(self, amount=-1):
+        self.read_calls += 1
+        if self.fail:
+            raise OSError("secret-value read failed")
+        result = super().read(amount)
+        if not result:
+            self.eof = True
+        return result
+
+    def close(self):
+        super().close()
+        if self.close_fail:
+            raise OSError("secret-value close failed")
+
+
+class S3Double:
+    """Only GET/PUT exist; every attempted operation is recorded."""
+
+    def __init__(self, target, objects=None, *, read_only=False):
+        config = SimpleNamespace(region_name="auto", s3={"addressing_style": "path"},
+                                 retries={"total_max_attempts": 1, "mode": "standard"},
+                                 request_checksum_calculation="when_required",
+                                 response_checksum_validation="when_required")
+        self.meta = SimpleNamespace(endpoint_url=target.endpoint, config=config)
+        self.objects = {} if objects is None else objects
+        self.calls = []
+        self.bodies = []
+        self.read_only = read_only
+        self.put_error = None
+        self.commit_before_error = False
+        self.put_response = {"ResponseMetadata": {"HTTPStatusCode": 200}, "ETag": '"opaque"'}
+        self.get_error = None
+        self.get_override = {}
+        self.body_fail = False
+        self.close_fail = False
+        self.fail_receipt = False
+
+    def put_object(self, **kwargs):
+        self.calls.append(("put", kwargs))
+        if self.read_only:
+            raise AssertionError("read-only client received write")
+        if self.fail_receipt and "/receipts/" in kwargs["Key"]:
+            raise SDKError(503, "ServiceUnavailable")
+        if self.put_error and not self.commit_before_error:
+            raise self.put_error
+        if kwargs["Key"] in self.objects:
+            raise SDKError(412, "PreconditionFailed")
+        self.objects[kwargs["Key"]] = kwargs["Body"]
+        if self.put_error:
+            raise self.put_error
+        return self.put_response
+
+    def get_object(self, **kwargs):
+        self.calls.append(("get", kwargs))
+        if self.get_error:
+            raise self.get_error
+        if kwargs["Key"] not in self.objects:
+            raise SDKError(404, "NoSuchKey")
+        raw = self.objects[kwargs["Key"]]
+        body = Body(raw, fail=self.body_fail, close_fail=self.close_fail)
+        self.bodies.append(body)
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}, "ContentLength": len(raw),
+                "Body": body, "StorageClass": "STANDARD", "ETag": '"not-a-sha256"',
+                **self.get_override}
+
+
+def observation(target, operation, result, *, status=200):
+    path = f"/accounts/{target.account}/r2/buckets/{target.bucket}"
+    if operation == "lifecycle":
+        raw = canonical_json_bytes({"ResponseMetadata": {"HTTPStatusCode": status, "RequestId": "request-1"}, **result})
+    else:
+        raw = canonical_json_bytes({"success": True, "errors": [], "messages": [], "result": result})
+    envelope = {
+        "account": target.account, "jurisdiction": target.jurisdiction, "bucket": target.bucket,
+        "archive_root": target.root, "source_commit": target.expected_source,
+        "run_id": target.expected_run, "run_attempt": target.expected_attempt,
+        "endpoint": target.endpoint if operation == "lifecycle" else "https://api.cloudflare.com/client/v4",
+        "method": "GET", "path": f"/{target.bucket}?lifecycle" if operation == "lifecycle" else path + ("/lock" if operation == "locks" else ""),
+        "operation": operation,
+        "headers": {"cf-r2-jurisdiction": target.jurisdiction} if operation != "lifecycle" and target.jurisdiction != "default" else {},
+        "observed_at": "2026-09-08T10:00:00Z", "status": status, "request_id": "request-1",
+        "authority_ref": "synthetic-config-reader", "raw_response": raw.decode(), "response_sha256": sha256_bytes(raw),
+    }
+    return PolicyObservation(canonical_json_bytes(envelope))
+
+
+class R2ArchiveTests(unittest.TestCase):
+    def setUp(self):
+        inventory, self.payloads = synthetic_bundle()
+        self.manifest = construct_manifest(inventory)
+        self.raw = canonical_json_bytes(self.manifest)
+        self.pin = sha256_bytes(self.raw)
+        self.target = R2Target("a" * 32, "default", "synthetic-primary", "synthetic-producer",
+                               self.raw, self.pin, SOURCE, RUN, ATTEMPT)
+        self.key = manifest_key(self.manifest)
+        self.object_key = self.manifest["artifacts"][0]["key"]
+        self.expected = dict(manifest_sha256=self.pin, expected_source=SOURCE,
+                             expected_run=RUN, expected_attempt=ATTEMPT)
+
+    def store(self, target=None, objects=None):
+        target = target or self.target
+        client = S3Double(target, objects)
+        return R2ArchiveStore(target, client), client
+
+    def seal(self, store):
+        return seal(store, self.manifest, lambda record: self.payloads[record["path"]])
+
+    def policy(self, *, target=None, rules=None, lifecycle=None, metadata=None, lifecycle_status=200):
+        target = target or self.target
+        if rules is None:
+            rules = [{"id": "forever", "enabled": True, "condition": {"type": "Indefinite"}}]
+        if metadata is None:
+            metadata = {"name": target.bucket, "jurisdiction": target.jurisdiction,
+                        "storageClass": "Standard", "creationDate": "2026-09-08T00:00:00Z"}
+        return dict(metadata=observation(target, "metadata", metadata),
+                    locks=observation(target, "locks", {"rules": rules}),
+                    lifecycle=observation(target, "lifecycle", {"Rules": []} if lifecycle is None else lifecycle,
+                                          status=lifecycle_status))
+
+    def assert_policy_fails(self, **kwargs):
+        with self.assertRaises(GovernanceError):
+            admit_configuration(self.target, **self.policy(**kwargs))
+
+    def test_target_endpoint_key_and_location_binding(self):
+        for jurisdiction in ("default", "eu", "us", "fedramp"):
+            target = replace(self.target, jurisdiction=jurisdiction)
+            self.assertEqual(target.endpoint, "https://" + "a" * 32 +
+                             ("." if jurisdiction == "default" else f".{jurisdiction}.") + "r2.cloudflarestorage.com")
+            store, client = self.store(target)
+            self.assertTrue(store.create(self.object_key, b"fresh"))
+            self.assertEqual(store.location, target.location)
+        for field, values in {
+            "account": ["A" * 32, "a" * 31, "user@host"],
+            "jurisdiction": ["EU", "default/path"],
+            "bucket": ["UPPER", "a", "a.b", "-bad", "bad-", "b" * 64, "a/b"],
+            "credential_ref": ["", "https://secret?token=value"],
+            "storage_class": ["Standard", "STANDARD_IA"],
+            "expected_source": ["b" * 40], "expected_run": [RUN + 1, True],
+            "expected_attempt": [ATTEMPT + 1], "manifest_sha256": ["b" * 64],
+        }.items():
+            for value in values:
+                with self.subTest(field=field, value=value), self.assertRaises(GovernanceError):
+                    replace(self.target, **{field: value})
+        wrong = copy.deepcopy(self.manifest)
+        wrong["archive_root"] = "sifr/wrong/"
+        raw = canonical_json_bytes(wrong)
+        with self.assertRaises(GovernanceError):
+            replace(self.target, manifest_bytes=raw, manifest_sha256=sha256_bytes(raw))
+        store, client = self.store()
+        for key in ["/" + self.key, self.key.replace(SOURCE, "b" * 40), self.target.root + "../manifest.json",
+                    self.target.root + "objects/sha256/" + "A" * 64, self.target.root + "%6danifest.json",
+                    self.target.root + "x\\manifest.json", self.target.root + "unknown", self.key + "?x=1",
+                    self.target.root + "x" * 1025]:
+            with self.assertRaises(GovernanceError):
+                store.create(key, b"x")
+            with self.assertRaises(GovernanceError):
+                store.read(key)
+        self.assertEqual(client.calls, [])
+        for field, value in [("endpoint_url", self.target.endpoint + "/"), ("endpoint_url", "https://custom.example"),
+                             ("endpoint_url", self.target.endpoint + ":443"), ("endpoint_url", self.target.endpoint + "?x=1")]:
+            bad = S3Double(self.target)
+            setattr(bad.meta, field, value)
+            with self.assertRaises(GovernanceError):
+                R2ArchiveStore(self.target, bad)
+        for field, value in [("region_name", "us-east-1"), ("s3", {"addressing_style": "virtual"}),
+                             ("retries", {"total_max_attempts": 2}), ("retries", {"max_attempts": 1}),
+                             ("request_checksum_calculation", "when_supported")]:
+            bad = S3Double(self.target)
+            setattr(bad.meta.config, field, value)
+            with self.assertRaises(GovernanceError):
+                R2ArchiveStore(self.target, bad)
+        client.meta.endpoint_url = "https://other.example"
+        with self.assertRaises(GovernanceError):
+            store.create(self.key, b"x")
+        self.assertEqual(client.calls, [])
+        self.assertEqual(replace(self.target, credential_ref="other-handle").location, self.target.location)
+        inventory, _ = synthetic_bundle()
+        inventory["identity"]["run_id"] += 1
+        for record in inventory["artifacts"]:
+            record["producer"]["run_id"] += 1
+        another_raw = canonical_json_bytes(construct_manifest(inventory))
+        another = replace(self.target, manifest_bytes=another_raw, manifest_sha256=sha256_bytes(another_raw),
+                          expected_run=RUN + 1)
+        self.assertNotEqual(another.root, self.target.root)
+        self.assertEqual(another.location, self.target.location)
+
+    def test_atomic_conditional_create_and_existing_content(self):
+        store, client = self.store()
+        competitor, other = self.store(objects=client.objects)
+        self.assertTrue(store.create(self.object_key, b"first"))
+        self.assertFalse(competitor.create(self.object_key, b"second"))
+        self.assertEqual(client.objects[self.object_key], b"first")
+        self.assertEqual(client.calls, [("put", dict(Bucket=self.target.bucket, Key=self.object_key, Body=b"first",
+                                                    ContentLength=5, IfNoneMatch="*", StorageClass="STANDARD"))])
+        self.assertEqual(len(other.calls), 1)
+        with self.assertRaises(GovernanceError):
+            self.seal(store)
+        self.assertNotIn(self.key, client.objects)
+        store, client = self.store()
+        record = self.manifest["artifacts"][0]
+        store.create(record["key"], self.payloads[record["path"]])
+        self.assertEqual(self.seal(store), self.pin)
+        original = client.objects[self.key]
+        with self.assertRaises(GovernanceError):
+            self.seal(store)
+        self.assertEqual(client.objects[self.key], original)
+
+    def test_create_errors_and_ambiguous_completion_fail_closed(self):
+        errors = [SDKError(code, "Denied") for code in (401, 403, 404, 409, 429, 500, 503)]
+        errors += [SDKError(412, "WrongCode"), SDKError(403, "PreconditionFailed"),
+                   SDKError(500, "https://secret-value/token"), TimeoutError("secret-value")]
+        for error in errors:
+            store, client = self.store()
+            client.put_error = error
+            with self.assertRaises(GovernanceError) as caught:
+                store.create(self.object_key, b"x")
+            self.assertNotIn("secret-value", str(caught.exception))
+            self.assertEqual(len(client.calls), 1)
+            self.assertEqual(client.objects, {})
+        for response in (None, {}, {"ResponseMetadata": {"HTTPStatusCode": 201}, "ETag": "x"},
+                         {"ResponseMetadata": {"HTTPStatusCode": 200}},
+                         {"ResponseMetadata": {"HTTPStatusCode": 200}, "ETag": "x", "Error": {}}):
+            store, client = self.store()
+            client.put_response = response
+            with self.assertRaises(GovernanceError):
+                store.create(self.object_key, b"x")
+            self.assertEqual(len(client.calls), 1)
+        for committed in (False, True):
+            store, client = self.store()
+            client.put_error = TimeoutError("secret-value")
+            client.commit_before_error = committed
+            with self.assertRaises(GovernanceError):
+                self.seal(store)
+            self.assertEqual(len(client.calls), 1)
+            self.assertNotIn(self.key, client.objects)
+            self.assertEqual(bool(client.objects), committed)
+            self.assertFalse(any("/receipts/" in key for key in client.objects))
+            client.put_error = None
+            self.assertEqual(self.seal(store), self.pin)
+
+    def test_fresh_complete_reads_and_body_cleanup(self):
+        store, client = self.store()
+        client.objects[self.object_key] = b"abc"
+        self.assertEqual(store.read(self.object_key), b"abc")
+        client.objects[self.object_key] = b"changed"
+        self.assertEqual(store.read(self.object_key), b"changed")
+        self.assertEqual(client.calls, [("get", {"Bucket": self.target.bucket, "Key": self.object_key})] * 2)
+        self.assertTrue(all(body.closed and body.eof for body in client.bodies))
+        for override in ({"ResponseMetadata": {"HTTPStatusCode": 206}}, {"ContentRange": "bytes 0-2/7"},
+                         {"ResponseMetadata": {"HTTPStatusCode": 200, "HTTPHeaders": {"content-range": "bytes 0-2/7"}}},
+                         {"ContentLength": 100}, {"ContentLength": 1}, {"ContentLength": None},
+                         {"ContentLength": MAX_SINGLE_PART_BYTES + 1}, {"ContentLength": True},
+                         {"StorageClass": None}, {"ContentEncoding": "gzip"}, {"Expiration": "expiry"}):
+            client.get_override = override
+            with self.assertRaises(GovernanceError):
+                store.read(self.object_key)
+            self.assertTrue(client.bodies[-1].closed)
+        client.get_override = {}
+        for setting in ("body_fail", "close_fail"):
+            setattr(client, setting, True)
+            with self.assertRaises(GovernanceError) as caught:
+                store.read(self.object_key)
+            self.assertNotIn("secret-value", str(caught.exception))
+            self.assertTrue(client.bodies[-1].closed)
+            setattr(client, setting, False)
+        for error in (SDKError(403, "AccessDenied"), SDKError(404, "NoSuchKey"), OSError("secret-value")):
+            client.get_error = error
+            with self.assertRaises(GovernanceError):
+                store.read(self.object_key)
+        client.get_error = None
+        with patch.object(client, "get_object", return_value=None):
+            with self.assertRaises(GovernanceError):
+                store.read(self.object_key)
+        for body in (SimpleNamespace(read=lambda _: "not bytes", close=lambda: None),
+                     SimpleNamespace(read=lambda _: b"", close=lambda: None)):
+            with patch.object(client, "get_object", return_value={"ResponseMetadata": {"HTTPStatusCode": 200},
+                              "Body": body, "ContentLength": 3, "StorageClass": "STANDARD"}):
+                with self.assertRaises(GovernanceError):
+                    store.read(self.object_key)
+        client.get_error = GovernanceError("secret-value from transport")
+        with self.assertRaises(GovernanceError) as caught:
+            store.read(self.object_key)
+        self.assertNotIn("secret-value", str(caught.exception))
+        client.get_error = None
+        client.objects.clear()
+        self.seal(store)
+        client.objects[self.object_key] += b"mutation"
+        with self.assertRaises(GovernanceError):
+            readback(store, key=self.key, **self.expected)
+
+    def test_indefinite_complete_root_lock_admission(self):
+        for prefix in (None, "", "sifr/", self.target.root):
+            rule = {"id": "forever", "enabled": True, "condition": {"type": "Indefinite"}}
+            if prefix is not None:
+                rule["prefix"] = prefix
+            admitted = admit_configuration(self.target, **self.policy(rules=[rule]))
+            self.assertEqual(admitted.assurance, "supplied-policy-observations-only")
+        base = {"id": "forever", "enabled": True, "condition": {"type": "Indefinite"}}
+        for rules in ([], [{**base, "enabled": False}], [{**base, "prefix": self.target.root + "objects/"}],
+                      [{**base, "condition": {"type": "Age", "maxAgeSeconds": 50}}],
+                      [{**base, "condition": {"type": "Date", "date": "2099-01-01T00:00:00Z"}}],
+                      [base, {**base, "id": "other", "condition": {"type": "Unknown"}}],
+                      [base, base], [{**base, "enabled": 1}], [{**base, "unexpected": True}]):
+            self.assert_policy_fails(rules=rules)
+        policies = self.policy()
+        for key, value in {"account": "b" * 32, "bucket": "wrong-bucket", "endpoint": "https://wrong.example",
+                           "archive_root": "sifr/wrong/", "source_commit": "b" * 40, "run_id": RUN + 1,
+                           "run_attempt": ATTEMPT + 1, "method": "PUT", "path": "/wrong", "headers": {"Authorization": "x"},
+                           "authority_ref": self.target.credential_ref, "observed_at": "2026-09-08", "status": 403,
+                           "response_sha256": "b" * 64}.items():
+            envelope = json.loads(policies["locks"].envelope)
+            envelope[key] = value
+            with self.assertRaises(GovernanceError):
+                admit_configuration(self.target, **{**policies, "locks": PolicyObservation(canonical_json_bytes(envelope))})
+        for operation in ("metadata", "locks", "lifecycle"):
+            envelope = json.loads(policies[operation].envelope)
+            raw = envelope["raw_response"]
+            first_key = next(iter(json.loads(raw)))
+            raw = '{"' + first_key + '":null,' + raw[1:]
+            envelope.update(raw_response=raw, response_sha256=sha256_bytes(raw.encode()))
+            with self.assertRaises(GovernanceError):
+                admit_configuration(self.target, **{**policies, operation: PolicyObservation(canonical_json_bytes(envelope))})
+        duplicate = b'{"account":"duplicate",' + policies["locks"].envelope[1:]
+        with self.assertRaises(GovernanceError):
+            admit_configuration(self.target, **{**policies, "locks": PolicyObservation(duplicate)})
+        eu = replace(self.target, jurisdiction="eu")
+        admit_configuration(eu, **self.policy(target=eu))
+
+    def test_no_expiry_standard_lifecycle_admission(self):
+        for prefix in ("", "sifr/", self.target.root, self.target.root + "receipts/"):
+            for action in ({"Expiration": {"Days": 30}}, {"Transitions": [{"Days": 0, "StorageClass": "STANDARD_IA"}]},
+                           {"NoncurrentVersionExpiration": {"NoncurrentDays": 1}}):
+                self.assert_policy_fails(lifecycle={"Rules": [{"Status": "Enabled", "Filter": {"Prefix": prefix}, **action}]})
+        for rule in ({"Status": "Disabled", "Prefix": "", "Expiration": {"Days": 1}},
+                     {"Status": "Enabled", "Filter": {"Prefix": "unrelated/"}, "Expiration": {"Days": 1}},
+                     {"Status": "Enabled", "Filter": {}, "AbortIncompleteMultipartUpload": {"DaysAfterInitiation": 7}}):
+            admit_configuration(self.target, **self.policy(lifecycle={"Rules": [rule]}))
+        for lifecycle in ({}, {"Rules": None}, {"Rules": [{"Status": "Enabled", "Filter": {"Tag": {"Key": "x", "Value": "y"}}, "Expiration": {"Days": 1}}]},
+                          {"Rules": [{"Status": "Enabled", "Prefix": "", "MysteryAction": {}}]},
+                          {"Rules": [{"Status": "Enabled", "Prefix": "", "Filter": {}, "Expiration": {"Days": 1}}]},
+                          {"Rules": [{"Status": "Enabled", "Prefix": ""}]},
+                          {"Rules": [{"Status": "Disabled", "Prefix": "", "Expiration": {"Mystery": 1}}]},
+                          {"Error": {"Code": "AccessDenied"}}):
+            self.assert_policy_fails(lifecycle=lifecycle)
+        admit_configuration(self.target, **self.policy(lifecycle={"Error": {"Code": "NoSuchLifecycleConfiguration"}}, lifecycle_status=404))
+        self.assert_policy_fails(lifecycle={"Error": {"Code": "AccessDenied"}}, lifecycle_status=404)
+        self.assert_policy_fails(lifecycle_status=403)
+        good = {"name": self.target.bucket, "jurisdiction": "default", "storageClass": "Standard", "creationDate": "2026-09-08T00:00:00Z"}
+        for field, value in (("name", "wrong-bucket"), ("jurisdiction", "eu"), ("storageClass", "InfrequentAccess"), ("storageClass", None)):
+            self.assert_policy_fails(metadata={**good, field: value})
+        self.assert_policy_fails(metadata={key: value for key, value in good.items() if key != "storageClass"})
+
+    def readback_handle(self, target, objects):
+        reader_target = replace(target, credential_ref="synthetic-reader")
+        writer_target = replace(target, credential_ref="synthetic-receipt-writer")
+        reader = S3Double(reader_target, objects, read_only=True)
+        writer = S3Double(writer_target, objects)
+        handle = R2ReadbackStore(R2ArchiveReader(reader_target, reader), R2ArchiveStore(writer_target, writer))
+        return handle, reader, writer
+
+    def test_reader_receipt_writer_and_custody_separation(self):
+        store, producer = self.store()
+        self.seal(store)
+        handle, reader, writer = self.readback_handle(self.target, producer.objects)
+        producer_calls = len(producer.calls)
+        receipt = attest_readback([handle], key=self.key, receipt_id="read-only-1", kind="readback", **self.expected)
+        self.assertEqual(receipt["assurance"], "complete-byte-readback-only")
+        self.assertEqual(len(producer.calls), producer_calls)
+        self.assertTrue(all(op == "get" for op, _ in reader.calls))
+        self.assertEqual(len(writer.calls), 1)
+        self.assertTrue(all(op == "put" and "/receipts/" in args["Key"] for op, args in writer.calls))
+        with self.assertRaises(GovernanceError):
+            handle.create(self.object_key, b"x")
+        reader.get_error = SDKError(403, "AccessDenied")
+        with self.assertRaises(GovernanceError):
+            handle.read(self.key)
+        self.assertEqual(len(producer.calls), producer_calls)
+        reader.get_error = None
+        reader_only = R2ArchiveReader(replace(self.target, credential_ref="reader"), reader)
+        with self.assertRaises(GovernanceError):
+            R2ReadbackStore(reader_only, None)
+        wrong, _ = self.store(replace(self.target, bucket="synthetic-other"))
+        with self.assertRaises(GovernanceError):
+            R2ReadbackStore(reader_only, wrong)
+        with self.assertRaises(GovernanceError):
+            R2ReadbackStore(reader_only, R2ArchiveStore(reader_only.target, reader))
+        alias, _, _ = self.readback_handle(replace(self.target, credential_ref="alias"), producer.objects)
+        with self.assertRaises(GovernanceError):
+            attest_readback([handle, alias], key=self.key, receipt_id="aliases", kind="copy", **self.expected)
+
+    def test_all_class_seal_readback_and_interrupted_copy(self):
+        primary, primary_client = self.store()
+        copy_target = replace(self.target, bucket="synthetic-copy")
+        secondary, copy_client = self.store(copy_target)
+        self.assertEqual(len(self.manifest["matrix"]), 6)
+        self.assertEqual(self.seal(primary), self.pin)
+        self.assertEqual(self.seal(secondary), self.pin)
+        primary_reader, _, _ = self.readback_handle(self.target, primary_client.objects)
+        copy_reader, _, writer = self.readback_handle(copy_target, copy_client.objects)
+        stores = [primary_reader, copy_reader]
+        original = primary_client.objects[self.key]
+        for bad in (None, b"mutated"):
+            saved = copy_client.objects.pop(self.object_key)
+            if bad is not None:
+                copy_client.objects[self.object_key] = bad
+            with self.assertRaises(GovernanceError):
+                attest_readback(stores, key=self.key, receipt_id="copy-missing", kind="copy", **self.expected)
+            self.assertFalse(any("/receipts/" in key for key in primary_client.objects))
+            copy_client.objects[self.object_key] = saved
+        for field, value in (("manifest_sha256", "b" * 64), ("expected_source", "b" * 40),
+                             ("expected_run", RUN + 1), ("expected_attempt", ATTEMPT + 1)):
+            with self.assertRaises(GovernanceError):
+                attest_readback(stores, key=self.key, receipt_id="wrong-pin", kind="copy", **{**self.expected, field: value})
+        writer.fail_receipt = True
+        with self.assertRaises(GovernanceError):
+            attest_readback(stores, key=self.key, receipt_id="interrupted-copy", kind="copy", **self.expected)
+        partial = [raw for key, raw in primary_client.objects.items() if "/receipts/" in key]
+        self.assertEqual(len(partial), 1)
+        self.assertEqual(json.loads(partial[0])["assurance"], "complete-byte-readback-only")
+        self.assertFalse(any("/receipts/" in key for key in copy_client.objects))
+        self.assertEqual(primary_client.objects[self.key], original)
+        self.assertEqual(copy_client.objects[self.key], original)
+        writer.fail_receipt = False
+        receipt = attest_readback(stores, key=self.key, receipt_id="complete-copy", kind="copy", **self.expected)
+        self.assertEqual(receipt["locations"], sorted([self.target.location, copy_target.location]))
+        self.assertEqual(receipt["assurance"], "complete-byte-readback-only")
+        self.assertNotIn("independence", receipt)
+
+    def test_single_part_size_and_no_live_side_effects(self):
+        class OverLimit(bytes):
+            def __len__(self):
+                return MAX_SINGLE_PART_BYTES + 1
+
+        with patch.object(socket, "socket", side_effect=AssertionError("network forbidden")), \
+             patch.object(subprocess, "Popen", side_effect=AssertionError("subprocess forbidden")), \
+             patch.dict("os.environ", {}, clear=True):
+            store, client = self.store()
+            with self.assertRaises(GovernanceError):
+                store.create(self.object_key, OverLimit(b"tiny"))
+            self.assertEqual(client.calls, [])
+            with patch("verification.areas.distribution_release.governance.archive_r2_store.MAX_SINGLE_PART_BYTES", 2):
+                with self.assertRaises(GovernanceError):
+                    store.create(self.object_key, b"abc")
+            self.assertEqual(client.calls, [])
+            client.objects[self.object_key] = b"tiny"
+            client.get_override = {"ContentLength": MAX_SINGLE_PART_BYTES + 1}
+            with self.assertRaises(GovernanceError):
+                store.read(self.object_key)
+            self.assertTrue(client.bodies[-1].closed)
+            self.assertEqual(client.bodies[-1].read_calls, 0)
+            client.get_override = {}
+            client.objects.clear()
+            self.assertEqual(self.seal(store), self.pin)
+            admit_configuration(self.target, **self.policy())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verification/areas/distribution_release/governance/archive_r2_store.py
+++ b/verification/areas/distribution_release/governance/archive_r2_store.py
@@ -1,0 +1,182 @@
+"""Explicit SDK-shaped R2 archive transport; no SDK factory or ambient access."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Protocol
+
+from .archive_r2_config import R2Target, _require
+from .common import GovernanceError
+
+MAX_SINGLE_PART_BYTES = 5 * 1024 ** 3
+READ_CHUNK_BYTES = 1024 ** 2
+
+
+class S3Client(Protocol):
+    meta: Any
+
+    def put_object(self, **kwargs: Any) -> dict: ...
+
+    def get_object(self, **kwargs: Any) -> dict: ...
+
+
+def validate_client(target: R2Target, client: S3Client) -> None:
+    """Inspect standard SDK metadata; wire/TLS/credential proof belongs to F1C2."""
+    try:
+        meta = client.meta
+        config = meta.config
+        valid = (meta.endpoint_url == target.endpoint and config.region_name == "auto"
+                 and config.s3 == {"addressing_style": "path"}
+                 and isinstance(config.retries, dict)
+                 and type(config.retries.get("total_max_attempts")) is int
+                 and config.retries["total_max_attempts"] == 1
+                 and set(config.retries) <= {"total_max_attempts", "mode"}
+                 and config.request_checksum_calculation == "when_required"
+                 and config.response_checksum_validation == "when_required")
+    except Exception:
+        raise GovernanceError("missing SDK target/configuration binding") from None
+    _require(valid, "SDK endpoint/region/path/retry/checksum configuration mismatch")
+
+
+def _status(response: Any) -> int | None:
+    if not isinstance(response, dict):
+        return None
+    metadata = response.get("ResponseMetadata")
+    if not isinstance(metadata, dict):
+        return None
+    status = metadata.get("HTTPStatusCode")
+    return status if type(status) is int else None
+
+
+def _error_parts(exc: Exception) -> tuple[int | None, str | None]:
+    try:
+        response = getattr(exc, "response", None)
+        status = _status(response)
+        error = response.get("Error") if isinstance(response, dict) else None
+        code = error.get("Code") if isinstance(error, dict) else None
+        return status, code if isinstance(code, str) else None
+    except Exception:
+        return None, None
+
+
+def _failure(operation: str, exc: Exception) -> GovernanceError:
+    status, code = _error_parts(exc)
+    # Do not expose exception text, arbitrary message bodies, URLs or credentials.
+    safe_status = str(status) if status is not None and 100 <= status <= 599 else "unknown"
+    safe_code = code if code and re.fullmatch(r"[A-Za-z][A-Za-z0-9]{0,63}", code) else "redacted"
+    return GovernanceError(f"R2 {operation} failed: HTTP {safe_status}, code {safe_code}")
+
+
+class R2ArchiveReader:
+    """Dedicated read client; this object exposes no create operation."""
+
+    def __init__(self, target: R2Target, client: S3Client):
+        validate_client(target, client)
+        self.target = target
+        self._client = client
+
+    @property
+    def location(self) -> str:
+        return self.target.location
+
+    def read(self, key: str) -> bytes:
+        self.target.validate_key(key)
+        validate_client(self.target, self._client)
+        body = None
+        try:
+            response = self._client.get_object(Bucket=self.target.bucket, Key=key)
+            if isinstance(response, dict):
+                body = response.get("Body")
+            _require(_status(response) == 200 and "Error" not in response
+                     and "ContentRange" not in response and "DeleteMarker" not in response,
+                     "R2 read requires a complete 200 response")
+            headers = response["ResponseMetadata"].get("HTTPHeaders", {})
+            _require(isinstance(headers, dict) and all(isinstance(key, str) for key in headers),
+                     "R2 read has malformed response headers")
+            _require(not {"content-range", "content-encoding", "x-amz-expiration"}.intersection(
+                key.lower() for key in headers), "R2 read has range, encoding or expiration headers")
+            _require(callable(getattr(body, "read", None)) and callable(getattr(body, "close", None)),
+                     "R2 read has no complete stream")
+            length = response.get("ContentLength")
+            _require(type(length) is int and 0 <= length <= MAX_SINGLE_PART_BYTES,
+                     "R2 read length is missing or over limit")
+            _require(response.get("StorageClass") == "STANDARD"
+                     and "ContentEncoding" not in response and "Expiration" not in response,
+                     "R2 read has missing Standard metadata, encoding or expiration")
+            chunks = []
+            total = 0
+            while True:
+                # Read through EOF, including one byte beyond a declared length.
+                chunk = body.read(min(READ_CHUNK_BYTES, length - total + 1))
+                _require(type(chunk) is bytes, "R2 body returned non-bytes")
+                if not chunk:
+                    break
+                total += len(chunk)
+                _require(total <= length and total <= MAX_SINGLE_PART_BYTES, "R2 body exceeds declared length")
+                chunks.append(chunk)
+            _require(total == length, "R2 body was truncated")
+            return b"".join(chunks)
+        except Exception as exc:
+            raise _failure("read", exc) from None
+        finally:
+            if body is not None:
+                try:
+                    body.close()
+                except Exception:
+                    raise GovernanceError("R2 body cleanup failed") from None
+
+
+class R2ArchiveStore(R2ArchiveReader):
+    """One conditional PUT per call; no existence probe, overwrite or retry."""
+
+    def create(self, key: str, content: bytes) -> bool:
+        self.target.validate_key(key)
+        _require(isinstance(content, bytes) and len(content) <= MAX_SINGLE_PART_BYTES,
+                 "R2 single-part content is invalid or over limit")
+        # Reject byte subclasses with a forged length before crossing the SDK boundary.
+        _require(type(content) is bytes, "R2 content must be exact bytes")
+        validate_client(self.target, self._client)
+        try:
+            response = self._client.put_object(
+                Bucket=self.target.bucket, Key=key, Body=content, ContentLength=len(content),
+                IfNoneMatch="*", StorageClass="STANDARD",
+            )
+        except Exception as exc:
+            if _error_parts(exc) == (412, "PreconditionFailed"):
+                return False
+            raise _failure("create", exc) from None
+        _require(_status(response) == 200 and "Error" not in response
+                 and isinstance(response.get("ETag"), str) and bool(response["ETag"]),
+                 "R2 create did not return complete success")
+        return True
+
+
+class R2ReadbackStore:
+    """F1B-compatible composition: independent reads plus receipt-only writes.
+
+Credential references are binding labels, not proof of actual role separation.
+The online owner must authenticate them without exposing credentials here.
+"""
+
+    def __init__(self, reader: R2ArchiveReader, receipt_writer: R2ArchiveStore | None):
+        _require(type(reader) is R2ArchiveReader, "dedicated read-only handle required")
+        _require(type(receipt_writer) is R2ArchiveStore, "separate receipt writer required")
+        _require(reader.target.binding == receipt_writer.target.binding,
+                 "receipt writer target mismatch")
+        _require(reader._client is not receipt_writer._client
+                 and reader.target.credential_ref != receipt_writer.target.credential_ref,
+                 "reader and receipt writer must have separate clients/references")
+        self._reader = reader
+        self._writer = receipt_writer
+
+    @property
+    def location(self) -> str:
+        return self._reader.location
+
+    def read(self, key: str) -> bytes:
+        return self._reader.read(key)
+
+    def create(self, key: str, content: bytes) -> bool:
+        self._reader.target.validate_key(key, receipt_only=True)
+        _require(self._reader.target.binding == self._writer.target.binding, "receipt writer target mismatch")
+        return self._writer.create(key, content)


### PR DESCRIPTION
Implements item 70-F1C1: the offline R2 adapter and configuration-admission contract registered by merged F1C0. An immutable manifest-bound target admits only canonical keys and matching explicit SDK client configuration; create uses one conditional PUT, and reads consume fresh complete bodies with length checks and cleanup. Pure supplied-observation validation requires complete-root indefinite locks and Standard/no-expiry lifecycle policy. Readback composes an explicit reader with a separate receipt-only writer.

Only the three registered governance Python modules and plan/phase records change. Existing F1B source/schema/CLI remain unchanged; tests import its complete synthetic inventory. Mocks establish no live SDK, access, retention or independent-custody readiness; F1C2/D remain separate.

Validation on candidate 29a1f965ebfdfb7c40261d903a993e74507fdc13: Python 3.14.7 named archive_r2_selftest passed all nine tests (1.277 seconds); git diff --check passed for base/candidate and clean worktree; file-size guard passed (3,770 files). No compiler, lockfile, fixture or workflow changes, so zero Sifr gates. Exact-SHA Opus source-only review pending.
