### PR TITLE
Pin documentation tooling to Mint 4.2.882

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,14 @@ Do not include a trailing slash in the documentation path. Mintlify expects `doc
 
 ```bash
 cd docs
-npx mint@latest dev
+npx --yes mint@4.2.882 dev
+```
+
+Use the same exact Mint release for documentation checks:
+
+```bash
+npx --yes mint@4.2.882 validate
+npx --yes mint@4.2.882 broken-links
 ```
 
 ## Assistant instructions

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,14 +47,13 @@
         "label": "Blog",
         "href": "https://sifr.sh/blog",
         "icon": "newspaper"
-      },
-      {
-        "label": "Install Sifr",
-        "href": "/installation",
-        "icon": "download",
-        "primary": true
       }
-    ]
+    ],
+    "primary": {
+      "type": "button",
+      "label": "Install Sifr",
+      "href": "/installation"
+    }
   },
   "navigation": {
     "tabs": [

--- a/scripts/import-mintlify-docs.sh
+++ b/scripts/import-mintlify-docs.sh
@@ -91,7 +91,14 @@ Source in this directory is deployed by [Mintlify](https://mintlify.com) from `s
 
 ```bash
 cd docs
-npx mint@latest dev
+npx --yes mint@4.2.882 dev
+```
+
+Use the same exact Mint release for documentation checks:
+
+```bash
+npx --yes mint@4.2.882 validate
+npx --yes mint@4.2.882 broken-links
 ```
 
 ## Internal reference (not published)
@@ -110,6 +117,7 @@ echo "Import complete. Pages:"
 find "$DOCS_DIR" -name '*.mdx' | wc -l | xargs echo "  MDX files:"
 echo ""
 echo "Next steps:"
-echo "  1. cd docs && npx mint@latest validate"
-echo "  2. Mintlify dashboard → Git Settings → sifr-lang/sifr, subdirectory docs"
-echo "  3. git add docs/ && git commit && git push"
+echo "  1. cd docs && npx --yes mint@4.2.882 validate"
+echo "  2. npx --yes mint@4.2.882 broken-links"
+echo "  3. Mintlify dashboard → Git Settings → sifr-lang/sifr, subdirectory docs"
+echo "  4. git add docs/ && git commit && git push"


### PR DESCRIPTION
Documentation commands used floating Mint, and the Install Sifr link's `primary` flag was stripped by the current schema. Pin maintained preview and validation commands to the frozen Mint 4.2.882 selection and express the same installation button through `navbar.primary`.

Delivers only existing convergence item 34: three prepared files applied independently to main after item 74 merged. No held item 40 ancestry, workflow, lock, compiler, fixture or submodule-pointer changes.

Validation on exact candidate `caa2174f0f4681710ec1459e8d3d0110153bbafb`:

- Exact Mint 4.2.882 `validate` and `broken-links`: PASS.
- Canonical documentation `structure`: PASS (1/1).
- Exact installed schema preserves the installation CTA; 287 navigation/asset/redirect paths and maintained command inventory: PASS.
- Importer `bash -n`, file-size guard (3770 files), and diff guard: PASS.

Per item delivery policy, no Sifr profile gates apply to this documentation/importer-only delta. Existing item 34 failures remain historical; item 74's merged parser repair enabled this fresh qualification. Initial exact-SHA Opus review pending; review evidence will be attached externally to this candidate.
