### PR TITLE
fix(docs): make governed section markers MDX-safe

### DIFF
--- a/docs/releases/stable.mdx
+++ b/docs/releases/stable.mdx
@@ -11,11 +11,11 @@ releases.
 
 ## Current stable release
 
-<!-- stable-release-facts:start -->
+{/* stable-release-facts:start */}
 Active stable version: `0.1.0`
 
 Withdrawn stable versions: none.
-<!-- stable-release-facts:end -->
+{/* stable-release-facts:end */}
 
 These facts are rendered from `stable-site-release-facts.json`, which is
 derived from the governed release index during protected publication. A

--- a/docs/rust-interop.mdx
+++ b/docs/rust-interop.mdx
@@ -273,7 +273,7 @@ load-bearing. Missing or stale metadata is rejected before Cargo is spawned as
 package and does not claim arbitrary Axum/tower-http APIs, live SQLx database
 connectivity, or product-level web framework support.
 
-<!-- rust-interop-stable-claims:start -->
+{/* rust-interop-stable-claims:start */}
 | Compatibility row | Category | Execution scope |
 | --- | --- | --- |
 | `direct_crate_crc32` | `supported` | `cargo-probe` |
@@ -315,7 +315,7 @@ connectivity, or product-level web framework support.
 | `cargo_locked_offline` | `supported` | `cargo-probe` |
 | `ecosystem_cli_certification` | `supported-through-bridge` | `cargo-probe` |
 | `ecosystem_backend_certification` | `supported-through-bridge` | `cargo-probe` |
-<!-- rust-interop-stable-claims:end -->
+{/* rust-interop-stable-claims:end */}
 
 ## Direct Bindings
 

--- a/scripts/distribution/render_stable_release_docs.py
+++ b/scripts/distribution/render_stable_release_docs.py
@@ -15,8 +15,8 @@ sys.path.insert(0, str(AREA_ROOT))
 from governance import GovernanceError, validate_site_release_facts  # noqa: E402
 from governance.common import load_json_strict  # noqa: E402
 
-START_MARKER = "<!-- stable-release-facts:start -->"
-END_MARKER = "<!-- stable-release-facts:end -->"
+START_MARKER = "{/* stable-release-facts:start */}"
+END_MARKER = "{/* stable-release-facts:end */}"
 
 
 class DocumentationRenderError(ValueError):

--- a/verification/areas/documentation/check_ga_release_docs.py
+++ b/verification/areas/documentation/check_ga_release_docs.py
@@ -28,8 +28,8 @@ RUST_CLAIMS_CHECK = (
     / "checks"
     / "check_stable_support_claims.py"
 )
-START_MARKER = "<!-- stable-release-facts:start -->"
-END_MARKER = "<!-- stable-release-facts:end -->"
+START_MARKER = "{/* stable-release-facts:start */}"
+END_MARKER = "{/* stable-release-facts:end */}"
 RENDERER_PATH = (
     REPO_ROOT / "scripts" / "distribution" / "render_stable_release_docs.py"
 )
@@ -139,8 +139,8 @@ REQUIRED_BY_DOCUMENT = {
     ),
     "rust-interop": (
         "stable_support_claims.json",
-        "<!-- rust-interop-stable-claims:start -->",
-        "<!-- rust-interop-stable-claims:end -->",
+        "{/* rust-interop-stable-claims:start */}",
+        "{/* rust-interop-stable-claims:end */}",
     ),
 }
 FORBIDDEN_CLAIMS = (

--- a/verification/areas/rust_interop/checks/check_stable_support_claims.py
+++ b/verification/areas/rust_interop/checks/check_stable_support_claims.py
@@ -15,8 +15,8 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[4]
 SOURCE_PATH = "verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json"
 PUBLIC_PATH = "docs/rust-interop.mdx"
-START_MARKER = "<!-- rust-interop-stable-claims:start -->"
-END_MARKER = "<!-- rust-interop-stable-claims:end -->"
+START_MARKER = "{/* rust-interop-stable-claims:start */}"
+END_MARKER = "{/* rust-interop-stable-claims:end */}"
 CLAIM_FIELDS = {"id", "category", "execution_kind", "capability"}
 RUNTIME_CLAIM_TERMS = (
     "runtime evidence",


### PR DESCRIPTION
Mint rejects the raw HTML comments that delimit generated release facts and Rust support claims. Use MDX expression comments in both documents and their three producer/checker contracts so the site parses while preserving section uniqueness, ordering, release assertions, and all 39 support claims.

This independently delivers Item 74 on current main with exactly twelve marker-line replacements across five files. No dependency, configuration, workflow, lockfile, compiler, or fixture changes are included.

Validation on candidate `30e4be9ea04ab9e0bcc082da2886fb8ef720a3c8`: exact pinned Mint 4.2.882 validate and broken-links pass against main's existing site configuration; canonical documentation structure/GA-release 2/2 and Rust stable-candidate 2/2 pass (39 claims, 33 self-tests); renderer consistency, 18 marker-drift negative assertions, file-size guard and diff guard pass. Original pinned Node/npm/uv/Python tools were copied privately; no release refresh. The applicable documentation-only policy requires no Cargo gate.

The prepared Item 74 initial Opus approval remains consumed and preserved. This independent candidate receives only the remaining exact-SHA review before merge.
