### PR TITLE
Add isolated R2 archival SDK runtime (70-F1C2A)

### DIFF
--- a/plans/issues/active/ad-hoc-latest-stable-item70-f1c2a-runtime.md
+++ b/plans/issues/active/ad-hoc-latest-stable-item70-f1c2a-runtime.md
@@ -1,0 +1,166 @@
+# Item 70-F1C2A: real SDK runtime and controlled configuration transport
+
+State: implementation complete; pre-edit registration retained below, 2026-09-08.
+Owner: release/distribution, issue #3775, child `/root/item70_f1c2a`.
+Owned clone `/private/tmp/sifr-item70-f1c2a.rE2PJS/codebase`, branch
+`codex/latest-stable-item70-f1c2a`, base
+`07d47de0a8358dde0344b6b2cf01d3ee5057cd07`; all evidence, cache, venv and
+temporary paths belong to `/private/tmp/sifr-item70-f1c2a.rE2PJS`.
+Parent and predecessor paths remain read-only.
+
+The coordinator's top F1C2A registration in the parent phase ledger splits
+offline runtime work from later F1C2B access/custody proof. Preserve the
+[F1C0 contract](ad-hoc-latest-stable-item70-f1c0-r2-plan.md) and F1B/F1C1
+semantics. No cloud operation, credential discovery, workflow wiring,
+compiler, fixture, historical research, qualification or later-item work.
+
+## Exact implementation registration
+
+New paths under `verification/areas/distribution_release/`:
+
+- `governance/archive_r2_runtime.py`: maintained Boto3/Botocore factory,
+  explicit supplied credentials, isolated SDK configuration, endpoint/TLS/
+  request binding and one total attempt; lifecycle observation bridge.
+- `governance/archive_r2_control.py`: explicit read-only Cloudflare HTTPS GET
+  transport for bucket metadata/locks, no redirect/proxy/ambient auth, bounded
+  complete fresh responses and sanitized observations.
+- `governance/archive_r2_runtime_selftest.py`: actual SDK serialization,
+  SDK stubs and local transport doubles only; deny all real sockets.
+- `runtime/pyproject.toml` and `runtime/uv.lock`: distribution-owned exact SDK
+  dependencies, Python 3.14.7, uv 0.12.5; lock is tracked and gate-bearing.
+
+Only this item document and `ad-hoc-latest-stable-release-convergence.md`
+may additionally change as scoped phase records. No existing adapter edit
+is currently needed, so the existing nine-case `archive_r2_selftest` is not
+registered for execution. Any necessary adapter integration must be registered
+here before its edit and nine-case test invocation.
+
+## Exact commands and focused test contract
+
+Run from the owned clone, with these task-owned environment variables:
+
+```sh
+export UV_CACHE_DIR=/private/tmp/sifr-item70-f1c2a.rE2PJS/uv-cache
+export UV_PROJECT_ENVIRONMENT=/private/tmp/sifr-item70-f1c2a.rE2PJS/venv
+export UV_PYTHON_DOWNLOADS=never
+export UV_PYTHON=/Users/yaseralnajjar/.local/share/uv/python/cpython-3.14.7-macos-aarch64-none/bin/python3
+export TMPDIR=/private/tmp/sifr-item70-f1c2a.rE2PJS
+```
+
+Read-only package metadata retrieval (no provider requests):
+`curl --fail --silent --show-error https://pypi.org/pypi/boto3/json --output /private/tmp/sifr-item70-f1c2a.rE2PJS/boto3.json`
+and the same exact command for `botocore/json` / `botocore.json`.
+Use `jq '{version:.info.version,requires_python:.info.requires_python,requires_dist:.info.requires_dist,files:[.urls[]|{filename,digests,url}]}'`
+on each metadata file; `shasum -a 256` on both files preserves metadata identity.
+Choose the latest compatible stable exact versions from those official records.
+
+```sh
+uv lock --project verification/areas/distribution_release/runtime --default-index https://pypi.org/simple
+uv lock --check --project verification/areas/distribution_release/runtime --offline
+uv sync --locked --project verification/areas/distribution_release/runtime --no-dev
+uv run --locked --offline --project verification/areas/distribution_release/runtime python -m unittest verification.areas.distribution_release.governance.archive_r2_runtime_selftest
+git diff --check
+python3 scripts/check_file_size_guardrails.py
+```
+
+Named cases in the one new suite:
+
+- `test_exact_runtime_versions_and_lock_hashes`: installed SDK pins, Python,
+  lock dependency hashes against retained official metadata.
+- `test_conditional_put_serialization_and_target_binding`: actual signed SDK
+  method, canonical target/path, condition, region/signature and TLS settings.
+- `test_one_total_attempt_and_redirect_refusal`: one transport attempt for
+  retriable/ambiguous/redirect responses and errors, no endpoint diversion.
+- `test_no_ambient_credentials_or_configuration`: hostile profiles/files,
+  metadata, endpoint/proxy/CA settings cannot supply credentials or retarget.
+- `test_required_only_checksums`: actual PUT wire headers omit optional
+  algorithms/trailers while SigV4 remains SDK-owned.
+- `test_fresh_complete_sdk_reads_and_cleanup`: fresh GET/body each time,
+  length/truncation/error handling and stream close with real SDK parsing.
+- `test_secret_safe_factory_and_transport_errors`: credentials, bearer values,
+  arbitrary exception text and authorization headers never enter errors.
+- `test_controlled_get_target_binding_and_observations`: exact metadata/lock
+  method/host/path/jurisdiction, bound raw-response digests and fresh reads.
+- `test_controlled_get_failures_and_cleanup`: redirect/status/size/truncated/
+  malformed/duplicate-key responses fail closed and connection/body close.
+- `test_lifecycle_sdk_observation_binding`: actual SDK lifecycle request/stub
+  200 rules and explicit absent configuration; denial/mismatch fail closed.
+
+The version/hash case uses the two retained metadata files via explicit
+`SIFR_R2_SDK_METADATA_DIR=/private/tmp/sifr-item70-f1c2a.rE2PJS`; it compares
+the locked SDK wheel/source artifact hashes to official metadata. This variable
+is required only for that evidence assertion, not runtime operation.
+
+## Review, gate dependency and terminal boundary
+
+Freeze one candidate, open one draft PR, and request one exact-base/exact-SHA
+Opus source-inspection-only review (Read/Grep/Glob tools, no commands or tests),
+with at most one remediation review. Preserve final evidence outside Git.
+The new `runtime/uv.lock` requires one merge-profile gate on the final candidate;
+no create-PR gate when merging the same SHA here. Do not run a knowingly
+blocked gate or reset predecessor counters. Coordinator reports compiler
+PR #3717 and solo-policy PR #3785 remain unmerged with retained gate failures;
+check actual main and coordinator before any heavy/native work. E2 B38 owns
+priority for its conditional proof. Finish focused implementation/review first.
+If those external prerequisites still block, preserve candidate and evidence,
+record the precise blocker and stop without merging or starting F1C2B/F1D.
+
+## Implemented boundary and dependency evidence
+
+Official [Boto3 PyPI metadata](https://pypi.org/pypi/boto3/json) and
+[Botocore PyPI metadata](https://pypi.org/pypi/botocore/json), retrieved
+2026-09-08, both select latest stable `1.43.89`. Boto3 requires Botocore
+`>=1.43.89,<1.44.0`; both require Python `>=3.10`. The owned lock pins both
+plus jmespath 1.1.0, s3transfer 0.19.2, python-dateutil 2.9.0.post0, six 1.17.0,
+and urllib3 2.7.0 with official artifact SHA-256 hashes. Lock generation,
+offline lock check and locked sync passed. This lock and pyproject are runtime
+inputs; the owned installation/cache and downloaded metadata are verification
+evidence, not alternate dependency authorities. Metadata JSON SHA-256:
+
+- `boto3.json`: `ebcbba503f36cd02050f2129d455a2549a2c1060fc9bfce828e716fbfa9e6583`.
+- `botocore.json`: `0b33ee3748fb26faadf35778fb02176c2d86120f929fb93265b1652ebc8b6304`.
+
+The version/hash test embeds the two official wheel/source digest pairs so
+it remains reproducible without the original cache. With the registered
+`SIFR_R2_SDK_METADATA_DIR` it additionally compares the retained PyPI records;
+the final item evidence uses that explicit directory. No metadata fetch occurs
+inside the tests. SDK configuration follows the official
+[Config reference](https://docs.aws.amazon.com/botocore/latest/reference/config.html)
+and [retry contract](https://docs.aws.amazon.com/boto3/latest/guide/retries.html).
+
+`create_r2_client` creates a fresh session with explicit credentials and
+role/reference binding. Its isolated session never loads shared profile or
+credential files; an empty credential resolver and SDK-owned model search path
+disable metadata/container/web-identity and custom ambient model discovery.
+Session configuration does not read environment overrides. Explicit configuration
+fixes endpoint, region `auto`, path addressing, SigV4, verified TLS, no proxy,
+no endpoint discovery, required-only checksums and one total attempt. Caller
+parameter checks run before SDK byte-to-stream conversion; the final signed
+request is rechecked before sending. Errors stop before S3 redirect handling
+can discover a region or issue a HEAD/retry. The existing adapter remains the
+sanitized error/full-body transport boundary. No signing code is implemented.
+
+Roles limit producer to conditional PUT/fresh GET, reader to GET, receipt writer
+to receipt-key PUT, and configuration reader to lifecycle GET. These are local
+operation limits, not a claim of actual provider permissions. Configuration
+observations require a separate nonsecret reference. `observe_lifecycle` binds
+the real SDK request/response and explicit 404/NoSuchLifecycleConfiguration;
+its raw response is canonical SDK-shaped JSON, with dates converted to ISO
+text and opaque transport headers/messages excluded. This is the existing
+F1C1 representation, not a claim to retain raw HTTP XML bytes.
+
+`observe_control` constructs only the fixed Cloudflare HTTPS metadata/locks
+GET paths, binds jurisdiction and uses the SDK-owned CA bundle explicitly.
+It does not follow redirects, use proxies or discover authentication. A new
+connection/response is consumed and closed each time; responses are bounded
+to 1 MiB, framing/encoding errors fail closed, and the existing strict parser
+checks the exact raw JSON and observation identity. Credentials are hidden
+from representations and error text; only the nonsecret authority reference
+is recorded. Pure `admit_configuration` remains the policy authority.
+
+The first focused run found SDK Body conversion preceding the original
+generic hook; fixed locally before review by moving parameter checks earlier.
+The second run passed nine cases and identified a test-only bytes/string
+header expectation, corrected before the final candidate. No broad suite,
+Sifr gate, existing nine-case suite or provider call was run. Final validation
+and exact-SHA review evidence will be retained outside the reviewed Git tree.

--- a/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
+++ b/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
@@ -6,6 +6,20 @@ ledger while Kafka and gate-bearing items retain explicit prerequisites.
 
 ## Objective
 
+### Item 70-F1C2A — real SDK/runtime and controlled configuration transport
+
+IMPLEMENTED, pending exact-candidate focused validation and source-only review;
+merge withheld until the gate-bearing new SDK lock has one passing applicable
+merge-profile gate. The coordinator split this offline item from F1C2B live
+access/custody proof after completed F1C1. Exact paths, ten named cases,
+owned installation/check commands and external gate prerequisites were
+[registered before implementation](ad-hoc-latest-stable-item70-f1c2a-runtime.md).
+Only the three new runtime/control/test modules, distribution-owned runtime
+pyproject/lock and item/phase records change. No compiler, existing adapter,
+fixture, workflow, historical recovery or live service operation changes.
+F1C2B and F1D remain separately blocked; this item creates no live access,
+durability, custody or release-qualification claim.
+
 ### Item 70-F1C1 — offline R2 adapter and admission contract
 
 COMPLETE via [PR #3818](https://github.com/sifr-lang/sifr/pull/3818), merged

--- a/verification/areas/distribution_release/governance/archive_r2_control.py
+++ b/verification/areas/distribution_release/governance/archive_r2_control.py
@@ -1,0 +1,112 @@
+"""Bound, read-only Cloudflare control transport. No redirects or proxy use."""
+
+from __future__ import annotations
+
+import http.client
+import ssl
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from botocore.httpsession import get_cert_path
+
+from .archive_r2_config import PolicyObservation, R2Target, _label, _require
+from .common import GovernanceError, canonical_json_bytes, sha256_bytes
+
+CONTROL_HOST = "api.cloudflare.com"
+CONTROL_ENDPOINT = "https://api.cloudflare.com/client/v4"
+MAX_CONTROL_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ControlCredentials:
+    reference: str
+    bearer_token: str = field(repr=False)
+
+    def __post_init__(self) -> None:
+        _require(_label(self.reference), "invalid control credential reference")
+        value = self.bearer_token
+        _require(type(value) is str and bool(value) and value.isascii()
+                 and all(33 <= ord(c) <= 126 for c in value), "explicit control credential required")
+
+
+def make_observation(target, operation, raw, status, request_id, authority_ref):
+    """Bind captured bytes to the request actually made; never include auth."""
+    path = f"/accounts/{target.account}/r2/buckets/{target.bucket}"
+    if operation == "locks":
+        path += "/lock"
+    if operation == "lifecycle":
+        path = f"/{target.bucket}?lifecycle"
+    value = {
+        "account": target.account, "jurisdiction": target.jurisdiction, "bucket": target.bucket,
+        "archive_root": target.root, "source_commit": target.expected_source,
+        "run_id": target.expected_run, "run_attempt": target.expected_attempt,
+        "endpoint": target.endpoint if operation == "lifecycle" else CONTROL_ENDPOINT,
+        "method": "GET", "path": path, "operation": operation,
+        "headers": ({"cf-r2-jurisdiction": target.jurisdiction}
+                    if operation != "lifecycle" and target.jurisdiction != "default" else {}),
+        "observed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "status": status, "request_id": request_id, "authority_ref": authority_ref,
+        "raw_response": raw.decode("utf-8"), "response_sha256": sha256_bytes(raw),
+    }
+    observation = PolicyObservation(canonical_json_bytes(value))
+    observation.parse(target, operation)
+    return observation
+
+
+def observe_control(target: R2Target, credentials: ControlCredentials, *, operation: str) -> PolicyObservation:
+    """Fetch fresh bucket metadata or lock rules once, through verified HTTPS."""
+    _require(type(target) is R2Target and type(credentials) is ControlCredentials,
+             "explicit control target and credentials required")
+    _require(credentials.reference != target.credential_ref, "separate configuration authority required")
+    _require(operation in ("metadata", "locks"), "unsupported control GET")
+    path = f"/client/v4/accounts/{target.account}/r2/buckets/{target.bucket}"
+    if operation == "locks":
+        path += "/lock"
+    headers = {"Authorization": "Bearer " + credentials.bearer_token, "Accept": "application/json",
+               "Accept-Encoding": "identity"}
+    if target.jurisdiction != "default":
+        headers["cf-r2-jurisdiction"] = target.jurisdiction
+    connection = response = None
+    try:
+        # Pin the SDK-owned CA bundle instead of SSL_CERT_FILE/SSL_CERT_DIR.
+        context = ssl.create_default_context(cafile=get_cert_path(True))
+        connection = http.client.HTTPSConnection(CONTROL_HOST, timeout=30, context=context)
+        connection.request("GET", path, headers=headers)
+        response = connection.getresponse()
+        _require(response.status == 200, "control GET failed")
+        pairs = response.getheaders()
+        names = [name.lower() for name, _ in pairs]
+        _require(len(names) == len(set(names)), "duplicate control response headers")
+        observed_headers = {name.lower(): value for name, value in pairs}
+        _require("content-encoding" not in observed_headers and "content-range" not in observed_headers,
+                 "encoded or partial control response")
+        length = observed_headers.get("content-length")
+        if length is not None:
+            _require(length.isascii() and length.isdecimal() and int(length) <= MAX_CONTROL_BYTES,
+                     "invalid control response length")
+        _require(not (length is not None and "transfer-encoding" in observed_headers),
+                 "ambiguous control response framing")
+        raw = response.read(MAX_CONTROL_BYTES + 1)
+        _require(type(raw) is bytes and len(raw) <= MAX_CONTROL_BYTES,
+                 "over-limit control response")
+        _require(length is None or len(raw) == int(length), "truncated control response")
+        _require(response.read(1) == b"", "incomplete control response")
+        return make_observation(target, operation, raw, response.status,
+                                observed_headers.get("cf-ray"), credentials.reference)
+    except Exception:
+        raise GovernanceError("R2 control observation failed") from None
+    finally:
+        cleanup_failed = False
+        try:
+            if response is not None:
+                response.close()
+        except Exception:
+            cleanup_failed = True
+        finally:
+            try:
+                if connection is not None:
+                    connection.close()
+            except Exception:
+                cleanup_failed = True
+        if cleanup_failed:
+            raise GovernanceError("R2 control cleanup failed") from None

--- a/verification/areas/distribution_release/governance/archive_r2_runtime.py
+++ b/verification/areas/distribution_release/governance/archive_r2_runtime.py
@@ -1,0 +1,188 @@
+"""Pinned SDK construction for explicitly delivered R2 credentials.
+
+No factory call performs a service request. Use the returned client through
+the archive adapters; configuration clients expose only lifecycle GETs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from functools import partial
+from urllib.parse import urlsplit
+
+import boto3
+import botocore.session
+from botocore.config import Config
+from botocore.configprovider import ConstantProvider
+from botocore.credentials import CredentialResolver
+from botocore.exceptions import ClientError
+from botocore.loaders import Loader
+
+from .archive_r2_config import PolicyObservation, R2Target, _label, _require
+from .archive_r2_control import make_observation
+from .archive_r2_store import _error_parts, _failure, validate_client
+from .common import GovernanceError, canonical_json_bytes
+
+
+@dataclass(frozen=True)
+class R2Credentials:
+    reference: str
+    access_key: str = field(repr=False)
+    secret_key: str = field(repr=False)
+    session_token: str | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        _require(_label(self.reference), "invalid credential reference")
+        for value in (self.access_key, self.secret_key):
+            _require(type(value) is str and bool(value) and value.isascii()
+                     and all(33 <= ord(c) <= 126 for c in value), "explicit SDK credentials required")
+        _require(self.session_token is None or (
+            type(self.session_token) is str and bool(self.session_token)
+            and self.session_token.isascii()
+            and all(33 <= ord(c) <= 126 for c in self.session_token)), "invalid explicit session token")
+
+
+class _IsolatedSession(botocore.session.Session):
+    """Never inspect shared profiles, credential files or ambient SDK models."""
+
+    def get_scoped_config(self):
+        return {}
+
+    @property
+    def full_config(self):
+        return {"profiles": {}}
+
+
+def _restrict_operation(target, purpose, params, model, **_):
+    permitted = {"configuration": {"GetBucketLifecycleConfiguration"},
+                 "reader": {"GetObject"},
+                 "producer": {"GetObject", "PutObject"},
+                 "receipt-writer": {"PutObject"}}[purpose]
+    _require(model.name in permitted and params.get("Bucket") == target.bucket,
+             "SDK operation or bucket is outside the bound role")
+    if model.name == "GetBucketLifecycleConfiguration":
+        _require(set(params) == {"Bucket"}, "unsupported lifecycle request parameters")
+        return
+    target.validate_key(params.get("Key"), receipt_only=purpose == "receipt-writer")
+    if model.name == "GetObject":
+        _require(set(params) == {"Bucket", "Key"}, "fresh complete SDK read required")
+    else:
+        _require(set(params) == {"Bucket", "Key", "Body", "ContentLength", "IfNoneMatch", "StorageClass"}
+                 and params["IfNoneMatch"] == "*" and params["StorageClass"] == "STANDARD"
+                 and type(params["Body"]) is bytes and type(params["ContentLength"]) is int
+                 and params["ContentLength"] == len(params["Body"]), "conditional exact-byte SDK PUT required")
+
+
+def _restrict_wire(target, purpose, request, **_):
+    url = urlsplit(request.url)
+    bound = urlsplit(target.endpoint)
+    _require(url.scheme == "https" and url.netloc == bound.netloc and not url.fragment,
+             "SDK serialized endpoint mismatch")
+    if purpose == "configuration":
+        _require(request.method == "GET" and url.path == f"/{target.bucket}"
+                 and url.query == "lifecycle", "SDK serialized lifecycle target mismatch")
+    else:
+        prefix = f"/{target.bucket}/"
+        _require(url.path.startswith(prefix) and not url.query, "SDK serialized object target mismatch")
+        target.validate_key(url.path[len(prefix):], receipt_only=purpose == "receipt-writer")
+        _require(request.method in ({"GET"} if purpose == "reader" else
+                                   {"PUT"} if purpose == "receipt-writer" else {"GET", "PUT"}),
+                 "SDK serialized method mismatch")
+        if request.method == "PUT":
+            _require(request.headers.get("If-None-Match") == b"*", "SDK omitted conditional create")
+
+
+def _stop_failed_attempt(response=None, caught_exception=None, operation=None, **_):
+    # Run before S3 region redirect handling, which can issue its own HEAD and
+    # retry independently of standard retry limits. Never discover/retarget.
+    if caught_exception is not None:
+        raise caught_exception
+    if response is not None and response[0].status_code >= 300:
+        raise ClientError(response[1], operation.name)
+
+
+def create_r2_client(target: R2Target, credentials: R2Credentials, *, purpose: str):
+    """Create a new client; no global session, credential search or network IO."""
+    _require(type(target) is R2Target and type(credentials) is R2Credentials,
+             "explicit R2 target and credentials required")
+    _require(purpose in ("producer", "reader", "receipt-writer", "configuration"), "invalid SDK role")
+    _require(credentials.reference == target.credential_ref, "SDK credential reference mismatch")
+    client = None
+    try:
+        variables = {name: (None, None, spec[2], spec[3])
+                     for name, spec in botocore.session.Session.SESSION_VARIABLES.items()}
+        session = _IsolatedSession(session_vars=variables)
+        session.register_component("credential_provider", CredentialResolver([]))
+        session.register_component("data_loader", Loader(
+            extra_search_paths=[Loader.BUILTIN_DATA_PATH], include_default_search_paths=False))
+        session.get_component("config_store").set_config_provider(
+            "s3", ConstantProvider({"addressing_style": "path"}))
+        session.set_credentials(credentials.access_key, credentials.secret_key, credentials.session_token)
+        config = Config(
+            region_name="auto", signature_version="s3v4", s3={"addressing_style": "path"},
+            retries={"total_max_attempts": 1, "mode": "standard"},
+            request_checksum_calculation="when_required", response_checksum_validation="when_required",
+            proxies={}, connect_timeout=10, read_timeout=30,
+            endpoint_discovery_enabled=False, ignore_configured_endpoint_urls=True,
+            use_dualstack_endpoint=False, use_fips_endpoint=False,
+            disable_request_compression=True,
+        )
+        client = boto3.Session(botocore_session=session).client(
+            "s3", endpoint_url=target.endpoint, region_name="auto", use_ssl=True, verify=True,
+            aws_access_key_id=credentials.access_key, aws_secret_access_key=credentials.secret_key,
+            aws_session_token=credentials.session_token, config=config,
+        )
+        # Check caller bytes before the SDK's PutObject-specific handler wraps
+        # Body in its own seekable stream for signing and transport.
+        client.meta.events.register_first("provide-client-params.s3", partial(_restrict_operation, target, purpose))
+        client.meta.events.register_first("before-send.s3", partial(_restrict_wire, target, purpose))
+        client.meta.events.register_first("needs-retry.s3", _stop_failed_attempt)
+        client._sifr_archive_binding = (target.binding, credentials.reference, purpose)
+        validate_client(target, client)
+        return client
+    except Exception:
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                pass
+        raise GovernanceError("R2 SDK construction failed") from None
+
+
+def _json_dates(value):
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, list):
+        return [_json_dates(part) for part in value]
+    if isinstance(value, dict):
+        return {key: _json_dates(part) for key, part in value.items()}
+    return value
+
+
+def observe_lifecycle(target: R2Target, client, *, authority_ref: str) -> PolicyObservation:
+    """One SDK GET; the retained raw_response is canonical SDK-shaped JSON."""
+    _require(_label(authority_ref) and authority_ref != target.credential_ref,
+             "separate configuration authority required")
+    _require(getattr(client, "_sifr_archive_binding", None) == (target.binding, authority_ref, "configuration"),
+             "lifecycle client authority/target mismatch")
+    validate_client(target, client)
+    try:
+        try:
+            response = client.get_bucket_lifecycle_configuration(Bucket=target.bucket)
+        except ClientError as exc:
+            if _error_parts(exc) != (404, "NoSuchLifecycleConfiguration"):
+                raise
+            response = {"ResponseMetadata": exc.response["ResponseMetadata"],
+                        "Error": {"Code": "NoSuchLifecycleConfiguration"}}
+        metadata = response["ResponseMetadata"]
+        status, request_id = metadata["HTTPStatusCode"], metadata.get("RequestId")
+        # Transport headers/messages may contain opaque or sensitive values;
+        # retain only the fields consumed by the existing observation contract.
+        raw = canonical_json_bytes(_json_dates({
+            "ResponseMetadata": {"HTTPStatusCode": status, "RequestId": request_id},
+            **{key: response[key] for key in ("Rules", "Error") if key in response},
+        }))
+        return make_observation(target, "lifecycle", raw, status, request_id, authority_ref)
+    except Exception as exc:
+        raise _failure("lifecycle observation", exc) from None

--- a/verification/areas/distribution_release/governance/archive_r2_runtime_selftest.py
+++ b/verification/areas/distribution_release/governance/archive_r2_runtime_selftest.py
@@ -1,0 +1,375 @@
+"""Real SDK wire contracts, with all sockets denied and local HTTP doubles."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+import socket
+import ssl
+import sys
+import tomllib
+import unittest
+from dataclasses import replace
+from unittest.mock import patch
+
+import boto3
+import botocore
+from botocore.awsrequest import AWSResponse
+from botocore.credentials import CredentialResolver
+from botocore.exceptions import EndpointConnectionError
+from botocore.httpsession import URLLib3Session
+from botocore.stub import Stubber
+
+from .archive_manifest import construct_manifest
+from .archive_offline_selftest import ATTEMPT, RUN, SOURCE, synthetic_bundle
+from .archive_r2_config import R2Target
+from .archive_r2_control import ControlCredentials, MAX_CONTROL_BYTES, observe_control
+from .archive_r2_runtime import R2Credentials, create_r2_client, observe_lifecycle
+from .archive_r2_store import R2ArchiveReader, R2ArchiveStore
+from .common import GovernanceError, canonical_json_bytes, sha256_bytes
+
+SDK_VERSION = "1.43.89"
+SDK_HASHES = {
+    "boto3": {"sha256:fe4190afe63eb562b6ba6a3911cf4427473b35fa047adde093bf696d3ae09fc0",
+              "sha256:c28abbe472e9b7cad08807356311aeec51bde5218c18489da827045d2267bfd9"},
+    "botocore": {"sha256:d7211220c815427fe71225acc6909e4ab5dfab3b03770e72fd16cf9eb86b3d1a",
+                 "sha256:f0574942970742657b0e0716cf08c2dfe6bef8e6de5fbb7081c3424e262b4cca"},
+}
+
+
+class Raw(io.BytesIO):
+    def stream(self, amt=1024, decode_content=False):
+        while chunk := self.read(amt):
+            yield chunk
+
+
+class ControlResponse(Raw):
+    def __init__(self, raw, status=200, headers=None):
+        super().__init__(raw)
+        self.status = status
+        self.headers = headers if headers is not None else [
+            ("Content-Length", str(len(raw))), ("CF-Ray", "synthetic-request-ARN")]
+
+    def getheaders(self):
+        return self.headers
+
+
+class ControlConnection:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+        self.closed = False
+
+    def request(self, method, path, *, headers):
+        self.calls.append((method, path, headers))
+
+    def getresponse(self):
+        return self.response
+
+    def close(self):
+        self.closed = True
+
+
+class R2RuntimeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        inventory, _ = synthetic_bundle()
+        raw = canonical_json_bytes(construct_manifest(inventory))
+        cls.target = R2Target("a" * 32, "default", "synthetic-primary", "synthetic-producer",
+                              raw, sha256_bytes(raw), SOURCE, RUN, ATTEMPT)
+        cls.key = cls.target.root + "objects/sha256/" + "b" * 64
+
+    def setUp(self):
+        self.addCleanup(patch.stopall)
+        self.socket = patch.object(socket.socket, "connect", side_effect=AssertionError("real socket forbidden")).start()
+        patch.object(socket, "create_connection", side_effect=AssertionError("real connection forbidden")).start()
+        self.send = patch.object(URLLib3Session, "send", side_effect=AssertionError("unregistered SDK send")).start()
+        self.credentials = R2Credentials(self.target.credential_ref, "TESTACCESSKEY", "secret-value", "session-secret")
+
+    def client(self, target=None, purpose="producer"):
+        target = target or self.target
+        client = create_r2_client(target, replace(self.credentials, reference=target.credential_ref), purpose=purpose)
+        self.addCleanup(client.close)
+        return client
+
+    def wire(self, *, status=200, content=b"", headers=None):
+        raw = Raw(content)
+        headers = headers if headers is not None else {"etag": '"opaque"'}
+        self.send.side_effect = lambda request: AWSResponse(request.url, status, headers, raw)
+        return raw
+
+    def control(self, raw=None, *, target=None, operation="metadata", status=200, headers=None):
+        target = target or self.target
+        if raw is None:
+            result = ({"rules": []} if operation == "locks" else
+                      {"name": target.bucket, "jurisdiction": target.jurisdiction,
+                       "storageClass": "Standard", "creationDate": "2026-09-08T00:00:00Z"})
+            raw = canonical_json_bytes({"success": True, "errors": [], "messages": [], "result": result})
+        response = ControlResponse(raw, status, headers)
+        connection = ControlConnection(response)
+        return response, connection, raw
+
+    def observe(self, connection, *, target=None, operation="metadata"):
+        with patch("http.client.HTTPSConnection", return_value=connection) as factory:
+            result = observe_control(target or self.target, ControlCredentials("config-reader", "bearer-secret"),
+                                     operation=operation)
+        return result, factory
+
+    def test_exact_runtime_versions_and_lock_hashes(self):
+        self.assertEqual(sys.version_info[:3], (3, 14, 7))
+        self.assertEqual(boto3.__version__, SDK_VERSION)
+        self.assertEqual(botocore.__version__, SDK_VERSION)
+        runtime = Path(__file__).resolve().parents[1] / "runtime"
+        lock = tomllib.loads((runtime / "uv.lock").read_text())
+        self.assertEqual(lock["requires-python"], "==3.14.7")
+        for name, hashes in SDK_HASHES.items():
+            record = next(p for p in lock["package"] if p["name"] == name)
+            self.assertEqual(record["version"], SDK_VERSION)
+            self.assertEqual(record["source"], {"registry": "https://pypi.org/simple"})
+            self.assertEqual({record["sdist"]["hash"], *(w["hash"] for w in record["wheels"])}, hashes)
+            if metadata_root := os.environ.get("SIFR_R2_SDK_METADATA_DIR"):
+                metadata = json.loads((Path(metadata_root) / f"{name}.json").read_text())
+                self.assertEqual(metadata["info"]["version"], SDK_VERSION)
+                self.assertEqual({"sha256:" + f["digests"]["sha256"] for f in metadata["urls"]}, hashes)
+
+    def test_conditional_put_serialization_and_target_binding(self):
+        for jurisdiction in ("default", "eu", "us", "fedramp"):
+            target = replace(self.target, jurisdiction=jurisdiction)
+            client = self.client(target)
+            self.wire()
+            self.assertTrue(R2ArchiveStore(target, client).create(self.key, b"new"))
+            request = self.send.call_args.args[0]
+            self.assertEqual(request.url, f"{target.endpoint}/{target.bucket}/{self.key}")
+            self.assertEqual(request.method, "PUT")
+            self.assertEqual(request.headers["If-None-Match"], b"*")
+            self.assertEqual(request.headers["Content-Length"], b"3")
+            self.assertEqual(request.headers["x-amz-storage-class"], b"STANDARD")
+            self.assertIn(b"/auto/s3/aws4_request", request.headers["Authorization"])
+            self.assertIn(b"AWS4-HMAC-SHA256", request.headers["Authorization"])
+            self.assertIs(client._endpoint.http_session._verify, True)
+            self.assertEqual(client.meta.config.proxies, {})
+            self.assertFalse(client.meta.config.endpoint_discovery_enabled)
+        self.send.reset_mock()
+        client = self.client()
+        for params in ({"Bucket": "wrong-bucket", "Key": self.key},
+                       {"Bucket": self.target.bucket, "Key": self.key, "Range": "bytes=0-1"}):
+            with self.assertRaises(GovernanceError):
+                client.get_object(**params)
+        with self.assertRaises(GovernanceError):
+            client.delete_object(Bucket=self.target.bucket, Key=self.key)
+        self.send.assert_not_called()
+        client.meta.events.register("before-sign.s3.PutObject", lambda request, **_: setattr(
+            request, "url", "https://untrusted.invalid/diverted"))
+        with self.assertRaises(GovernanceError):
+            R2ArchiveStore(self.target, client).create(self.key, b"new")
+        self.send.assert_not_called()
+
+    def test_one_total_attempt_and_redirect_refusal(self):
+        client = self.client()
+        store = R2ArchiveStore(self.target, client)
+        for status, code in ((301, "PermanentRedirect"), (307, "TemporaryRedirect"),
+                             (400, "AuthorizationHeaderMalformed"), (403, "AccessDenied"),
+                             (409, "ConditionalRequestConflict"), (429, "SlowDown"),
+                             (500, "InternalError"), (503, "SlowDown"), (412, "Other")):
+            self.send.reset_mock()
+            self.wire(status=status, content=f"<Error><Code>{code}</Code><Message>secret-value</Message></Error>".encode(),
+                      headers={"location": "https://untrusted.invalid/", "x-amz-bucket-region": "other"})
+            with self.assertRaises(GovernanceError):
+                store.create(self.key, b"new")
+            self.assertEqual(self.send.call_count, 1)
+        self.send.reset_mock()
+        self.wire(status=412, content=b"<Error><Code>PreconditionFailed</Code></Error>")
+        self.assertFalse(store.create(self.key, b"new"))
+        self.assertEqual(self.send.call_count, 1)
+        self.send.reset_mock()
+        self.send.side_effect = EndpointConnectionError(endpoint_url="https://secret-value.invalid")
+        with self.assertRaises(GovernanceError):
+            store.create(self.key, b"new")
+        self.assertEqual(self.send.call_count, 1)
+        self.socket.assert_not_called()
+
+    def test_no_ambient_credentials_or_configuration(self):
+        hostile = {"AWS_PROFILE": "not-present", "AWS_DEFAULT_PROFILE": "not-present",
+                   "AWS_CONFIG_FILE": "/must-not-read", "AWS_SHARED_CREDENTIALS_FILE": "/must-not-read",
+                   "AWS_ACCESS_KEY_ID": "AMBIENT", "AWS_SECRET_ACCESS_KEY": "ambient-secret",
+                   "AWS_SESSION_TOKEN": "ambient-token", "AWS_WEB_IDENTITY_TOKEN_FILE": "/must-not-read",
+                   "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/ambient",
+                   "AWS_CONTAINER_CREDENTIALS_FULL_URI": "http://169.254.170.2/",
+                   "AWS_EC2_METADATA_DISABLED": "false", "AWS_ENDPOINT_URL": "http://wrong.invalid",
+                   "AWS_ENDPOINT_URL_S3": "http://wrong.invalid", "AWS_CA_BUNDLE": "/must-not-read",
+                   "AWS_DATA_PATH": "/must-not-read", "AWS_DEFAULT_REGION": "wrong",
+                   "AWS_MAX_ATTEMPTS": "99", "AWS_RETRY_MODE": "adaptive",
+                   "AWS_S3_USE_ARN_REGION": "true", "AWS_S3_US_EAST_1_REGIONAL_ENDPOINT": "regional",
+                   "AWS_CSM_ENABLED": "true", "HTTPS_PROXY": "http://wrong.invalid",
+                   "SSL_CERT_FILE": "/must-not-read", "SSL_CERT_DIR": "/must-not-read"}
+        with patch.dict(os.environ, hostile), \
+             patch.object(CredentialResolver, "load_credentials", side_effect=AssertionError("ambient credentials")), \
+             patch("botocore.configloader.load_config", side_effect=AssertionError("ambient config")), \
+             patch("botocore.configloader.raw_config_parse", side_effect=AssertionError("ambient profile")):
+            client = self.client()
+            self.wire()
+            self.assertTrue(R2ArchiveStore(self.target, client).create(self.key, b"new"))
+            authorization = self.send.call_args.args[0].headers["Authorization"]
+            self.assertIn(b"TESTACCESSKEY", authorization)
+            self.assertNotIn(b"AMBIENT", authorization)
+            self.assertEqual(self.send.call_args.args[0].headers["X-Amz-Security-Token"], b"session-secret")
+            self.assertEqual(client.meta.config.retries["total_max_attempts"], 1)
+            response, connection, _ = self.control()
+            self.observe(connection)
+            self.assertTrue(response.closed)
+        self.socket.assert_not_called()
+        with self.assertRaises(GovernanceError):
+            R2Credentials(self.target.credential_ref, "", "")
+
+    def test_required_only_checksums(self):
+        client = self.client()
+        self.wire()
+        R2ArchiveStore(self.target, client).create(self.key, b"body")
+        headers = {key.lower(): value for key, value in self.send.call_args.args[0].headers.items()}
+        self.assertFalse(any(key.startswith("x-amz-checksum-") for key in headers))
+        self.assertFalse({"x-amz-sdk-checksum-algorithm", "x-amz-trailer", "transfer-encoding", "content-encoding"} & headers.keys())
+        self.assertIn("x-amz-content-sha256", headers)
+        self.assertEqual(client.meta.config.request_checksum_calculation, "when_required")
+        self.assertEqual(client.meta.config.response_checksum_validation, "when_required")
+
+    def test_fresh_complete_sdk_reads_and_cleanup(self):
+        client = self.client(purpose="reader")
+        reader = R2ArchiveReader(self.target, client)
+        for content in (b"first", b"second"):
+            raw = self.wire(content=content, headers={"content-length": str(len(content)), "x-amz-storage-class": "STANDARD"})
+            self.assertEqual(reader.read(self.key), content)
+            self.assertTrue(raw.closed)
+            request = self.send.call_args.args[0]
+            self.assertEqual(request.method, "GET")
+            self.assertNotIn("Range", request.headers)
+            self.assertNotIn("If-None-Match", request.headers)
+        self.assertEqual(self.send.call_count, 2)
+        for status, headers in ((200, {"content-length": "20", "x-amz-storage-class": "STANDARD"}),
+                                (206, {"content-length": "3", "x-amz-storage-class": "STANDARD"}),
+                                (200, {"content-length": "3"}),
+                                (200, {"content-length": "3", "x-amz-storage-class": "STANDARD", "content-encoding": "gzip"})):
+            raw = self.wire(status=status, content=b"bad", headers=headers)
+            with self.assertRaises(GovernanceError):
+                reader.read(self.key)
+            self.assertTrue(raw.closed)
+        raw = self.wire(content=b"bad", headers={"content-length": "3", "x-amz-storage-class": "STANDARD"})
+        with patch.object(raw, "read", side_effect=OSError("secret-value interrupted body")):
+            with self.assertRaises(GovernanceError):
+                reader.read(self.key)
+        self.assertTrue(raw.closed)
+        self.send.reset_mock()
+        with self.assertRaises(GovernanceError):
+            R2ArchiveStore(self.target, client).create(self.key, b"forbidden")
+        self.send.assert_not_called()
+
+    def test_secret_safe_factory_and_transport_errors(self):
+        self.assertNotIn("secret-value", repr(self.credentials))
+        self.assertNotIn("bearer-secret", repr(ControlCredentials("config", "bearer-secret")))
+        with patch.object(boto3.Session, "client", side_effect=RuntimeError("secret-value")):
+            with self.assertRaises(GovernanceError) as caught:
+                self.client()
+        self.assertEqual(str(caught.exception), "R2 SDK construction failed")
+        client = self.client()
+        self.send.side_effect = RuntimeError("secret-value Authorization bearer-secret")
+        with self.assertRaises(GovernanceError) as caught:
+            R2ArchiveStore(self.target, client).create(self.key, b"body")
+        self.assertNotIn("secret", str(caught.exception))
+        _, connection, _ = self.control()
+        with patch.object(connection, "request", side_effect=RuntimeError("bearer-secret")):
+            with self.assertRaises(GovernanceError) as caught:
+                self.observe(connection)
+        self.assertEqual(str(caught.exception), "R2 control observation failed")
+        self.assertTrue(connection.closed)
+        _, connection, _ = self.control()
+        with patch.object(connection, "close", side_effect=RuntimeError("bearer-secret")):
+            with self.assertRaises(GovernanceError) as caught:
+                self.observe(connection)
+        self.assertEqual(str(caught.exception), "R2 control cleanup failed")
+
+    def test_controlled_get_target_binding_and_observations(self):
+        seen = []
+        for jurisdiction in ("default", "eu", "us", "fedramp"):
+            target = replace(self.target, jurisdiction=jurisdiction)
+            for operation in ("metadata", "locks"):
+                response, connection, raw = self.control(target=target, operation=operation)
+                observation, factory = self.observe(connection, target=target, operation=operation)
+                parsed = json.loads(observation.envelope)
+                self.assertEqual(parsed["response_sha256"], sha256_bytes(raw))
+                self.assertEqual(parsed["raw_response"].encode(), raw)
+                self.assertNotIn(b"bearer-secret", observation.envelope)
+                self.assertNotIn(b"Authorization", observation.envelope)
+                self.assertEqual(factory.call_args.args, ("api.cloudflare.com",))
+                context = factory.call_args.kwargs["context"]
+                self.assertEqual(context.verify_mode, ssl.CERT_REQUIRED)
+                self.assertTrue(context.check_hostname)
+                method, path, headers = connection.calls[0]
+                self.assertEqual(method, "GET")
+                self.assertEqual(path, "/client/v4" + parsed["path"])
+                self.assertEqual(headers["Authorization"], "Bearer bearer-secret")
+                self.assertEqual(headers.get("cf-r2-jurisdiction"), None if jurisdiction == "default" else jurisdiction)
+                self.assertTrue(response.closed and connection.closed)
+                seen.append(response)
+                with self.assertRaises(GovernanceError):
+                    observation.parse(replace(target, bucket="wrong-bucket"), operation)
+        self.assertEqual(len({id(response) for response in seen}), 8)
+
+    def test_controlled_get_failures_and_cleanup(self):
+        good = canonical_json_bytes({"success": True, "errors": [], "messages": [], "result": {}})
+        cases = [(good, 302, [("Location", "https://wrong.invalid")]),
+                 (good, 403, []), (good, 500, []),
+                 (good, 200, [("Content-Length", str(len(good) + 1))]),
+                 (good, 200, [("Content-Length", "-1")]),
+                 (good, 200, [("Content-Length", "5"), ("content-length", "5")]),
+                 (good, 200, [("Content-Encoding", "gzip")]),
+                 (b"x" * (MAX_CONTROL_BYTES + 1), 200, []),
+                 (b'{"success":true,"success":true}', 200, []),
+                 (b"not-json bearer-secret", 200, []), (b"\xff", 200, []),
+                 (good, 200, [("CF-Ray", "https://secret.invalid")])]
+        for raw, status, headers in cases:
+            with self.subTest(status=status, size=len(raw)):
+                response, connection, _ = self.control(raw, status=status, headers=headers)
+                with self.assertRaises(GovernanceError) as caught:
+                    self.observe(connection)
+                self.assertEqual(str(caught.exception), "R2 control observation failed")
+                self.assertTrue(response.closed and connection.closed)
+                self.assertEqual(len(connection.calls), 1)
+        with patch("http.client.HTTPSConnection") as factory:
+            for operation in ("delete", "lifecycle", "metadata?redirect"):
+                with self.assertRaises(GovernanceError):
+                    observe_control(self.target, ControlCredentials("config", "bearer-secret"), operation=operation)
+            factory.assert_not_called()
+
+    def test_lifecycle_sdk_observation_binding(self):
+        target = replace(self.target, credential_ref="config-reader")
+        client = self.client(target, purpose="configuration")
+        self.wire(content=b'<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+                  b'<Rule><ID>abort</ID><Status>Enabled</Status><Filter><Prefix></Prefix></Filter>'
+                  b'<AbortIncompleteMultipartUpload><DaysAfterInitiation>7</DaysAfterInitiation>'
+                  b'</AbortIncompleteMultipartUpload></Rule></LifecycleConfiguration>',
+                  headers={"x-amz-request-id": "synthetic-lifecycle"})
+        observation = observe_lifecycle(self.target, client, authority_ref="config-reader")
+        self.assertEqual(observation.parse(self.target, "lifecycle")["Rules"][0]["ID"], "abort")
+        request = self.send.call_args.args[0]
+        self.assertEqual(request.url, f"{self.target.endpoint}/{self.target.bucket}?lifecycle")
+        self.assertEqual(request.method, "GET")
+        with Stubber(client) as stub:
+            stub.add_client_error("get_bucket_lifecycle_configuration", "NoSuchLifecycleConfiguration",
+                                  http_status_code=404, expected_params={"Bucket": target.bucket})
+            observation = observe_lifecycle(self.target, client, authority_ref="config-reader")
+            self.assertEqual(observation.parse(self.target, "lifecycle"), {"Rules": []})
+            stub.add_client_error("get_bucket_lifecycle_configuration", "AccessDenied",
+                                  service_message="secret-value", http_status_code=403,
+                                  expected_params={"Bucket": target.bucket})
+            with self.assertRaises(GovernanceError):
+                observe_lifecycle(self.target, client, authority_ref="config-reader")
+            stub.assert_no_pending_responses()
+        self.send.reset_mock()
+        with self.assertRaises(GovernanceError):
+            observe_lifecycle(replace(self.target, bucket="wrong-bucket"), client, authority_ref="config-reader")
+        self.send.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verification/areas/distribution_release/runtime/pyproject.toml
+++ b/verification/areas/distribution_release/runtime/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "sifr-distribution-archive-runtime"
+version = "0.0.0"
+description = "Explicit R2 archival transport SDK; no ambient credentials"
+requires-python = "==3.14.7"
+dependencies = ["boto3==1.43.89", "botocore==1.43.89"]
+
+[tool.uv]
+package = false
+required-version = "==0.12.5"

--- a/verification/areas/distribution_release/runtime/uv.lock
+++ b/verification/areas/distribution_release/runtime/uv.lock
@@ -1,0 +1,97 @@
+version = 1
+revision = 3
+requires-python = "==3.14.7"
+
+[[package]]
+name = "boto3"
+version = "1.43.89"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/26/48b3da85526a72a02df55e564481fc348e93699c15f0f502681b12ac2c8a/boto3-1.43.89.tar.gz", hash = "sha256:c28abbe472e9b7cad08807356311aeec51bde5218c18489da827045d2267bfd9", size = 112702, upload-time = "2026-09-04T19:24:57.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/12/e1b5cb4a00a9bfd72cf2d3f982c5826757aacdfc90aa4bd61902dcc94856/boto3-1.43.89-py3-none-any.whl", hash = "sha256:fe4190afe63eb562b6ba6a3911cf4427473b35fa047adde093bf696d3ae09fc0", size = 140028, upload-time = "2026-09-04T19:24:55.929Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.89"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/06/f63fb1befdf77af18539fb24ea01f2da0f13965ed5de091061708ac96416/botocore-1.43.89.tar.gz", hash = "sha256:f0574942970742657b0e0716cf08c2dfe6bef8e6de5fbb7081c3424e262b4cca", size = 16074206, upload-time = "2026-09-04T19:24:52.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/9d/96f9dee6d12eedf1c2b4264eefd59c7ac8cac10daadb9a7bfccc9ee881c6/botocore-1.43.89-py3-none-any.whl", hash = "sha256:d7211220c815427fe71225acc6909e4ab5dfab3b03770e72fd16cf9eb86b3d1a", size = 15768272, upload-time = "2026-09-04T19:24:49.769Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
+name = "sifr-distribution-archive-runtime"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = "==1.43.89" },
+    { name = "botocore", specifier = "==1.43.89" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]


### PR DESCRIPTION
Item 70-F1C2A adds a distribution-owned Boto3/Botocore 1.43.89 runtime for the existing R2 archive adapter. Explicit credentials, fixed endpoints, verified TLS, role-bound requests and one total attempt now have actual SDK serialization coverage. Read-only Cloudflare metadata/lock and S3 lifecycle observations feed the existing policy validator.

Validation: the ten registered offline SDK/control tests passed in 0.946 seconds; official package artifact hashes, locked environment generation/check/sync, diff checks and the source-size guard passed. All service transports were intercepted locally and real sockets denied. Existing adapter/compiler/workflow/fixture files are unchanged.

The single exact-SHA [Opus review](https://github.com/sifr-lang/sifr/pull/3821#issuecomment-5583242421) is SATISFIED with no blocking findings; zero remediation reviews. [Validation evidence](https://github.com/sifr-lang/sifr/pull/3821#issuecomment-5583095394) covers source candidate 6632dbcd60dafd524a4ebde50f6fcadde2dae179.

This PR remains draft and unmerged because the new tracked runtime/uv.lock is gate-bearing. Compiler PR #3717 and policy PR #3785 remain OPEN external merge prerequisites; no knowingly blocked merge gate was run. Resume this item's closure after actual prerequisite delivery and run the one applicable final-candidate merge-profile gate before merge. This item supplies no live cloud access, durable-custody proof or release qualification. Scope and exact commands are in plans/issues/active/ad-hoc-latest-stable-item70-f1c2a-runtime.md.
